### PR TITLE
GIVCAMP-78 | In View Animation wrapper; redo homepage hero animation and structure; vertical card updates

### DIFF
--- a/src/components/Animate/AnimateInView.tsx
+++ b/src/components/Animate/AnimateInView.tsx
@@ -24,7 +24,7 @@ export const AnimateInView = ({
 
   // Don't animate if the user has "reduced motion" enabled
   if (prefersReducedMotion) {
-    return <div>children</div>;
+    return <div>{children}</div>;
   }
 
   return (

--- a/src/components/Animate/AnimateInView.tsx
+++ b/src/components/Animate/AnimateInView.tsx
@@ -1,0 +1,40 @@
+import React, { useRef } from 'react';
+import { useInView, m } from 'framer-motion';
+
+type AnimateInViewProps = {
+  once?: boolean;
+  children: React.ReactNode;
+};
+
+export const AnimateInView = ({
+  once = true,
+  children,
+  ...props
+}: AnimateInViewProps) => {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once });
+
+  const variants = {
+    hidden: {
+      opacity: 0,
+      scale: 0.8,
+    },
+    visible: {
+      opacity: 1,
+      scale: 1,
+      transition: { duration: 1, ease: [0.17, 0.55, 0.55, 1], delay: 0.2 },
+    },
+  };
+
+  return (
+    <m.div
+      ref={ref}
+      variants={variants}
+      initial="hidden"
+      animate={isInView ? 'visible' : 'hidden'}
+      {...props}
+    >
+      {children}
+    </m.div>
+  );
+};

--- a/src/components/Animate/AnimateInView.tsx
+++ b/src/components/Animate/AnimateInView.tsx
@@ -1,35 +1,41 @@
 import React, { useRef } from 'react';
-import { useInView, m } from 'framer-motion';
+import { useInView, m, useReducedMotion } from 'framer-motion';
+import { AnimationMap, AnimationType } from './AnimationMap';
 
 type AnimateInViewProps = {
+  animation?: AnimationType;
   once?: boolean;
+  duration?: number;
+  delay?: number;
   children: React.ReactNode;
 };
 
 export const AnimateInView = ({
+  animation = 'zoomIn',
   once = true,
+  duration = 1,
+  delay = 0.3,
   children,
   ...props
 }: AnimateInViewProps) => {
   const ref = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
   const isInView = useInView(ref, { once });
 
-  const variants = {
-    hidden: {
-      opacity: 0,
-      scale: 0.8,
-    },
-    visible: {
-      opacity: 1,
-      scale: 1,
-      transition: { duration: 1, ease: [0.17, 0.55, 0.55, 1], delay: 0.2 },
-    },
-  };
+  // Don't animate if the user has "reduced motion" enabled
+  if (prefersReducedMotion) {
+    return <div>children</div>;
+  }
 
   return (
     <m.div
       ref={ref}
-      variants={variants}
+      variants={AnimationMap[animation]}
+      transition={{
+        duration,
+        ease: [0.17, 0.55, 0.55, 1],
+        delay,
+      }}
       initial="hidden"
       animate={isInView ? 'visible' : 'hidden'}
       {...props}

--- a/src/components/Animate/AnimateInView.tsx
+++ b/src/components/Animate/AnimateInView.tsx
@@ -33,7 +33,10 @@ export const AnimateInView = ({
       variants={AnimationMap[animation]}
       transition={{
         duration,
-        ease: [0.17, 0.55, 0.55, 1],
+        type: 'spring',
+        bounce: 0.5,
+        damping: 20,
+        mass: 3,
         delay,
       }}
       initial="hidden"

--- a/src/components/Animate/AnimationMap.ts
+++ b/src/components/Animate/AnimationMap.ts
@@ -19,10 +19,20 @@ export const AnimationMap = {
       x: 0,
     },
   },
+  slideInFromRight: {
+    hidden: {
+      opacity: 0,
+      x: 100,
+    },
+    visible: {
+      opacity: 1,
+      x: 0,
+    },
+  },
   slideUp: {
     hidden: {
       opacity: 0,
-      y: 200,
+      y: 100,
     },
     visible: {
       opacity: 1,
@@ -32,7 +42,7 @@ export const AnimationMap = {
   slideDown: {
     hidden: {
       opacity: 0,
-      y: -200,
+      y: -100,
     },
     visible: {
       opacity: 1,

--- a/src/components/Animate/AnimationMap.ts
+++ b/src/components/Animate/AnimationMap.ts
@@ -22,7 +22,7 @@ export const AnimationMap = {
   slideUp: {
     hidden: {
       opacity: 0,
-      y: 300,
+      y: 200,
     },
     visible: {
       opacity: 1,
@@ -32,7 +32,7 @@ export const AnimationMap = {
   slideDown: {
     hidden: {
       opacity: 0,
-      y: -300,
+      y: -200,
     },
     visible: {
       opacity: 1,

--- a/src/components/Animate/AnimationMap.ts
+++ b/src/components/Animate/AnimationMap.ts
@@ -21,9 +21,21 @@ export const AnimationMap = {
   },
   slideUp: {
     hidden: {
-      y: 200,
+      opacity: 0,
+      y: 300,
     },
     visible: {
+      opacity: 1,
+      y: 0,
+    },
+  },
+  slideDown: {
+    hidden: {
+      opacity: 0,
+      y: -300,
+    },
+    visible: {
+      opacity: 1,
       y: 0,
     },
   },

--- a/src/components/Animate/AnimationMap.ts
+++ b/src/components/Animate/AnimationMap.ts
@@ -2,7 +2,7 @@ export const AnimationMap = {
   zoomIn: {
     hidden: {
       opacity: 0,
-      scale: 0.7,
+      scale: 0.8,
     },
     visible: {
       opacity: 1,

--- a/src/components/Animate/AnimationMap.ts
+++ b/src/components/Animate/AnimationMap.ts
@@ -1,0 +1,31 @@
+export const AnimationMap = {
+  zoomIn: {
+    hidden: {
+      opacity: 0,
+      scale: 0.7,
+    },
+    visible: {
+      opacity: 1,
+      scale: 1,
+    },
+  },
+  slideInFromLeft: {
+    hidden: {
+      opacity: 0,
+      x: -100,
+    },
+    visible: {
+      opacity: 1,
+      x: 0,
+    },
+  },
+  slideUp: {
+    hidden: {
+      y: 200,
+    },
+    visible: {
+      y: 0,
+    },
+  },
+};
+export type AnimationType = keyof typeof AnimationMap;

--- a/src/components/Animate/index.ts
+++ b/src/components/Animate/index.ts
@@ -1,0 +1,1 @@
+export * from './AnimateInView';

--- a/src/components/Animate/index.ts
+++ b/src/components/Animate/index.ts
@@ -1,1 +1,2 @@
 export * from './AnimateInView';
+export * from './AnimationMap';

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -39,7 +39,7 @@ export const Grid = ({
     {...props}
     className={dcnb(
       'su-grid',
-      gap ? 'su-grid-gap' : '',
+      gap ? 'su-grid-gap su-gap-y-[5rem] xl:su-gap-y-[7rem]' : '',
       xs ? styles.gridNumCols.xs[xs] : '',
       sm ? styles.gridNumCols.sm[sm] : '',
       md ? styles.gridNumCols.md[md] : '',

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -36,7 +36,7 @@ export const HomepageHero = () => {
         when: 'beforeChildren',
         duration: 0.8,
         delay: 1,
-        staggerChildren: 0.4,
+        staggerChildren: 0.3,
       },
     },
     hidden: {
@@ -55,6 +55,7 @@ export const HomepageHero = () => {
       // opacity: 1,
       transition: {
         duration: 0.5,
+        ease: 'circOut',
       },
     },
     hidden: {
@@ -122,8 +123,8 @@ export const HomepageHero = () => {
           </button>
         </div>
       </div>
-      <m.div className="su-cc" variants={parentVariants} initial="hidden" animate="visible">
-        <Heading as="h1" size={9} leading="none" font="druk" color="white" className="su-absolute su-top-0 su-mb-0 su-pt-120 md:su-pt-216 2xl:su-pt-228">
+      <m.div variants={parentVariants} initial="hidden" animate="visible">
+        <Heading as="h1" size={9} leading="none" font="druk" color="white" className="su-cc su-absolute su-top-0 su-mb-0 su-pt-120 md:su-pt-216 2xl:su-pt-228">
           {lines.map((text, index) => (
             <m.div variants={itemVariants} key={`line${index + 1}`}>
               {text}

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -107,7 +107,7 @@ export const HomepageHero = () => {
             className="su-block su-w-full su-h-full su-object-cover"
           >
             <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/a3e3e04cdd/record-compressed.webm')} type="video/webm" />
-            <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/883ff6f9dc/ocean2-compressed.mp4')} type="video/mp4" />
+            <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/e36a5877cf/record-compressed.mp4')} type="video/mp4" />
             <p>Your browser does not support HTML video.</p>
           </video>
           <div className="su-absolute su-w-full su-h-full su-top-0 su-left-0 su-bg-gradient-to-b su-from-black su-via-black/70 su-via-30% su-to-80%" />

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -16,13 +16,27 @@ export const HomepageHero = () => {
     'On purpose.',
   ];
 
+  const fadeVariants = {
+    visible: {
+      opacity: 1,
+      transition: {
+        duration: 1,
+        delay: 0,
+      },
+    },
+    hidden: {
+      opacity: 0,
+    },
+  };
+
   const parentVariants = {
     visible: {
       opacity: 1,
       transition: {
         when: 'beforeChildren',
-        duration: 1,
-        staggerChildren: 0.8,
+        duration: 0.8,
+        delay: 1,
+        staggerChildren: 0.4,
       },
     },
     hidden: {
@@ -35,19 +49,19 @@ export const HomepageHero = () => {
 
   const itemVariants = {
     visible: {
-      opacity: 1,
-      transform: 'translateY(0)',
+      y: 0,
       WebkitTextStroke: '0',
       color: '#fff',
+      // opacity: 1,
       transition: {
         duration: 0.5,
       },
     },
     hidden: {
-      opacity: 1,
+      // opacity: 0,
       WebkitTextStroke: '2px #ddd',
-      color: 'rgba(255, 255, 255, 0)',
-      transform: 'translateY(0.3em)',
+      color: 'rgba(255, 255, 255, 0.1)',
+      y: '0.3em',
     },
   };
 
@@ -71,49 +85,52 @@ export const HomepageHero = () => {
   };
 
   return (
-    <Container width="full" className="su-relative">
-      <Container style={{ backgroundImage: darkMesh5 }} className="su-bg-black su-pt-120 md:su-pt-216 2xl:su-pt-228 su-bg-no-repeat su-bg-[center_top_-23vw] 2xl:su-bg-[center_top_-27rem]">
-        <Heading as="h1" size={9} leading="none" font="druk" className="su-z-10 su-relative su-mb-0">
-          <m.div
-            variants={parentVariants}
-            initial="hidden"
-            animate="visible"
+    <Container width="full" className="su-relative su-bg-black">
+      <div className="">
+        <m.div
+          variants={fadeVariants}
+          initial="hidden"
+          animate="visible"
+        >
+          <Container style={{ backgroundImage: darkMesh5 }} className="su-bg-black su-h-[34.3rem] md:su-h-[56.2rem] lg:su-h-[71.5rem] 2xl:su-h-[77.9rem] su-bg-no-repeat su-bg-[center_top_-2vw] 2xl:su-bg-top" />
+        </m.div>
+        <div className="su-relative su-h-[100vw] md:su-h-600 xl:su-h-[57vw] su-w-full su-bg-black su--mb-1 su-z-0">
+          <video
+            ref={videoRef}
+            playsInline
+            autoPlay={!prefersReduceMotion}
+            muted
+            loop
+            aria-label="Background Video"
+            poster={getProcessedImage('https://a-us.storyblok.com/f/1005200/1851x1041/e7319575a3/record-poster.jpg', '1920x1080')}
+            className="su-block su-w-full su-h-full su-object-cover"
           >
-            {lines.map((text, index) => (
-              <m.div variants={itemVariants} key={`line${index + 1}`}>
-                {text}
-              </m.div>
-            ))}
-          </m.div>
-        </Heading>
-      </Container>
-      <div className="su-relative su-h-[100vw] md:su-h-600 xl:su-h-[57vw] su-w-full su-bg-black su--mb-1 su-z-0">
-        <video
-          ref={videoRef}
-          playsInline
-          autoPlay={!prefersReduceMotion}
-          muted
-          loop
-          aria-label="Background Video"
-          poster={getProcessedImage('https://a-us.storyblok.com/f/1005200/1851x1041/e7319575a3/record-poster.jpg', '1920x1080')}
-          className="su-block su-w-full su-h-full su--mt-[9.4rem] md:su--mt-[14.4rem] lg:su--mt-[21rem] 2xl:su--mt-[23rem] su-object-cover"
-        >
-          <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/a3e3e04cdd/record-compressed.webm')} type="video/webm" />
-          <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/e36a5877cf/record-compressed.mp4')} type="video/mp4" />
-          <p>Your browser does not support HTML video.</p>
-        </video>
-        <div className="su-absolute su-w-full su-h-full su-top-0 su-left-0 su-bg-black-true/40" />
-        <button
-          type="button"
-          onClick={toggleVideo}
-          className="su-text-white/50 su-absolute su-bottom-[7%] su-left-[50%] su-translate-x-[-50%] su-type-6 hocus:su-text-white su-transition"
-        >
-          <HeroIcon
-            icon={isPlaying ? 'pause' : 'play'}
-            title={`${isPlaying ? 'Pause' : 'Play'} background video`}
-          />
-        </button>
+            <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/a3e3e04cdd/record-compressed.webm')} type="video/webm" />
+            <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/883ff6f9dc/ocean2-compressed.mp4')} type="video/mp4" />
+            <p>Your browser does not support HTML video.</p>
+          </video>
+          <div className="su-absolute su-w-full su-h-full su-top-0 su-left-0 su-bg-gradient-to-b su-from-black su-via-black/70 su-via-30% su-to-80%" />
+          <button
+            type="button"
+            onClick={toggleVideo}
+            className="su-text-white/50 su-absolute su-bottom-[7%] su-left-[50%] su-translate-x-[-50%] su-type-6 hocus:su-text-white su-transition"
+          >
+            <HeroIcon
+              icon={isPlaying ? 'pause' : 'play'}
+              title={`${isPlaying ? 'Pause' : 'Play'} background video`}
+            />
+          </button>
+        </div>
       </div>
+      <m.div className="su-cc" variants={parentVariants} initial="hidden" animate="visible">
+        <Heading as="h1" size={9} leading="none" font="druk" color="white" className="su-absolute su-top-0 su-mb-0 su-pt-120 md:su-pt-216 2xl:su-pt-228">
+          {lines.map((text, index) => (
+            <m.div variants={itemVariants} key={`line${index + 1}`}>
+              {text}
+            </m.div>
+          ))}
+        </Heading>
+      </m.div>
     </Container>
   );
 };

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -20,7 +20,7 @@ export const HomepageHero = () => {
     visible: {
       opacity: 1,
       transition: {
-        duration: 1,
+        duration: 0.6,
         delay: 0,
       },
     },
@@ -34,8 +34,8 @@ export const HomepageHero = () => {
       opacity: 1,
       transition: {
         when: 'beforeChildren',
-        duration: 0.8,
-        delay: 1,
+        duration: 0.6,
+        delay: 0.6,
         staggerChildren: 0.3,
       },
     },
@@ -60,7 +60,7 @@ export const HomepageHero = () => {
     },
     hidden: {
       // opacity: 0,
-      WebkitTextStroke: '2px #ddd',
+      WebkitTextStroke: '2px #fff',
       color: 'rgba(255, 255, 255, 0.1)',
       y: '0.3em',
     },
@@ -95,21 +95,23 @@ export const HomepageHero = () => {
         >
           <Container style={{ backgroundImage: darkMesh5 }} className="su-bg-black su-h-[34.3rem] md:su-h-[56.2rem] lg:su-h-[71.5rem] 2xl:su-h-[77.9rem] su-bg-no-repeat su-bg-[center_top_-2vw] 2xl:su-bg-top" />
         </m.div>
-        <div className="su-relative su-h-[100vw] md:su-h-600 xl:su-h-[57vw] su-w-full su-bg-black su--mb-1 su-z-0">
-          <video
-            ref={videoRef}
-            playsInline
-            autoPlay={!prefersReduceMotion}
-            muted
-            loop
-            aria-label="Background Video"
-            poster={getProcessedImage('https://a-us.storyblok.com/f/1005200/1851x1041/e7319575a3/record-poster.jpg', '1920x1080')}
-            className="su-block su-w-full su-h-full su-object-cover"
-          >
-            <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/a3e3e04cdd/record-compressed.webm')} type="video/webm" />
-            <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/e36a5877cf/record-compressed.mp4')} type="video/mp4" />
-            <p>Your browser does not support HTML video.</p>
-          </video>
+        <div className="su-relative su-w-full su-bg-black su--mb-1">
+          <div className="su-aspect-w-1 su-aspect-h-1 md:su-aspect-w-16 md:su-aspect-h-9">
+            <video
+              ref={videoRef}
+              playsInline
+              autoPlay={!prefersReduceMotion}
+              muted
+              loop
+              aria-label="Background Video"
+              poster={getProcessedImage('https://a-us.storyblok.com/f/1005200/1851x1041/e7319575a3/record-poster.jpg', '1920x1080')}
+              className="su-block su-w-full su-h-full su-object-cover"
+            >
+              <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/a3e3e04cdd/record-compressed.webm')} type="video/webm" />
+              <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/e36a5877cf/record-compressed.mp4')} type="video/mp4" />
+              <p>Your browser does not support HTML video.</p>
+            </video>
+          </div>
           <div className="su-absolute su-w-full su-h-full su-top-0 su-left-0 su-bg-gradient-to-b su-from-black su-via-black/70 su-via-30% su-to-80%" />
           <button
             type="button"

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -14,7 +14,7 @@ export const stanford = (variant: LogoVariantType) => dcnb('su-leading-none', {
   'su-text-[1.08em]': variant === 'horizontal',
 });
 
-export const onPurpose = (variant: LogoVariantType) => dcnb('', {
+export const onPurpose = (variant: LogoVariantType) => dcnb('!su-tracking-normal', {
   'su-ml-[0.15em] su-leading-[.7]': variant === 'horizontal',
 });
 

--- a/src/components/SplitPoster/PosterContent.tsx
+++ b/src/components/SplitPoster/PosterContent.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import { dcnb } from 'cnbuilder';
+import { AnimateInView } from '../Animate';
 import { FlexBox } from '../FlexBox';
 import { Heading, Paragraph, HeadingType } from '../Typography';
 import { ImageOverlay } from '../ImageOverlay';
@@ -46,31 +47,33 @@ export const PosterContent = ({
         />
       )}
       {hasContent && (
-        <FlexBox
-          direction="col"
-          className={styles.content}
-          alignItems={contentAlign === 'left' ? 'start' : 'end'}
-        >
-          {heading && (
-            <Heading
-              as={headingLevel}
-              size={3}
-              font="druk-wide"
-              leading="tight"
-              uppercase
-              className={styles.heading(!!imageSrc)}
-              align={contentAlign}
-            >
-              {heading}
-            </Heading>
-          )}
-          {body && (
-            <Paragraph size={1} leading="snug" align={contentAlign} className={styles.body}>
-              {body}
-            </Paragraph>
-          )}
-          {children}
-        </FlexBox>
+        <AnimateInView delay={0.2} duration={0.7} animation={contentAlign === 'left' ? 'slideDown' : 'slideUp'}>
+          <FlexBox
+            direction="col"
+            className={styles.content}
+            alignItems={contentAlign === 'left' ? 'start' : 'end'}
+          >
+            {heading && (
+              <Heading
+                as={headingLevel}
+                size={3}
+                font="druk-wide"
+                leading="tight"
+                uppercase
+                className={styles.heading(!!imageSrc)}
+                align={contentAlign}
+              >
+                {heading}
+              </Heading>
+            )}
+            {body && (
+              <Paragraph size={1} leading="snug" align={contentAlign} className={styles.body}>
+                {body}
+              </Paragraph>
+            )}
+            {children}
+          </FlexBox>
+        </AnimateInView>
       )}
     </FlexBox>
   );

--- a/src/components/Storyblok/SbVerticalCard.tsx
+++ b/src/components/Storyblok/SbVerticalCard.tsx
@@ -15,6 +15,7 @@ type SbVerticalCardProps = {
     image?: SbImageType;
     textColor?: TextColorType;
     tabColor?: AccentBgColorType;
+    ctaLabel?: string;
     link?: SbLinkType;
   };
 };
@@ -30,6 +31,7 @@ export const SbVerticalCard = ({
     image: { filename, focus, alt } = {},
     textColor,
     tabColor,
+    ctaLabel,
     link,
   },
   blok,
@@ -46,6 +48,7 @@ export const SbVerticalCard = ({
     alt={alt}
     textColor={textColor}
     tabColor={tabColor}
+    ctaLabel={ctaLabel}
     link={link}
   />
 );

--- a/src/components/Storyblok/SbVerticalCard.tsx
+++ b/src/components/Storyblok/SbVerticalCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
+import { AnimationType } from '../Animate';
 import { HeadingType } from '../Typography';
 import { VerticalCard, TextColorType } from '../VerticalCard';
 import { SbImageType, SbLinkType } from './Storyblok.types';
@@ -17,6 +18,8 @@ type SbVerticalCardProps = {
     tabColor?: AccentBgColorType;
     ctaLabel?: string;
     link?: SbLinkType;
+    animation?: AnimationType;
+    delay?: number;
   };
 };
 
@@ -33,6 +36,8 @@ export const SbVerticalCard = ({
     tabColor,
     ctaLabel,
     link,
+    animation,
+    delay,
   },
   blok,
 }: SbVerticalCardProps) => (
@@ -50,5 +55,7 @@ export const SbVerticalCard = ({
     tabColor={tabColor}
     ctaLabel={ctaLabel}
     link={link}
+    animation={animation}
+    delay={delay}
   />
 );

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -37,7 +37,7 @@ export const Text = ({
   color = 'default',
   variant,
   leading,
-  useDefaultTracking = font === 'druk' || font === 'druk-wide',
+  useDefaultTracking = font === 'druk-wide',
   italic,
   srOnly,
   uppercase = font === 'druk',
@@ -65,6 +65,7 @@ export const Text = ({
           srOnly ? 'su-sr-only' : '',
           uppercase ? 'su-uppercase' : '',
           useDefaultTracking ? 'su-tracking-normal' : '',
+          font === 'druk' ? 'sm:su-tracking-wide' : '',
           className,
         )
       }

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -65,7 +65,7 @@ export const Text = ({
           srOnly ? 'su-sr-only' : '',
           uppercase ? 'su-uppercase' : '',
           useDefaultTracking ? 'su-tracking-normal' : '',
-          font === 'druk' ? 'sm:su-tracking-wide' : 'su-tracking-normal',
+          font === 'druk' ? 'su-tracking-normal sm:su-tracking-wide' : '',
           className,
         )
       }

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -65,7 +65,7 @@ export const Text = ({
           srOnly ? 'su-sr-only' : '',
           uppercase ? 'su-uppercase' : '',
           useDefaultTracking ? 'su-tracking-normal' : '',
-          font === 'druk' ? 'sm:su-tracking-wide' : '',
+          font === 'druk' ? 'sm:su-tracking-wide' : 'su-tracking-normal',
           className,
         )
       }

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import { dcnb } from 'cnbuilder';
-import { AnimateInView } from '../Animate';
+import { AnimateInView, AnimationType } from '../Animate';
 import { CtaLink } from '../Cta/CtaLink';
 import { Heading, HeadingType, Paragraph } from '../Typography';
 import { SbLinkType } from '../Storyblok/Storyblok.types';
@@ -22,6 +22,8 @@ type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
   ctaLabel?: string;
   href?: string;
   link?: SbLinkType;
+  animation?: AnimationType;
+  delay?: number;
 };
 
 export const VerticalCard = ({
@@ -37,10 +39,12 @@ export const VerticalCard = ({
   ctaLabel,
   link,
   href,
+  animation,
+  delay,
   className,
   ...props
 }: VerticalCardProps) => (
-  <AnimateInView>
+  <AnimateInView animation={animation} delay={delay}>
     <article
       className={dcnb('su-group su-relative su-z-10', styles.textColors[textColor], className)}
       {...props}

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -19,6 +19,7 @@ type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
   alt?: string;
   textColor?: TextColorType;
   tabColor?: datasource.AccentBgColorType;
+  ctaLabel?: string;
   href?: string;
   link?: SbLinkType;
 };
@@ -33,6 +34,7 @@ export const VerticalCard = ({
   alt = '',
   textColor = 'black',
   tabColor,
+  ctaLabel,
   link,
   href,
   className,
@@ -59,7 +61,12 @@ export const VerticalCard = ({
           leading="tight"
           className="su-rs-mt-1 su-rs-mb-neg1"
         >
-          {heading}
+          {(!ctaLabel && (link || href))
+            ? (
+              <CtaLink sbLink={link} href={href} color={textColor} className="su-stretched-link su-no-underline !su-font-bold">
+                {heading}
+              </CtaLink>
+            ) : heading}
         </Heading>
       )}
       {tabColor && (
@@ -68,7 +75,7 @@ export const VerticalCard = ({
       {body && (
         <Paragraph variant="big" leading="snug">{body}</Paragraph>
       )}
-      {(href || link) && (
+      {ctaLabel && (link || href) && (
         <CtaLink
           color={textColor}
           icon="triangle-right"
@@ -78,7 +85,7 @@ export const VerticalCard = ({
           uppercase
           className="su-stretched-link"
         >
-          Learn How
+          {ctaLabel}
         </CtaLink>
       )}
     </article>

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -1,6 +1,6 @@
-import React, { HTMLAttributes, useRef } from 'react';
-import { useInView } from 'framer-motion';
+import React, { HTMLAttributes } from 'react';
 import { dcnb } from 'cnbuilder';
+import { AnimateInView } from '../Animate';
 import { CtaLink } from '../Cta/CtaLink';
 import { Heading, HeadingType, Paragraph } from '../Typography';
 import { SbLinkType } from '../Storyblok/Storyblok.types';
@@ -37,18 +37,9 @@ export const VerticalCard = ({
   href,
   className,
   ...props
-}: VerticalCardProps) => {
-  const ref = useRef(null);
-  const isInView = useInView(ref, { once: false });
-
-  return (
+}: VerticalCardProps) => (
+  <AnimateInView>
     <article
-      style={{
-        transform: isInView ? 'none' : 'scale(0.8)',
-        opacity: isInView ? 1 : 0.6,
-        transition: 'all 1s cubic-bezier(0.17, 0.55, 0.55, 1) 0.2s',
-      }}
-      ref={ref}
       className={dcnb('su-group su-relative su-z-10', styles.textColors[textColor], className)}
       {...props}
     >
@@ -91,5 +82,5 @@ export const VerticalCard = ({
         </CtaLink>
       )}
     </article>
-  );
-};
+  </AnimateInView>
+);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add AnimateInView wrapper component - can take input from Storyblok and let user pick animation type and delay (more later)
- Restructure the homepage hero so it's more flexible, plus can animate the fade in for the background gradient first
- Vertical cards - render CTA if there's a cta label provided, otherwise add the link inside the heading.

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and the code
2. Note: on Storyblok, I added delays to the cards to stagger the animation effect.

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-78
