### PR TITLE
GIVCAMP-69 | updated Storyblok Link field support + keep filtered list of UTM params

### DIFF
--- a/src/components/Cta/CtaLink.tsx
+++ b/src/components/Cta/CtaLink.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { GatsbyLinkProps } from 'gatsby';
 import { CtaCommonProps } from './Cta.types';
@@ -21,17 +22,54 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       ...rest
     } = props;
 
+    const {
+      id,
+      fieldtype,
+      linktype,
+      cached_url: cachedUrl,
+      url,
+      target,
+      anchor,
+      // External link in Storyblok can have additional custom attributes
+      ...sbLinkProps
+    } = sbLink || {};
+
     // Check for internal links
-    const isInternal = /^\/(?!\/)/.test(href) || sbLink?.linktype === 'story';
+    const isInternal = /^\/(?!\/)/.test(href) || linktype === 'story';
+
+    // Open internal links in new tab because passing target="_blank" to GatsbyLink doesn't work at the moment
+    const openGatsbyLinkInNewTab = () => {
+      if (target === '_blank') {
+        window.open(cachedUrl || href, '_blank');
+      }
+    };
 
     if (isInternal) {
+      let toLink: string = cachedUrl;
+
+      if (sbLink?.anchor) {
+        toLink = `${toLink}#${anchor}`;
+      }
+
       return (
-        <CtaGatsbyLink {...rest} to={sbLink?.cached_url || href} ref={ref} />
+        <CtaGatsbyLink
+          {...rest}
+          ref={ref}
+          to={toLink || href}
+          target={target || undefined}
+          onClick={openGatsbyLinkInNewTab}
+        />
       );
     }
 
     return (
-      <CtaExternalLink {...rest} href={sbLink?.url || sbLink?.cached_url || href} ref={ref} />
+      <CtaExternalLink
+        {...rest}
+        {...sbLinkProps}
+        ref={ref}
+        href={url || cachedUrl || href}
+        target={target || undefined}
+      />
     );
   },
 );

--- a/src/components/Cta/CtaLink.tsx
+++ b/src/components/Cta/CtaLink.tsx
@@ -5,6 +5,7 @@ import { CtaCommonProps } from './Cta.types';
 import { CtaExternalLink } from './CtaExternalLink';
 import { CtaGatsbyLink } from './CtaGatsbyLink';
 import { SbLinkType } from '../Storyblok/Storyblok.types';
