### PR TITLE
GIVCAMP-71 | Add updated Storyblok image service processing with masked CDN URL

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,13 +1,11 @@
-import React, { ReactNode, HTMLAttributes } from 'react';
-import { dcnb, ClassValue } from 'cnbuilder';
+import React, { HTMLAttributes } from 'react';
+import { dcnb } from 'cnbuilder';
 import * as styles from './Container.styles';
 
 export type ContainerProps = HTMLAttributes<HTMLElement> & {
   as?: styles.ContainerElementType;
   width?: styles.ContainerWidthType;
-  children?: ReactNode;
   style?: React.CSSProperties;
-  className?: ClassValue;
 };
 
 export const Container = ({

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, HTMLAttributes } from 'react';
+import React, { HTMLAttributes } from 'react';
 import { dcnb } from 'cnbuilder';
 import * as styles from './Grid.styles';
 import * as types from './Grid.types';
@@ -16,7 +16,6 @@ export type GridProps = HTMLAttributes<HTMLElement> & {
   justifyItems?: types.GridJustifyItemsType,
   alignContent?: types.GridAlignContentType,
   alignItems?: types.GridAlignItemsType,
-  children: ReactNode,
 };
 
 export const Grid = ({

--- a/src/components/Grid/WidthBox.styles.ts
+++ b/src/components/Grid/WidthBox.styles.ts
@@ -1,0 +1,18 @@
+export const widthClasses = {
+  4: {
+    column: 'sm:su-col-span-10 md:su-col-span-8 lg:su-col-span-6 2xl:su-col-span-4',
+    columnStart: 'sm:su-col-start-2 md:su-col-start-3 lg:su-col-start-4 2xl:su-col-start-5',
+  },
+  6: {
+    column: 'md:su-col-span-10 lg:su-col-span-8 xl:su-col-span-6',
+    columnStart: 'md:su-col-start-2 lg:su-col-start-3 xl:su-col-start-4',
+  },
+  8: {
+    column: 'lg:su-col-span-10 xl:su-col-span-8',
+    columnStart: 'lg:su-col-start-2 xl:su-col-start-3',
+  },
+  10: {
+    column: 'xl:su-col-span-10',
+    columnStart: 'xl:su-col-start-2',
+  },
+};

--- a/src/components/Grid/WidthBox.tsx
+++ b/src/components/Grid/WidthBox.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { dcnb } from 'cnbuilder';
+import { Container, ContainerProps } from '../Container';
+import { Grid, GridProps } from './Grid';
+import * as styles from './WidthBox.styles';
+
+/**
+ * For use as a wrapper container that sets a width in terms of number of columns.
+ * E.g., Edge-to-edge, site container width (12 of 12 columns), 10 of 12, 8 of 12 columns etc.
+ * */
+
+type WidthBoxProps = GridProps & Omit<ContainerProps, 'width'> & {
+  width: 'edge-to-edge' | 'site' | '10' | '8' | '6' | '4';
+  align?: 'left' | 'center';
+};
+
+export const WidthBox = ({
+  width = 'site',
+  align = 'center',
+  children,
+  className,
+  ...props
+}: WidthBoxProps) => {
+  // If it is edge-to-edge or takes up 12 of 12 column, no need to use a grid
+  if (width === 'edge-to-edge' || width === 'site') {
+    return (
+      <Container {...props} width={width === 'site' ? 'site' : 'full'} className={className}>
+        {children}
+      </Container>
+    );
+  }
+
+  return (
+    <Grid {...props} gap sm={12} className={dcnb('su-cc', className)}>
+      <div
+        className={dcnb(
+          styles.widthClasses[width].column,
+          align === 'center' ? styles.widthClasses[width].columnStart : '',
+        )}
+      >
+        {children}
+      </div>
+    </Grid>
+  );
+};

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -5,6 +5,7 @@ import { CtaLink } from '../Cta/CtaLink';
 import { Heading, HeadingType, Paragraph } from '../Typography';
 import { SbLinkType } from '../Storyblok/Storyblok.types';
 import { TextColorType } from './VerticalCard.styles';
+import { getProcessedImage } from '../../utilities/getProcessedImage';
 import * as styles from './VerticalCard.styles';
 
 type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
@@ -49,7 +50,7 @@ export const VerticalCard = ({
       {imageSrc && (
         <div className="su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none group-hover:su-rounded-tl-[10rem] group-hover:su-rounded-br-[10rem] group-focus-within:su-rounded-tl-[10rem] group-focus-within:su-rounded-br-[10rem] su-overflow-hidden">
           <img
-            src={imageSrc}
+            src={getProcessedImage(imageSrc, '600x600', imageFocus)}
             alt={alt}
             className="su-object-cover su-w-full su-h-full"
           />

--- a/src/utilities/config.ts
+++ b/src/utilities/config.ts
@@ -7,4 +7,5 @@ export const config = {
       ? '/'
       : process.env.GATSBY_BASE_PATH,
   assetCdn: process.env.GATSBY_ASSET_CDN ?? 'https://assets.stanford.edu/',
+  imageService: 'https://a-us.storyblok.com/',
 };

--- a/src/utilities/getProcessedImage.ts
+++ b/src/utilities/getProcessedImage.ts
@@ -1,0 +1,47 @@
+import { config } from './config';
+
+/**
+ *
+ * @param {string} image - The Storyblok URL of the image
+ * @param {string} [crop] - The dimension of the image crop (eg., "600 x 400")
+ * @param {string} [focus] - The focal point of the image provided by the Storyblok Asset field (eg, "348x414:349x415")
+ * @param {string} [filters] - Additional filters to apply to the image (eg., "blur(10)").
+ * To add multiple filters, separate them with a colon, eg., "blur(10):grayscale()"
+ * @returns {string} The processed Storyblok image URL that is masked by our asset CDN
+ * @see {@link https://www.storyblok.com/docs/image-service} for more info on the Storyblok image service
+ */
+
+export const getProcessedImage = (image, crop = '', focus = '', filters = '') => {
+  const { imageService } = config;
+
+  // Adding '/m' at the end of the URL to automatically convert the image to webp if the browser supports it.
+  // Suppports jpg, png (including transparent ones). Animated GIFs will retain the GIF format automatically.
+  let myParams = '/m';
+
+  // Start off the filters with a default image quality of 70% - works for webp
+  let myFilters = '/filters:quality(70)';
+
+  if (crop) {
+    myParams += `/${crop}`;
+    /**
+     * If the crop dimensions are provide, and if a focal point is provided, add the focal point to the filters
+     * If no focal point is provided, activate the "smart" face detection feature
+     */
+    if (focus) {
+      myFilters += `:focal(${focus})`;
+    } else {
+      myParams += '/smart';
+    }
+  }
+
+  // Add any additional filters
+  if (filters) {
+    myFilters += `:${filters}`;
+  }
+
+  // The URL of the processed Stoeyblok image
+  const processedSbUrl = `${image}${myParams}${myFilters}`;
+  const maskedUrl = processedSbUrl.replace(imageService, `${config.assetCdn}a-us/`);
+
+  return maskedUrl;
+};

--- a/src/utilities/getProcessedImage.ts
+++ b/src/utilities/getProcessedImage.ts
@@ -2,30 +2,40 @@ import { config } from './config';
 
 /**
  *
- * @param {string} image - The Storyblok URL of the image
- * @param {string} [crop] - The dimension of the image crop (eg., "600 x 400")
- * @param {string} [focus] - The focal point of the image provided by the Storyblok Asset field (eg, "348x414:349x415")
- * @param {string} [filters] - Additional filters to apply to the image (eg., "blur(10)").
+ * @param imageSrc - The Storyblok URL of the image
+ * @param crop - The dimension of the image crop (eg., "600 x 400")
+ * @param focus - The focal point of the image provided by the Storyblok Asset field (eg, "348x414:349x415")
+ * @param filters - Additional filters to apply to the image (eg., "blur(10)").
  * To add multiple filters, separate them with a colon, eg., "blur(10):grayscale()"
- * @returns {string} The processed Storyblok image URL that is masked by our asset CDN
+ * @returns The processed Storyblok image URL that is masked by our asset CDN
  * @see {@link https://www.storyblok.com/docs/image-service} for more info on the Storyblok image service
  */
 
-export const getProcessedImage = (image, crop = '', focus = '', filters = '') => {
+export const getProcessedImage = (
+  imageSrc: string,
+  crop: string = '',
+  focus: string = '',
+  filters: string = '',
+): string => {
   const { imageService } = config;
 
+  // Get the width and the height from the crop dimension
+  const width = crop.split('x')[0];
+  const height = crop.split('x')[1];
+
   // Adding '/m' at the end of the URL to automatically convert the image to webp if the browser supports it.
-  // Suppports jpg, png (including transparent ones). Animated GIFs will retain the GIF format automatically.
+  // Supports jpg, png (including transparent ones). Animated GIFs will retain the GIF format automatically.
   let myParams = '/m';
 
   // Start off the filters with a default image quality of 70% - works for webp
   let myFilters = '/filters:quality(70)';
 
-  if (crop) {
+  if (crop && width !== '0' && height !== '0') {
     myParams += `/${crop}`;
     /**
-     * If the crop dimensions are provide, and if a focal point is provided, add the focal point to the filters
-     * If no focal point is provided, activate the "smart" face detection feature
+     * Handle focus only if a crop dimension is provided and it has both width and height
+     * If a focal point is provided, add the focal point to the filters.
+     * If no focal point is provided, activate the "smart" face detection feature.
      */
     if (focus) {
       myFilters += `:focal(${focus})`;
@@ -39,8 +49,8 @@ export const getProcessedImage = (image, crop = '', focus = '', filters = '') =>
     myFilters += `:${filters}`;
   }
 
-  // The URL of the processed Stoeyblok image
-  const processedSbUrl = `${image}${myParams}${myFilters}`;
+  // The URL of the processed Storyblok image
+  const processedSbUrl = `${imageSrc}${myParams}${myFilters}`;
   const maskedUrl = processedSbUrl.replace(imageService, `${config.assetCdn}a-us/`);
 
   return maskedUrl;

--- a/src/utilities/getSbImageSize.ts
+++ b/src/utilities/getSbImageSize.ts
@@ -1,0 +1,17 @@
+/**
+ *
+ * @param {string} imageUrl - The URL of the Storyblok image.
+ * @returns {object} The dimensions (width and height) of the image.
+ */
+export const getSbImageSize = (imageUrl) => {
+  if (imageUrl.startsWith('http')) {
+    const imageSize = {
+      width: imageUrl.split('/')[5].split('x')[0],
+      height: imageUrl.split('/')[5].split('x')[1],
+    };
+
+    return imageSize;
+  }
+
+  return null;
+};


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- New image utilities that uses the new version of Storyblok Image Service (different from the one we use in SAA Homesite )
- Add WidthBox which we'll need later for x of 12 column type of width options

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at preview and inspect the card image with the pallas cat
2. See that it uses the new format of the Storyblok image service, and that it uses our masked URL from the assets CDN
![Screenshot 2023-04-17 at 9 57 19 AM](https://user-images.githubusercontent.com/42749717/232557759-e9007dbb-bedb-4c89-ab77-32ed4237eebe.png)
Note: image focus is supported and supported image types are converted to webp format for supported browsers
Note: it should preserve the animated GIFS (the pusheen) - it wouldn't get turned into a webp

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-71
