### PR TITLE
GIVCAMP-58 GIVCAMP-33 | More components; Gatsby Slice Global Footer

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,3 +1,9 @@
+// @ts-check
+
+/**
+ * @type {import('gatsby').GatsbyConfig}
+ */
+
 import type { GatsbyConfig } from 'gatsby';
 import * as dotenv from 'dotenv';
 
@@ -9,9 +15,8 @@ let siteUrl = 'http://localhost:8000';
 // Support for Production site builds.
 if (process.env.CONTEXT === 'production') {
   siteUrl = process.env.URL;
-}
-// Support for non-production netlify builds (branch/preview)
-else if (process.env.CONTEXT !== 'production' && process.env.NETLIFY) {
+} else if (process.env.CONTEXT !== 'production' && process.env.NETLIFY) {
+  // Support for non-production netlify builds (branch/preview)
   siteUrl = process.env.DEPLOY_PRIME_URL;
 }
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -11,5 +11,6 @@ exports.createPages = async ({ actions }) => {
   actions.createSlice({
     id: 'global-footer',
     component: path.resolve('./src/components/GlobalFooter/GlobalFooter.tsx'),
+    context: {},
   });
 };

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,0 +1,15 @@
+// @ts-check
+
+/**
+ * @type {import('gatsby').GatsbyNode['createPages']}
+ */
+
+// eslint-disable-next-line import/no-import-module-exports
+import path from 'path';
+
+exports.createPages = async ({ actions }) => {
+  actions.createSlice({
+    id: 'global-footer',
+    component: path.resolve('./src/components/GlobalFooter/GlobalFooter.tsx'),
+  });
+};

--- a/src/components/Container/Container.styles.ts
+++ b/src/components/Container/Container.styles.ts
@@ -1,0 +1,8 @@
+export type ContainerElementType = 'div' | 'section' | 'article' | 'main' | 'footer' | 'aside' | 'header' | 'nav' | 'form' | 'fieldset';
+
+export const containerWidths = {
+  full: 'su-w-full', // width: 100%; default
+  site: 'su-cc', // Use Decanter custom screen margins and sets max content width of 1500px
+  screen: 'su-w-screen', // width: 100vw
+};
+export type ContainerWidthType = keyof typeof containerWidths;

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,0 +1,25 @@
+import React, { ReactNode, HTMLAttributes } from 'react';
+import { dcnb, ClassValue } from 'cnbuilder';
+import * as styles from './Container.styles';
+
+export interface ContainerProps {
+  as?: styles.ContainerElementType;
+  width?: styles.ContainerWidthType;
+  children?: ReactNode;
+  className?: ClassValue;
+}
+
+export const Container = ({
+  as = 'div',
+  width = 'site',
+  className,
+  children,
+  ...props
+}: ContainerProps & HTMLAttributes<HTMLElement>) => React.createElement(
+  as,
+  {
+    className: dcnb(styles.containerWidths[width], className),
+    ...props,
+  },
+  children,
+);

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -2,24 +2,27 @@ import React, { ReactNode, HTMLAttributes } from 'react';
 import { dcnb, ClassValue } from 'cnbuilder';
 import * as styles from './Container.styles';
 
-export interface ContainerProps {
+export type ContainerProps = HTMLAttributes<HTMLElement> & {
   as?: styles.ContainerElementType;
   width?: styles.ContainerWidthType;
   children?: ReactNode;
   className?: ClassValue;
-}
+};
 
 export const Container = ({
-  as = 'div',
+  as: AsComponent = 'div',
   width = 'site',
   className,
   children,
   ...props
-}: ContainerProps & HTMLAttributes<HTMLElement>) => React.createElement(
-  as,
-  {
-    className: dcnb(styles.containerWidths[width], className),
-    ...props,
-  },
-  children,
+}: ContainerProps) => (
+  <AsComponent
+    {...props}
+    className={dcnb(
+      width ? styles.containerWidths[width] : '',
+      className,
+    )}
+  >
+    {children}
+  </AsComponent>
 );

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -1,0 +1,1 @@
+export * from './Container';

