### PR TITLE
Use custom useStoryblokStory hook which force refresh content after saving/publishing

### DIFF
--- a/src/hooks/useStoryblokState.ts
+++ b/src/hooks/useStoryblokState.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  ISbStoryData,
+  SbGatsbyStory,
+  StoryblokBridgeConfigV2,
+  StoryblokBridgeV2,
+  StoryblokComponentType,
+} from 'gatsby-source-storyblok';
+
+const refreshDevContent = () => fetch('__refresh', { method: 'post' });
+
+/**
+ * Source: https://github.com/storyblok/storyblok-js/blob/8c887c3c35950bb8070abb13417d4f8742437b69/lib/index.ts
+ */
+const useStoryblokBridge = <T extends StoryblokComponentType<string> = any>
+  (id: Number, cb: (newStory: ISbStoryData<T>) => void, options: StoryblokBridgeConfigV2 = {}) => {
+  const isServer = typeof window === 'undefined';
+  const isBridgeLoaded = !isServer && typeof window.storyblokRegisterEvent !== 'undefined';
+
+  if (!isBridgeLoaded) {
+    return;
+  }
+
+  if (!id) {
+    console.warn('Story ID is not defined. Please provide a valid ID.');
+    return;
+  }
+
+  window.storyblokRegisterEvent(() => {
+    const sbBridge: StoryblokBridgeV2 = new window.StoryblokBridge(options);
+    sbBridge.on(['input', 'published', 'change'], (event) => {
+      if (!event) return;
+      console.log('StoryblokBridge event:', event);
+
+      if (event.action === 'input' && event.story?.id === id) {
+        cb(event.story);
+      } else if (
+        (event.action === 'change' || event.action === 'published')
+        && (event.storyId as any) === id
+      ) {
+        refreshDevContent(); // 👈 HERE
+        window.location.reload();
+      }
+    });
+  });
+};
+
+/**
+ * https://github.com/storyblok/gatsby-source-storyblok/issues/194
+ * Temporary patched hook, ensures updated content on "Save" or "Publish" in Storyblok UI
+ */
+export const useStoryblokState = (originalStory: SbGatsbyStory, bridgeOptions: StoryblokBridgeConfigV2 = {}) => {
+  if (typeof originalStory.content === 'string') {
+    originalStory.content = JSON.parse(originalStory.content);
+  }
+
+  const [story, setStory] = useState(originalStory);
+
+  const updateStory = useCallback((newStory: SbGatsbyStory) => {
+    setStory(newStory);
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useStoryblokBridge(story.internalId, updateStory, bridgeOptions);
+  }, [bridgeOptions, story.internalId, updateStory]);
+
+  return story;
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { graphql } from 'gatsby';
-import { StoryblokComponent, storyblokEditable, useStoryblokState } from 'gatsby-source-storyblok';
+import { StoryblokComponent, storyblokEditable } from 'gatsby-source-storyblok';
+import { useStoryblokState } from '../hooks/useStoryblokState';
 import Layout from '../components/layout';
 
 const IndexPage = ({ data }) => {

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { graphql } from 'gatsby';
-import { StoryblokComponent, storyblokEditable, useStoryblokState } from 'gatsby-source-storyblok';
+import { StoryblokComponent, storyblokEditable } from 'gatsby-source-storyblok';
+import { useStoryblokState } from '../hooks/useStoryblokState';
 import Layout from '../components/layout';
 
 const StoryblokEntry = ({ data }) => {


### PR DESCRIPTION
# READY FOR REVIEW (retro)

# Summary
- Use temporary solution (link in code comment) to override useStoryblokState from gatsby-source-storyblok
- Allow for refreshing content after clicking Save or publish in visual editor.

# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Review Tasks

## Setup tasks and/or behavior to test

1. Please review retro - this is a temporary workaround and is easily reversible.
