### PR TITLE
Nojira | Add missing internal link logic to add / in front of cached URL

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -11,6 +11,5 @@ exports.createPages = async ({ actions }) => {
   actions.createSlice({
     id: 'global-footer',
     component: path.resolve('./src/components/GlobalFooter/GlobalFooter.tsx'),
-    context: {},
   });
 };

--- a/src/components/Cta/CtaLink.tsx
+++ b/src/components/Cta/CtaLink.tsx
@@ -37,7 +37,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
     } = sbLink || {};
 
     // Check for internal links
-    const isInternal: boolean = /^\/(?!\/)/.test(href) || linktype === 'story';
+    const isInternal: boolean = linktype === 'story' || /^\/(?!\/)/.test(href);
 
     // Open internal links in new tab because passing target="_blank" to GatsbyLink doesn't work at the moment
     const openGatsbyLinkInNewTab = (e) => {
@@ -51,6 +51,10 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
 
     if (isInternal) {
       myLink = cachedUrl || href;
+
+      if (!myLink.startsWith('/')) {
+        myLink = myLink === 'home' ? '/' : `/${myLink}`;
+      }
 
       if (anchor) {
         myLink = `${myLink}#${anchor}`;
@@ -79,7 +83,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
         {...rest}
         {...sbLinkProps}
         ref={ref}
-        href={myLinkWithUtm}
+        href={myLink}
         target={target || undefined}
       />
     );

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -8,7 +8,7 @@ const StoryblokEntry = ({ data }) => {
   let story = data.storyblokEntry;
   story = useStoryblokState(story);
 
-  const components = story.content.body.map((blok) => (<StoryblokComponent blok={blok} key={blok._uid} />));
+  const components = story.content.body?.map((blok) => (<StoryblokComponent blok={blok} key={blok._uid} />));
 
   return (
     <Layout>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Storyblok link fix - for cachedUrl - need to add "/" in front
- Do not pass utm params to external links

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview and scroll down to the split poster
![Screenshot 2023-04-27 at 3 11 40 PM](https://user-images.githubusercontent.com/42749717/235002500-77724ec1-2e99-4336-af1f-9840816868ea.png)
2. Click on the CTA link button
3. Verify that it scrolls to the page top of the /about-test page
4. On the /about-test page, scroll down to the bottom
5. Click on the red button and verify that it takes you back to home, not /about-test/home

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)