--- a/src/components/FlexBox/FlexBox.styles.ts
+++ b/src/components/FlexBox/FlexBox.styles.ts
@@ -1,0 +1,38 @@
+export const flexDirection = {
+  row: 'su-flex-row',
+  'row-reverse': 'su-flex-row-reverse',
+  col: 'su-flex-col',
+  'col-reverse': 'su-flex-col-reverse',
+};
+
+export const flexWrap = {
+  wrap: 'su-flex-wrap',
+  'wrap-reverse': 'su-flex-wrap-reverse',
+  nowrap: 'su-flex-nowrap',
+};
+
+export const flexJustifyContent = {
+  start: 'su-justify-start',
+  end: 'su-justify-end',
+  center: 'su-justify-center',
+  between: 'su-justify-between',
+  around: 'su-justify-around',
+  evenly: 'su-justify-evenly',
+};
+
+export const flexAlignContent = {
+  start: 'su-content-start',
+  end: 'su-content-end',
+  center: 'su-content-center',
+  between: 'su-content-between',
+  around: 'su-content-around',
+  evenly: 'su-content-evenly',
+};
+
+export const flexAlignItems = {
+  start: 'su-items-start',
+  end: 'su-items-end',
+  center: 'su-items-center',
+  baseline: 'su-items-baseline',
+  stretch: 'su-items-stretch',
+};

--- a/src/components/FlexBox/FlexBox.tsx
+++ b/src/components/FlexBox/FlexBox.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode, HTMLAttributes } from 'react';
+import { dcnb } from 'cnbuilder';
+import * as styles from './FlexBox.styles';
+import * as types from './FlexBox.types';
+
+type FlexBoxProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode;
+  as?: types.FlexElementType;
+  direction?: types.FlexDirectionType;
+  wrap?: types.FlexWrapType;
+  gap?: boolean;
+  justifyContent?: types.FlexJustifyContentType;
+  alignContent?: types.FlexAlignContentType;
+  alignItems?: types.FlexAlignItemsType;
+};
+
+export const FlexBox = ({
+  as: AsComponent = 'div',
+  direction,
+  wrap,
+  gap,
+  justifyContent,
+  alignContent,
+  alignItems,
+  className,
+  children,
+  ...props
+}: FlexBoxProps) => (
+  <AsComponent
+    {...props}
+    className={dcnb(
+      'su-flex',
+      direction ? styles.flexDirection[direction] : '',
+      wrap ? styles.flexWrap[wrap] : '',
+      justifyContent ? styles.flexJustifyContent[justifyContent] : '',
+      alignContent ? styles.flexAlignContent[alignContent] : '',
+      alignItems ? styles.flexAlignItems[alignItems] : '',
+      gap ? 'su-grid-gap' : '',
+      className,
+    )}
+  >
+    {children}
+  </AsComponent>
+);

--- a/src/components/FlexBox/FlexBox.types.ts
+++ b/src/components/FlexBox/FlexBox.types.ts
@@ -1,0 +1,13 @@
+import * as styles from './FlexBox.styles';
+
+export type FlexElementType = 'div' | 'section' | 'article' | 'main' | 'footer' | 'aside' | 'header' | 'nav' | 'form' | 'button' | 'fieldset';
+
+export type FlexDirectionType = keyof typeof styles.flexDirection;
+
+export type FlexWrapType = keyof typeof styles.flexWrap;
+
+export type FlexJustifyContentType = keyof typeof styles.flexJustifyContent;
+
+export type FlexAlignContentType = keyof typeof styles.flexAlignContent;
+
+export type FlexAlignItemsType = keyof typeof styles.flexAlignItems;

--- a/src/components/FlexBox/FlexBox.types.ts
+++ b/src/components/FlexBox/FlexBox.types.ts
@@ -1,6 +1,6 @@
 import * as styles from './FlexBox.styles';
 
