### PR TITLE
GIVCAMP-86 | Add fix for a line that appears sometimes when browser is resized

### DIFF
--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -73,7 +73,7 @@ export const HomepageHero = () => {
   return (
     <Container width="full" className="su-relative">
       <Container style={{ backgroundImage: darkMesh5 }} className="su-bg-black su-pt-120 md:su-pt-216 2xl:su-pt-228 su-bg-no-repeat su-bg-[center_top_-23vw] 2xl:su-bg-[center_top_-27rem]">
-        <Heading as="h1" size={9} leading="none" font="druk" className="su-z-20 su-relative su-mb-0">
+        <Heading as="h1" size={9} leading="none" font="druk" className="su-z-10 su-relative su-mb-0">
           <m.div
             variants={parentVariants}
             initial="hidden"
@@ -87,7 +87,7 @@ export const HomepageHero = () => {
           </m.div>
         </Heading>
       </Container>
-      <div className="su-relative su-z-10 su-h-[100vw] md:su-h-600 xl:su-h-[57vw] su-w-full su-bg-black">
+      <div className="su-relative su-h-[100vw] md:su-h-600 xl:su-h-[57vw] su-w-full su-bg-black su--mb-1 su-z-0">
         <video
           ref={videoRef}
           playsInline

--- a/src/components/Storyblok/SbSection.tsx
+++ b/src/components/Storyblok/SbSection.tsx
@@ -34,6 +34,7 @@ export const SbSection = ({
     bgColor={bgColor}
     pt={paddingTop}
     pb={paddingBottom}
+    className="su-relative"
   >
     {heading && (
       <Heading as={headingLevel} size={9} leading="none" uppercase font="druk">


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Occasionally, when you resized the browser, a line could appear under the video
![Screenshot 2023-04-21 at 5 33 15 PM](https://user-images.githubusercontent.com/42749717/233752396-cd518aeb-d470-4c73-a7db-b5c8d5656fb1.png)
- This appears to be a browser rendering issue.


# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Resize the browser and check that you don't see a white line anymore.
2. Look at approach (there are multiple ways)

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-86

