### PR TITLE
GIVCAMP-104 | Create theme cards; add section superhead

### DIFF
--- a/src/components/Grid/GridAlternating.tsx
+++ b/src/components/Grid/GridAlternating.tsx
@@ -43,7 +43,7 @@ export const GridAlternating = ({
   const containerRef = useRef(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
-    offset: ['-600px', '200px'],
+    offset: ['-600px', '60%'],
   });
   const scaleY = useSpring(scrollYProgress, {
     stiffness: 100,

--- a/src/components/Grid/GridAlternating.tsx
+++ b/src/components/Grid/GridAlternating.tsx
@@ -58,7 +58,7 @@ export const GridAlternating = ({
         {childrenArray?.map((item, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <React.Fragment key={index}>
-            <div className={paddingBottoms[spacing]}>{item}</div>
+            <div className={dcnb(paddingBottoms[spacing], 'last:su-pb-0')}>{item}</div>
             {index !== childrenArray.length - 1 && (
               <>
                 <div />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { SbGridAlternating } from './Storyblok/SbGridAlternating';
 import { SbLogo } from './Storyblok/SbLogo';
 import { SbSection } from './Storyblok/SbSection';
 import { SbSplitPoster } from './Storyblok/SbSplitPoster';
+import { SbThemeCard } from './Storyblok/SbThemeCard';
 import { SbVerticalCard } from './Storyblok/SbVerticalCard';
 import { SbWysiwyg } from './Storyblok/SbWysiwyg';
 
@@ -29,6 +30,7 @@ storyblokInit({
     sbLogo: SbLogo,
     sbSection: SbSection,
     sbSplitPoster: SbSplitPoster,
+    sbThemeCard: SbThemeCard,
     sbVerticalCard: SbVerticalCard,
     sbWysiwyg: SbWysiwyg,
   },
@@ -38,6 +40,8 @@ export const Layout = ({ children }: LayoutProps) => (
   <FlexBox justifyContent="between" direction="col" className="su-min-h-screen su-relative">
     <Masthead />
     <main>{children}</main>
-    <Slice alias="global-footer" />
+    <footer>
+      <Slice alias="global-footer" />
+    </footer>
   </FlexBox>
 );

--- a/src/components/Storyblok/SbGridAlternating.tsx
+++ b/src/components/Storyblok/SbGridAlternating.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storyblokEditable, StoryblokComponent } from 'gatsby-source-storyblok';
-import { GridAlternating } from '../Grid';
+import { GridAlternating, GridWidthType } from '../Grid';
 import { PaddingType } from '../../utilities/datasource';
 
 type SbGridAlternatingProps = {
@@ -9,9 +9,12 @@ type SbGridAlternatingProps = {
     items: any[];
     startOnRight?: boolean;
     addCenterLine?: boolean;
+    width?: GridWidthType;
+    spacing?: PaddingType;
     paddingTop?: PaddingType;
     paddingBottom?: PaddingType;
-  };
+  },
+  isDarkTheme: boolean;
 };
 
 export const SbGridAlternating = ({
@@ -20,9 +23,12 @@ export const SbGridAlternating = ({
     items,
     startOnRight,
     addCenterLine,
+    width,
+    spacing,
     paddingTop,
     paddingBottom,
   },
+  isDarkTheme,
   blok,
 }: SbGridAlternatingProps) => (
   <GridAlternating
@@ -30,9 +36,11 @@ export const SbGridAlternating = ({
     key={_uid}
     startOnRight={startOnRight}
     addCenterLine={addCenterLine}
+    width={width}
+    spacing={spacing}
     pt={paddingTop}
     pb={paddingBottom}
   >
-    {items.map((item) => <StoryblokComponent blok={item} key={item._uid} />)}
+    {items.map((item) => <StoryblokComponent blok={item} key={item._uid} isDarkTheme={isDarkTheme} />)}
   </GridAlternating>
 );

--- a/src/components/Storyblok/SbSection.tsx
+++ b/src/components/Storyblok/SbSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { CreateBloks } from '../CreateBloks';
-import { Heading, HeadingType } from '../Typography';
+import { Heading, HeadingType, Text } from '../Typography';
 import { Container, BgColorType } from '../Container';
 import { PaddingType } from '../../utilities/datasource';
 
@@ -9,6 +9,7 @@ type SbSectionProps = {
   blok: {
     _uid: string;
     content?: any[];
+    superhead?: string;
     heading?: string;
     headingLevel?: HeadingType;
     bgColor?: BgColorType;
@@ -21,6 +22,7 @@ export const SbSection = ({
   blok: {
     _uid,
     content,
+    superhead,
     heading,
     headingLevel,
     bgColor,
@@ -37,8 +39,13 @@ export const SbSection = ({
     pb={paddingBottom}
     className="su-relative"
   >
+    {superhead && (
+      <Text size={2} leading="tight" font="serif">
+        {superhead}
+      </Text>
+    )}
     {heading && (
-      <Heading as={headingLevel} size={9} leading="none" uppercase font="druk">
+      <Heading as={headingLevel} size={9} leading="none" uppercase font="druk" className="su-max-w-1000">
         {heading}
       </Heading>
     )}

--- a/src/components/Storyblok/SbThemeCard.tsx
+++ b/src/components/Storyblok/SbThemeCard.tsx
@@ -13,7 +13,6 @@ export const SbThemeCard = ({
     body,
     // TODO: seperate alt as separate field
     image: { filename, focus, alt } = {},
-    textColor,
     tabColor,
     ctaLabel,
     link,
@@ -21,6 +20,7 @@ export const SbThemeCard = ({
     delay,
   },
   blok,
+  isDarkTheme,
 }: SbThemeCardProps) => (
   <ThemeCard
     {...storyblokEditable(blok)}
@@ -31,7 +31,7 @@ export const SbThemeCard = ({
     imageSrc={filename}
     imageFocus={focus}
     alt={alt}
-    textColor={textColor}
+    textColor={isDarkTheme ? 'white' : 'black'}
     tabColor={tabColor}
     ctaLabel={ctaLabel}
     link={link}

--- a/src/components/Storyblok/SbThemeCard.tsx
+++ b/src/components/Storyblok/SbThemeCard.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
-import { AnimationType } from '../Animate';
-import { HeadingType } from '../Typography';
 import { ThemeCard } from '../VerticalCard';
 import { SbVerticalCardProps } from './SbVerticalCard';
 

--- a/src/components/Storyblok/SbThemeCard.tsx
+++ b/src/components/Storyblok/SbThemeCard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { storyblokEditable } from 'gatsby-source-storyblok';
+import { AnimationType } from '../Animate';
+import { HeadingType } from '../Typography';
+import { ThemeCard } from '../VerticalCard';
+import { SbVerticalCardProps } from './SbVerticalCard';
+
+type SbThemeCardProps = Omit<SbVerticalCardProps, 'isSmallHeading'>;
+
+export const SbThemeCard = ({
+  blok: {
+    _uid,
+    heading,
+    headingLevel,
+    body,
+    // TODO: seperate alt as separate field
+    image: { filename, focus, alt } = {},
+    textColor,
+    tabColor,
+    ctaLabel,
+    link,
+    animation,
+    delay,
+  },
+  blok,
+}: SbThemeCardProps) => (
+  <ThemeCard
+    {...storyblokEditable(blok)}
+    key={_uid}
+    heading={heading}
+    headingLevel={headingLevel}
+    body={body}
+    imageSrc={filename}
+    imageFocus={focus}
+    alt={alt}
+    textColor={textColor}
+    tabColor={tabColor}
+    ctaLabel={ctaLabel}
+    link={link}
+    animation={animation}
+    delay={delay}
+  />
+);

--- a/src/components/Storyblok/SbVerticalCard.tsx
+++ b/src/components/Storyblok/SbVerticalCard.tsx
@@ -6,7 +6,7 @@ import { VerticalCard, TextColorType } from '../VerticalCard';
 import { SbImageType, SbLinkType } from './Storyblok.types';
 import { AccentBgColorType } from '../../utilities/datasource';
 
-type SbVerticalCardProps = {
+export type SbVerticalCardProps = {
   blok: {
     _uid: string;
     heading?: string;

--- a/src/components/Storyblok/SbVerticalCard.tsx
+++ b/src/components/Storyblok/SbVerticalCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { AnimationType } from '../Animate';
 import { HeadingType } from '../Typography';
-import { VerticalCard, TextColorType } from '../VerticalCard';
+import { VerticalCard } from '../VerticalCard';
 import { SbImageType, SbLinkType } from './Storyblok.types';
 import { AccentBgColorType } from '../../utilities/datasource';
 
@@ -14,13 +14,13 @@ export type SbVerticalCardProps = {
     isSmallHeading?: boolean;
     body?: string;
     image?: SbImageType;
-    textColor?: TextColorType;
     tabColor?: AccentBgColorType;
     ctaLabel?: string;
     link?: SbLinkType;
     animation?: AnimationType;
     delay?: number;
   };
+  isDarkTheme?: boolean;
 };
 
 export const SbVerticalCard = ({
@@ -32,7 +32,6 @@ export const SbVerticalCard = ({
     body,
     // TODO: seperate alt as separate field
     image: { filename, focus, alt } = {},
-    textColor,
     tabColor,
     ctaLabel,
     link,
@@ -40,6 +39,7 @@ export const SbVerticalCard = ({
     delay,
   },
   blok,
+  isDarkTheme,
 }: SbVerticalCardProps) => (
   <VerticalCard
     {...storyblokEditable(blok)}
@@ -51,7 +51,7 @@ export const SbVerticalCard = ({
     imageSrc={filename}
     imageFocus={focus}
     alt={alt}
-    textColor={textColor}
+    textColor={isDarkTheme ? 'white' : 'black'}
     tabColor={tabColor}
     ctaLabel={ctaLabel}
     link={link}

--- a/src/components/Storyblok/SbWysiwyg.tsx
+++ b/src/components/Storyblok/SbWysiwyg.tsx
@@ -16,7 +16,8 @@ type SbWysiwygProps = {
     width?: WidthType;
     spacingTop?: PaddingType;
     spacingBottom?: PaddingType;
-  };
+  },
+  isDarkTheme?: boolean;
 };
 
 export const SbWysiwyg = ({
@@ -30,6 +31,7 @@ export const SbWysiwyg = ({
     spacingBottom,
   },
   blok,
+  isDarkTheme,
 }: SbWysiwygProps) => (
   <WidthBox
     {...storyblokEditable(blok)}
@@ -38,6 +40,6 @@ export const SbWysiwyg = ({
     pt={spacingTop}
     pb={spacingBottom}
   >
-    <RichText wysiwyg={content} isLightText={isLightText} textAlign={textAlign} />
+    <RichText wysiwyg={content} isLightText={isDarkTheme || isLightText} textAlign={textAlign} />
   </WidthBox>
 );

--- a/src/components/VerticalCard/ThemeCard.tsx
+++ b/src/components/VerticalCard/ThemeCard.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { VerticalCard, VerticalCardProps } from './VerticalCard';
+
+type ThemeCardProps = Omit<VerticalCardProps, 'headingFont' | 'isSmallHeading'>;
+
+export const ThemeCard = (props: ThemeCardProps) => (
+  <VerticalCard {...props} headingFont="druk" />
+);

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -1,7 +1,19 @@
+export const root = 'su-group su-relative su-z-10 su-max-w-500 su-mx-auto';
+
+export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none group-hover:su-rounded-tl-[10rem] group-hover:su-rounded-br-[10rem] group-focus-within:su-rounded-tl-[10rem] group-focus-within:su-rounded-br-[10rem] su-overflow-hidden';
+
+export const image = 'su-object-cover su-w-full su-h-full';
+
+export const heading = 'su-rs-mt-1 su-rs-mb-neg1';
+
+export const headingLink = 'su-stretched-link su-no-underline !su-font-bold';
+
 export const textColors = {
   white: 'su-text-white',
   black: 'su-text-black',
 };
 export type TextColorType = keyof typeof textColors;
 
-export const tab = 'su-h-[2.4rem] su-w-70 su-rs-mb-0';
+export const tab = 'su-h-[2.4rem] su-w-70 su-rs-my-0';
+
+export const ctaLink = 'su-inline-block su-w-fit su-stretched-link su-rs-mt-1';

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -48,15 +48,15 @@ export const VerticalCard = ({
 }: VerticalCardProps) => (
   <AnimateInView animation={animation} delay={delay}>
     <article
-      className={dcnb('su-group su-relative su-z-10', styles.textColors[textColor], className)}
+      className={dcnb(styles.root, styles.textColors[textColor], className)}
       {...props}
     >
       {imageSrc && (
-        <div className="su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none group-hover:su-rounded-tl-[10rem] group-hover:su-rounded-br-[10rem] group-focus-within:su-rounded-tl-[10rem] group-focus-within:su-rounded-br-[10rem] su-overflow-hidden">
+        <div className={styles.imageWrapper}>
           <img
             src={getProcessedImage(imageSrc, '600x600', imageFocus)}
             alt={alt}
-            className="su-object-cover su-w-full su-h-full"
+            className={styles.image}
           />
         </div>
       )}
@@ -66,11 +66,11 @@ export const VerticalCard = ({
           font={headingFont}
           size={isSmallHeading ? 3 : 4}
           leading="tight"
-          className="su-rs-mt-1 su-rs-mb-neg1"
+          className={styles.heading}
         >
           {(!ctaLabel && (link || href))
             ? (
-              <CtaLink sbLink={link} href={href} color={textColor} className="su-stretched-link su-no-underline !su-font-bold">
+              <CtaLink sbLink={link} href={href} color={textColor} className={styles.headingLink}>
                 {heading}
               </CtaLink>
             ) : heading}
@@ -80,7 +80,7 @@ export const VerticalCard = ({
         <div className={dcnb(styles.tab, accentBgColors[tabColor])} />
       )}
       {body && (
-        <Paragraph variant="big" leading="snug" noMargin>{body}</Paragraph>
+        <Paragraph variant="card" noMargin>{body}</Paragraph>
       )}
       {ctaLabel && (link || href) && (
         <CtaLink
@@ -90,7 +90,7 @@ export const VerticalCard = ({
           sbLink={link}
           href={href}
           uppercase
-          className="su-inline-block su-w-fit su-stretched-link su-rs-mt-1"
+          className={styles.ctaLink}
         >
           {ctaLabel}
         </CtaLink>

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -9,7 +9,7 @@ import { getProcessedImage } from '../../utilities/getProcessedImage';
 import * as styles from './VerticalCard.styles';
 import { accentBgColors, AccentBgColorType } from '../../utilities/datasource';
 
-type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
+export type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;
   headingLevel?: HeadingType;
   headingFont?: 'serif' | 'druk';

--- a/src/components/VerticalCard/index.ts
+++ b/src/components/VerticalCard/index.ts
@@ -1,2 +1,3 @@
+export * from './ThemeCard';
 export * from './VerticalCard';
 export * from './VerticalCard.styles';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Create Theme Cards out of Vertical Cards
- Styles clean up
- Add auto select text color based on parent section background color
- Add superhead field for Storyblok Sections

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and scroll down to see the theme cards
2. Look at code and things called out

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-104