-export type FlexElementType = 'div' | 'section' | 'article' | 'main' | 'footer' | 'aside' | 'header' | 'nav' | 'form' | 'button' | 'fieldset';
+export type FlexElementType = 'div' | 'section' | 'article' | 'main' | 'footer' | 'aside' | 'header' | 'nav' | 'form' | 'button' | 'fieldset' | 'ul' | 'ol' | 'li';
 
 export type FlexDirectionType = keyof typeof styles.flexDirection;
 

--- a/src/components/FlexBox/index.ts
+++ b/src/components/FlexBox/index.ts
@@ -1,0 +1,1 @@
+export * from './FlexBox';

--- a/src/components/GlobalFooter/GlobalFooter.styles.ts
+++ b/src/components/GlobalFooter/GlobalFooter.styles.ts
@@ -1,3 +1,10 @@
+export const root = 'su-w-full su-basefont-20 su-rs-py-1 su-text-white su-bg-cardinal-red';
+export const logoWrapper = 'su-text-center su-mt-5 su-mb-9';
+export const logo = 'su-type-3';
+export const contentWrapper = 'lg:su-pl-45 xl:su-pl-50 su-text-left sm:su-text-center lg:su-text-left su-grow';
+export const menusWrapper = 'sm:su-flex-col sm:su-items-center lg:su-items-start su-mb-10';
+export const stanfordMenu = 'su-list-unstyled su-mb-10 sm:su-mb-4 su-mr-19 sm:su-mr-0 su-p-0 su-text-15 md:su-text-17 2xl:su-text-18 su-flex su-flex-col sm:su-flex-row';
+export const legalMenu = 'su-list-unstyled su-mb-10 sm:su-mb-0 su-ml-19 sm:su-ml-0 su-p-0 su-text-15 sm:su-text-14 md:su-text-15 xl:su-text-16 su-flex su-flex-col sm:su-flex-row sm:su-link-regular';
 export const listItem = 'sm:su-mr-10 md:su-mr-20 lg:su-mr-27';
 export const link = 'su-text-white su-no-underline hocus:su-underline hocus:su-text-white';
 export const copyright = 'su-text-13 sm:su-text-14 su-text-center lg:su-text-left';

--- a/src/components/GlobalFooter/GlobalFooter.styles.ts
+++ b/src/components/GlobalFooter/GlobalFooter.styles.ts
@@ -1,0 +1,4 @@
+export const listItem = 'sm:su-mr-10 md:su-mr-20 lg:su-mr-27';
+export const link = 'su-text-white su-no-underline hocus:su-underline hocus:su-text-white';
+export const copyright = 'su-text-13 sm:su-text-14 su-text-center lg:su-text-left';
+export const copyrightText = 'su-whitespace-no-wrap';

--- a/src/components/GlobalFooter/GlobalFooter.styles.ts
+++ b/src/components/GlobalFooter/GlobalFooter.styles.ts
@@ -1,4 +1,5 @@
 export const root = 'su-w-full su-basefont-20 su-rs-py-1 su-text-white su-bg-cardinal-red';
+export const outerWrapper = 'lg:su-flex-row';
 export const logoWrapper = 'su-text-center su-mt-5 su-mb-9';
 export const logo = 'su-type-3';
 export const contentWrapper = 'lg:su-pl-45 xl:su-pl-50 su-text-left sm:su-text-center lg:su-text-left su-grow';

--- a/src/components/GlobalFooter/GlobalFooter.tsx
+++ b/src/components/GlobalFooter/GlobalFooter.tsx
@@ -16,7 +16,7 @@ const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
     className={dcnb(styles.root, className)}
     width="site"
   >
-    <FlexBox direction="col" className="lg:su-flex-row">
+    <FlexBox direction="col" className={styles.outerWrapper}>
       <div className={styles.logoWrapper}>
         <StanfordLogo isLink className={styles.logo} type="stacked" color="white" />
       </div>

