### PR TITLE
Nojira | Fix visual artifacts with brackets due to CSS transform

### DIFF
--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -3,13 +3,7 @@ import { dcnb } from 'cnbuilder';
 // Bracket Curve styles
 export const root = 'su-border-current';
 
-export const corners = {
-  tl: '',
-  bl: 'su-scale-y-[-1]',
-  tr: 'su-scale-x-[-1]',
-  br: 'su-rotate-180',
-};
-export type CornerType = keyof typeof corners;
+export type CornerType = 'tl' | 'bl' | 'tr' | 'br';
 
 export const colors = {
   white: 'su-text-white',
@@ -17,19 +11,34 @@ export const colors = {
 };
 export type ColorType = keyof typeof colors;
 
-export const curve = (isSolid: boolean) => dcnb(
+export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
   'su-w-[83%] su-h-[8em] su-border-t-2 su-border-l-2 su-rounded-tl-full',
-  isSolid ? 'su-bg-current' : '',
+  {
+    'su-bg-current': isSolid,
+    'su-rounded-tl-full': corner === 'tl',
+    'su-rounded-bl-full': corner === 'bl',
+    'su-rounded-tr-full': corner === 'tr',
+    'su-rounded-br-full': corner === 'br',
+    'su-border-t-2': corner === 'tl' || corner === 'tr',
+    'su-border-l-2': corner === 'tl' || corner === 'bl',
+    'su-border-b-2': corner === 'bl' || corner === 'br',
+    'su-border-r-2 su-order-2': corner === 'tr' || corner === 'br',
+  },
 );
-export const rectangle = (isSolid: boolean) => dcnb(
-  'su-w-[17%] su-h-[8em] su-border-r-2 su-border-y-2',
-  isSolid ? 'su-bg-current' : '',
+export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
+  'su-w-[17%] su-h-[8em] su-border-y-2',
+  {
+    'su-bg-current': isSolid,
+    'su-border-r-2': corner === 'tl' || corner === 'bl',
+    'su-border-l-2 su-order-1': corner === 'tr' || corner === 'br',
+  },
 );
 
 // Bracket styles
-export const directions = (isClose: boolean) => (isClose ? 'su-rotate-180' : '');
-
-export const middle = (isSolid: boolean) => dcnb(
-  'su-grow su-border-l-2 su-border-r-2 su-border-current su-w-[calc(83%_+_0.2rem)]',
-  isSolid ? 'su-bg-current' : '',
+export const middle = (isClose: boolean, isSolid: boolean) => dcnb(
+  'su-grow su-border-x-2 su-border-current su-w-[calc(83%_+_0.2rem)]',
+  {
+    'su-self-end': isClose,
+    'su-bg-current': isSolid,
+  },
 );

--- a/src/components/Bracket/Bracket.tsx
+++ b/src/components/Bracket/Bracket.tsx
@@ -20,13 +20,12 @@ export const Bracket = ({
     direction="col"
     className={dcnb(
       styles.colors[color],
-      styles.directions(isClose),
       className,
     )}
     {...props}
   >
-    <BracketCurve isSolid={isSolid} color={color} />
-    <div className={styles.middle(isSolid)} />
-    <BracketCurve isSolid={isSolid} color={color} corner="bl" />
+    <BracketCurve isSolid={isSolid} color={color} corner={isClose ? 'tr' : 'tl'} />
+    <div className={styles.middle(isClose, isSolid)} />
+    <BracketCurve isSolid={isSolid} color={color} corner={isClose ? 'br' : 'bl'} />
   </FlexBox>
 );

--- a/src/components/Bracket/BracketCurve.tsx
+++ b/src/components/Bracket/BracketCurve.tsx
@@ -20,12 +20,11 @@ export const BracketCurve = ({
     className={dcnb(
       styles.root,
       styles.colors[color],
-      styles.corners[corner],
       className,
     )}
     {...props}
   >
-    <div className={styles.curve(isSolid)} />
-    <div className={styles.rectangle(isSolid)} />
+    <div className={styles.curve(corner, isSolid)} />
+    <div className={styles.rectangle(corner, isSolid)} />
   </FlexBox>
 );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- I previously create the top left corner of the bracket, then use CSS transform to get the other 3 corners of the bracket curved and then the "close" version (flipping the "open" one) of the bracket, but found that it introduces visual imperfections.
- Fix it by not using transform

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to preview and scroll to bracket cards, look at the ones with the close bracket particularly, resize the cards (LG and up) and make sure that the bracket corners look good

Before (bad)
![Screenshot 2023-05-04 at 5 21 11 PM](https://user-images.githubusercontent.com/42749717/236356174-259c3e66-53d9-4108-9aba-633b346382d7.png)

![Screenshot 2023-05-03 at 1 30 43 PM](https://user-images.githubusercontent.com/42749717/236355946-d156be20-3644-49c4-ad9e-849e1b6bd6d4.png)

After (should be smooth)

![Screenshot 2023-05-04 at 5 06 52 PM](https://user-images.githubusercontent.com/42749717/236355955-75ba5ae2-37a9-4c80-b8bf-08595ee96d77.png)
![Screenshot 2023-05-04 at 5 07 01 PM](https://user-images.githubusercontent.com/42749717/236355964-73cc440c-5046-4f2d-9538-f11e8436f3de.png)
![Screenshot 2023-05-04 at 5 06 56 PM](https://user-images.githubusercontent.com/42749717/236355976-02018553-cb9e-4143-b135-ea80c9bfba9f.png)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-108