### PR TITLE
GIVCAMP-68 | Reduce bundle size of Framer Motion

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,2 +1,0 @@
-// Note: For some reason this set up doesn't like the file name global.css so we use index.css instead
-import './src/styles/index.css';

--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import type { GatsbyBrowser } from 'gatsby';
+import { LazyMotion, domAnimation } from 'framer-motion';
+// Note: For some reason this set up doesn't like the file name global.css so we use index.css instead
+import './src/styles/index.css';
+
+export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({
+  element,
+}) => (
+  <LazyMotion features={domAnimation} strict>{element}</LazyMotion>
+);

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Container } from '../Container';
 import { Section } from '../Section';
 import { Heading } from '../Typography';
@@ -54,17 +54,17 @@ export const HomepageHero = () => {
     <Container width="full" className="su-relative">
       <Section className="!su-rs-pb-7 !su-rs-pt-10" style={{ backgroundColor: '#2F2D29', backgroundImage: darkMesh5 }}>
         <Heading as="h1" size={9} leading="none" font="druk">
-          <motion.div
+          <m.div
             variants={parentVariants}
             initial="hidden"
             animate="visible"
           >
             {lines.map((text, index) => (
-              <motion.div variants={itemVariants} key={`line${index + 1}`}>
+              <m.div variants={itemVariants} key={`line${index + 1}`}>
                 {text}
-              </motion.div>
+              </m.div>
             ))}
-          </motion.div>
+          </m.div>
         </Heading>
       </Section>
     </Container>

--- a/src/components/NumberCounter.tsx
+++ b/src/components/NumberCounter.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { motion, useInView } from 'framer-motion';
+import { m, useInView } from 'framer-motion';
 import { Text } from './Typography';
 
 /**
@@ -20,8 +20,8 @@ export const NumberCounter = ({ number, duration = 2500, afterText = '' }) => {
   }, [count, number, isInView, interval]);
 
   return (
-    <motion.span animate={{ opacity: count > 0 ? 1 : 0 }} ref={ref}>
+    <m.span animate={{ opacity: count > 0 ? 1 : 0 }} ref={ref}>
       <Text size={8} weight="bold" align="center" className="su-text-robins-egg">{count}{afterText}</Text>
-    </motion.span>
+    </m.span>
   );
 };

--- a/src/components/Parallax/Parallax.tsx
+++ b/src/components/Parallax/Parallax.tsx
@@ -2,7 +2,7 @@ import React, {
   useState, useRef, useLayoutEffect, ReactNode,
 } from 'react';
 import {
-  motion,
+  m,
   useScroll,
   useTransform,
   useSpring,
@@ -55,8 +55,8 @@ export const Parallax = ({ children, offset = 60 }: ParallaxProps) => {
   }
 
   return (
-    <motion.div ref={ref} style={{ y }}>
+    <m.div ref={ref} style={{ y }}>
       {children}
-    </motion.div>
+    </m.div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { graphql } from 'gatsby';
 import { StoryblokComponent, storyblokEditable } from 'gatsby-source-storyblok';
-import { useScroll, motion } from 'framer-motion';
+import { useScroll, m } from 'framer-motion';
 import { useStoryblokState } from '../hooks/useStoryblokState';
 import { HomepageHero } from '../components/Hero/HomepageHero';
 import { Layout } from '../components/Layout';
@@ -22,7 +22,7 @@ const IndexPage = ({ data }) => {
 
   return (
     <Layout>
-      <motion.div
+      <m.div
         className="su-w-10 su-fixed su-z-10 su-top-0 su-left-0 su-block su-bg-poppy su-h-screen su-origin-top"
         style={{ scaleY: scrollYProgress }}
       />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,7 +102,7 @@
   "include": [
     "./src/**/*.ts",
     "./src/**/*.tsx",
-    "./gatsby-browser.ts",
+    "./gatsby-browser.tsx",
     "./gatsby-config.ts",
     "./gatsby-node.ts",
     "./gatsby-ssr.tsx",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Reduce bundle size of Framer Motion following documentation
https://www.framer.com/motion/guide-reduce-bundle-size/

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview and check that the previous animations are still all working.
2. Look at code

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-68