--- a/src/components/GlobalFooter/GlobalFooter.tsx
+++ b/src/components/GlobalFooter/GlobalFooter.tsx
@@ -1,0 +1,136 @@
+import React, { HTMLAttributes } from 'react';
+import { dcnb } from 'cnbuilder';
+import { StanfordLogo } from '../StanfordLogo';
+import { SrOnlyText } from '../Typography';
+import { Container } from '../Container';
+import { FlexBox } from '../FlexBox';
+import * as styles from './GlobalFooter.styles';
+
+type GlobalFooterProps = Omit<HTMLAttributes<HTMLDivElement>, 'className'> & {
+  className?: string;
+};
+
+export const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
+  <Container
+    {...rest}
+    className={dcnb('su-basefont-20 su-rs-py-1 su-text-white su-bg-cardinal-red', className)}
+    width="site"
+  >
+    <FlexBox direction="col" className="lg:su-flex-row">
+      <div className="su-text-center su-mt-5 su-mb-9">
+        <StanfordLogo isLink className="su-type-3" type="stacked" color="white" />
+      </div>
+      <div className="lg:su-pl-45 xl:su-pl-50 su-text-left sm:su-text-center lg:su-text-left su-grow">
+        <nav
+          aria-label="global footer menu"
+          className="su-flex su-flex-row sm:su-flex-col su-justify-center sm:su-items-center lg:su-items-start su-mb-10"
+        >
+          <ul className="su-list-unstyled su-mb-10 sm:su-mb-4 su-mr-19 sm:su-mr-0 su-p-0 su-text-15 md:su-text-17 2xl:su-text-18 su-flex su-flex-col sm:su-flex-row">
+            <li className={styles.listItem}>
+              <a
+                href="https://www.stanford.edu"
+                className={styles.link}
+              >
+                Stanford Home
+                <SrOnlyText />
+              </a>
+            </li>
+            <li className={styles.listItem}>
+              <a
+                href="https://visit.stanford.edu/plan/"
+                className={styles.link}
+              >
+                Maps &amp; Directions
+                <SrOnlyText />
+              </a>
+            </li>
+            <li className={styles.listItem}>
+              <a
+                href="https://www.stanford.edu/search/"
+                className={styles.link}
+              >
+                Search Stanford
+                <SrOnlyText />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://emergency.stanford.edu"
+                className={styles.link}
+              >
+                Emergency Info
+                <SrOnlyText />
+              </a>
+            </li>
+          </ul>
+          <ul className="su-list-unstyled su-mb-10 sm:su-mb-0 su-ml-19 sm:su-ml-0 su-p-0 su-text-15 sm:su-text-14 md:su-text-15 xl:su-text-16 su-flex su-flex-col sm:su-flex-row sm:su-link-regular">
+            <li className={styles.listItem}>
+              <a
+                href="https://www.stanford.edu/site/terms/"
+                title="Terms of use for sites"
+                className={styles.link}
+              >
+                Terms of Use
+                <SrOnlyText />
+              </a>
+            </li>
+            <li className={styles.listItem}>
+              <a
+                href="https://www.stanford.edu/site/privacy/"
+                title="Privacy and cookie policy"
+                className={styles.link}
+              >
+                Privacy
+                <SrOnlyText />
+              </a>
+            </li>
+            <li className={styles.listItem}>
+              <a
+                href="https://uit.stanford.edu/security/copyright-infringement"
+                title="Report alleged copyright infringement"
+                className={styles.link}
+              >
+                Copyright
+                <SrOnlyText />
+              </a>
+            </li>
+            <li className={styles.listItem}>
+              <a
+                href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4"
+                title="Ownership and use of Stanford trademarks and images"
+                className={styles.link}
+              >
+                Trademarks
+                <SrOnlyText />
+              </a>
+            </li>
+            <li className={styles.listItem}>
+              <a
+                href="https://studentservices.stanford.edu/more-resources/student-policies/non-academic/non-discrimination"
+                title="Non-discrimination policy"
+                className={styles.link}
+              >
+                Non-Discrimination
+                <SrOnlyText />
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.stanford.edu/site/accessibility"
+                title="Report web accessibility issues"
+                className={styles.link}
+              >
+                Accessibility
+                <SrOnlyText />
+              </a>
+            </li>
+          </ul>
+        </nav>
+        <div className={styles.copyright}>
+          <span className={styles.copyrightText}>&copy; Stanford University.</span>
+          <span className={styles.copyrightText}>&nbsp; Stanford, California 94305.</span>
+        </div>
+      </div>
+    </FlexBox>
+  </Container>
+);