+import { useAddUtmParams } from '../../hooks/useAddUtmParams';
 
 /**
  * Use this component for CTA links.
@@ -46,18 +47,27 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       }
     };
 
+    let myLink: string = '';
+
     if (isInternal) {
-      let toLink: string = cachedUrl;
+      myLink = cachedUrl || href;
 
-      if (sbLink?.anchor) {
-        toLink = `${toLink}#${anchor}`;
+      if (anchor) {
+        myLink = `${myLink}#${anchor}`;
       }
+    } else {
+      myLink = url || cachedUrl || `mailto:${email}` || href;
+    }
 
+    // Add UTM params to internal links
+    const myLinkWithUtm = useAddUtmParams(myLink);
+
+    if (isInternal) {
       return (
         <CtaGatsbyLink
           {...rest}
           ref={ref}
-          to={toLink || href}
+          to={myLinkWithUtm}
           target={target || undefined}
           onClick={openGatsbyLinkInNewTab}
         />
@@ -69,7 +79,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
         {...rest}
         {...sbLinkProps}
         ref={ref}
-        href={url || cachedUrl || `mailto:${email}` || href}
+        href={myLinkWithUtm}
         target={target || undefined}
       />
     );

--- a/src/components/Cta/CtaLink.tsx
+++ b/src/components/Cta/CtaLink.tsx
@@ -35,11 +35,12 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
     } = sbLink || {};
 
     // Check for internal links
-    const isInternal = /^\/(?!\/)/.test(href) || linktype === 'story';
+    const isInternal: boolean = /^\/(?!\/)/.test(href) || linktype === 'story';
 
     // Open internal links in new tab because passing target="_blank" to GatsbyLink doesn't work at the moment
-    const openGatsbyLinkInNewTab = () => {
+    const openGatsbyLinkInNewTab = (e) => {
       if (target === '_blank') {
+        e.preventDefault();
         window.open(cachedUrl || href, '_blank');
       }
     };

--- a/src/components/Cta/CtaLink.tsx
+++ b/src/components/Cta/CtaLink.tsx
@@ -28,6 +28,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       linktype,
       cached_url: cachedUrl,
       url,
+      email,
       target,
       anchor,
       // External link in Storyblok can have additional custom attributes
@@ -68,7 +69,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
         {...rest}
         {...sbLinkProps}
         ref={ref}
-        href={url || cachedUrl || href}
+        href={url || cachedUrl || `mailto:${email}` || href}
         target={target || undefined}
       />
     );

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -4,6 +4,7 @@ import { Link } from 'gatsby';
 import { StanfordLogo } from '../StanfordLogo';
 import { Text, FontSizeType } from '../Typography';
 import * as styles from './Logo.styles';
+import { useAddUtmParams } from '../../hooks/useAddUtmParams';
 
 type LogoProps = HTMLAttributes<HTMLElement> & {
   color?: styles.LogoColorType;
@@ -41,12 +42,14 @@ export const Logo = ({
     </Text>
   );
 
+  const homeLink = useAddUtmParams('/');
+
   // Render logo as link if isLink is true
   if (isLink) {
     return (
       <Link
         {...rest}
-        to="/"
+        to={homeLink}
         className={dcnb(styles.link, className)}
       >
         {LogoText}

--- a/src/hooks/useAddUtmParams.ts
+++ b/src/hooks/useAddUtmParams.ts
@@ -1,0 +1,11 @@
+import { useFilteredUtmParams } from './useFilteredUtmParams';
+
+export const useAddUtmParams = (url: string) => {
+  const utmParamsToKeep = useFilteredUtmParams();
+
+  if (utmParamsToKeep) {
+    return `${url}${url.includes('?') ? '&' : '?'}${utmParamsToKeep}`;
+  }
+
+  return url;
+};

--- a/src/hooks/useAddUtmParams.ts
+++ b/src/hooks/useAddUtmParams.ts
@@ -1,5 +1,10 @@
 import { useFilteredUtmParams } from './useFilteredUtmParams';
 
+/**
+ *
+ * @param url The URL to which UTM parameters should be added.
+ * @returns A new URL string with the specified UTM parameters appended to it.
+ */
 export const useAddUtmParams = (url: string) => {
   const utmParamsToKeep = useFilteredUtmParams();
 

--- a/src/hooks/useFilteredUtmParams.ts
+++ b/src/hooks/useFilteredUtmParams.ts
@@ -1,0 +1,28 @@
+import { useLocation } from '@reach/router';
+
+/**
+ * @returns A string with a selected set of query params from the current page's URL
+ */
+export const useFilteredUtmParams = () => {
+  const paramsToKeep = [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+  ];
+  // Get the query params from the current page's URL
+  const { search } = useLocation();
+  const queryParams = new URLSearchParams(search);
+  const filteredParams = {};
+
+  queryParams.forEach((value, param) => {
+    if (paramsToKeep.includes(param)) {
+      filteredParams[param] = value;
+    }
+  });
+
+  const newQueryParams = new URLSearchParams(filteredParams).toString();
+
+  return newQueryParams;
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -217,7 +217,8 @@ const IndexPage = ({ data }) => {
           <CtaLink href="/about-test" variant="ghostLeaf" icon="arrow-right" animate="right" color="black">Learn More</CtaLink>
           <CtaLink href="/about-test" variant="ghostLeaf" uppercase icon="arrow-right" animate="right" color="black">Learn More</CtaLink>
           <CtaLink
-            href="/about-test"
+            href="https://stanford.edu"
+            rel="nofollow"
             variant="ghost"
             color="black"
             icon="triangle-down"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updated CtaLink to absorb more functionality of SbLink from Homesite with updated code
- Add hooks to get specified list of UTM params and to add those params to a URL

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-30--giving-campaign.netlify.app/?utm_medium=instagram&utm_monkey=chimp&utm_campaign=giving
2. Click on the Logo, or go to the Light Section and click on the first card
3. Check that only utm_medium and utm_campaign have been preserved. utm_monkey is gone
4. Inspect the link in the 2nd card in the Dark section
5. Check that it has the rel, title, data-test added to the a tag.

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-69