--- a/src/components/GlobalFooter/GlobalFooter.tsx
+++ b/src/components/GlobalFooter/GlobalFooter.tsx
@@ -10,22 +10,23 @@ type GlobalFooterProps = Omit<HTMLAttributes<HTMLDivElement>, 'className'> & {
   className?: string;
 };
 
-export const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
+const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
   <Container
     {...rest}
-    className={dcnb('su-basefont-20 su-rs-py-1 su-text-white su-bg-cardinal-red', className)}
+    className={dcnb(styles.root, className)}
     width="site"
   >
     <FlexBox direction="col" className="lg:su-flex-row">
-      <div className="su-text-center su-mt-5 su-mb-9">
-        <StanfordLogo isLink className="su-type-3" type="stacked" color="white" />
+      <div className={styles.logoWrapper}>
+        <StanfordLogo isLink className={styles.logo} type="stacked" color="white" />
       </div>
-      <div className="lg:su-pl-45 xl:su-pl-50 su-text-left sm:su-text-center lg:su-text-left su-grow">
-        <nav
+      <div className={styles.contentWrapper}>
+        <FlexBox
+          justifyContent="center"
           aria-label="global footer menu"
-          className="su-flex su-flex-row sm:su-flex-col su-justify-center sm:su-items-center lg:su-items-start su-mb-10"
+          className={styles.menusWrapper}
         >
-          <ul className="su-list-unstyled su-mb-10 sm:su-mb-4 su-mr-19 sm:su-mr-0 su-p-0 su-text-15 md:su-text-17 2xl:su-text-18 su-flex su-flex-col sm:su-flex-row">
+          <ul className={styles.stanfordMenu}>
             <li className={styles.listItem}>
               <a
                 href="https://www.stanford.edu"
@@ -63,7 +64,7 @@ export const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
               </a>
             </li>
           </ul>
-          <ul className="su-list-unstyled su-mb-10 sm:su-mb-0 su-ml-19 sm:su-ml-0 su-p-0 su-text-15 sm:su-text-14 md:su-text-15 xl:su-text-16 su-flex su-flex-col sm:su-flex-row sm:su-link-regular">
+          <ul className={styles.legalMenu}>
             <li className={styles.listItem}>
               <a
                 href="https://www.stanford.edu/site/terms/"
@@ -125,7 +126,7 @@ export const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
               </a>
             </li>
           </ul>
-        </nav>
+        </FlexBox>
         <div className={styles.copyright}>
           <span className={styles.copyrightText}>&copy; Stanford University.</span>
           <span className={styles.copyrightText}>&nbsp; Stanford, California 94305.</span>
@@ -134,3 +135,6 @@ export const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
     </FlexBox>
   </Container>
 );
+
+// Must use default export for Gatsby slice
+export default GlobalFooter;

--- a/src/components/GlobalFooter/index.ts
+++ b/src/components/GlobalFooter/index.ts
@@ -1,0 +1,1 @@
+export * from './GlobalFooter';

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { Slice } from 'gatsby';
 import { storyblokInit, apiPlugin } from 'gatsby-source-storyblok';
+import { FlexBox } from './FlexBox';
 import Teaser from './Storyblok/Teaser';
 import Grid from './Storyblok/Grid';
 import Feature from './Storyblok/Feature';
@@ -22,9 +24,10 @@ storyblokInit({
 });
 
 const Layout = ({ children }: LayoutProps) => (
-  <div>
+  <FlexBox justifyContent="between" direction="col" className="su-min-h-screen">
     <main>{children}</main>
-  </div>
+    <Slice alias="global-footer" />
+  </FlexBox>
 );
 
 export default Layout;

--- a/src/components/StanfordLogo/StanfordLogo.styles.ts
+++ b/src/components/StanfordLogo/StanfordLogo.styles.ts
@@ -1,0 +1,7 @@
+export const logoColors = {
+  'cardinal-red': 'su-text-cardinal-red hocus:su-text-cardinal-red',
+  'digital-red': 'su-text-digital-red hocus:su-text-digital-red',
+  black: 'su-text-black hocus:su-text-black',
+  white: 'su-text-white hocus:su-text-white',
+};
+export type LogoColorType = keyof typeof logoColors;

--- a/src/components/StanfordLogo/StanfordLogo.tsx
+++ b/src/components/StanfordLogo/StanfordLogo.tsx
@@ -1,0 +1,59 @@
+import React, { HTMLAttributes, ReactNode } from 'react';
+import { dcnb } from 'cnbuilder';
+import * as styles from './StanfordLogo.styles';
+
+type StanfordLogoProps = HTMLAttributes<HTMLElement> & {
+  color?: styles.LogoColorType;
+  type?: 'short' | 'full' | 'stacked';
+  isLink?: boolean;
+};
+
+export const StanfordLogo = ({
+  className,
+  color = 'cardinal-red',
+  type,
+  isLink,
+  ...rest
+}: StanfordLogoProps) => {
+  let logoText: string | ReactNode;
+
+  switch (type) {
+    case 'full':
+      logoText = 'Stanford University';
+      break;
+
+    case 'stacked':
+      logoText = (
+        <>
+          Stanford
+          <br />
+          University
+        </>
+      );
+      break;
+
+    case 'short':
+    default:
+      logoText = 'Stanford';
+      break;
+  }
+
+  // Render logo as link if isLink is true
+  if (isLink) {
+    return (
+      <a
+        {...rest}
+        href="https://www.stanford.edu"
+        className={dcnb(color ? styles.logoColors[color] : '', className)}
+      >
+        {logoText}
+      </a>
+    );
+  }
+
+  return (
+    <div {...rest} className={dcnb(color ? styles.logoColors[color] : '', className)}>
+      {logoText}
+    </div>
+  );
+};

--- a/src/components/StanfordLogo/StanfordLogo.tsx
+++ b/src/components/StanfordLogo/StanfordLogo.tsx
@@ -44,7 +44,7 @@ export const StanfordLogo = ({
       <a
         {...rest}
         href="https://www.stanford.edu"
-        className={dcnb(color ? styles.logoColors[color] : '', className)}
+        className={dcnb('su-logo', color ? styles.logoColors[color] : '', className)}
       >
         {logoText}
       </a>
@@ -52,7 +52,7 @@ export const StanfordLogo = ({
   }
 
   return (
-    <div {...rest} className={dcnb(color ? styles.logoColors[color] : '', className)}>
+    <div {...rest} className={dcnb('su-logo', color ? styles.logoColors[color] : '', className)}>
       {logoText}
     </div>
   );

--- a/src/components/StanfordLogo/index.ts
+++ b/src/components/StanfordLogo/index.ts
@@ -1,0 +1,1 @@
+export * from './StanfordLogo';

--- a/src/components/Typography/SrOnlyText.tsx
+++ b/src/components/Typography/SrOnlyText.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, TextProps } from './Text';
 
-export const SrOnlyText = ({ children, ...props }: TextProps) => (
+export const SrOnlyText = ({ children = '(link is external)', ...props }: TextProps) => (
   <Text {...props} srOnly className="su-white-space-pre">
     {` ${children}`}
   </Text>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add GlobalFooter and other Layout/Identity components
- Add GlobalFooter to Layout component as a Gatsby Slice
- make Global Footer sticky to bottom

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and see that the Global Footer is showing up
2. Look at code and comments below

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-58, GIVCAMP-33
