### PR TITLE
Nojira | Set up SB components to use new Storyblok custom palette picker

### DIFF
--- a/src/components/Storyblok/SbBracketCard.tsx
+++ b/src/components/Storyblok/SbBracketCard.tsx
@@ -4,6 +4,7 @@ import { HeadingType } from '../Typography';
 import { BracketCard } from '../BracketCard';
 import { SbImageType, SbLinkType } from './Storyblok.types';
 import { AccentBgColorType, MarginType } from '../../utilities/datasource';
+import { paletteAccentColors, PaletteAccentColorType } from '../../utilities/colorPalettePlugin';
 
 export type SbBracketCardProps = {
   blok: {
@@ -14,7 +15,9 @@ export type SbBracketCardProps = {
     textOnLeft?: boolean;
     body?: string;
     image?: SbImageType;
-    tabColor?: AccentBgColorType;
+    tabColor?: {
+      value?: PaletteAccentColorType;
+    }
     ctaLabel?: string;
     link?: SbLinkType;
     spacingBottom?: MarginType;
@@ -32,7 +35,7 @@ export const SbBracketCard = ({
     body,
     // TODO: seperate alt as separate field
     image: { filename, focus, alt } = {},
-    tabColor,
+    tabColor: { value } = {},
     ctaLabel,
     link,
     spacingBottom,
@@ -52,7 +55,7 @@ export const SbBracketCard = ({
     imageFocus={focus}
     alt={alt}
     textColor={isDarkTheme ? 'white' : 'black'}
-    tabColor={tabColor}
+    tabColor={paletteAccentColors[value] as AccentBgColorType}
     ctaLabel={ctaLabel}
     link={link}
     spacingBottom={spacingBottom}

--- a/src/components/Storyblok/SbThemeCard.tsx
+++ b/src/components/Storyblok/SbThemeCard.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { ThemeCard } from '../VerticalCard';
 import { SbVerticalCardProps } from './SbVerticalCard';
+import { AccentBgColorType } from '../../utilities/datasource';
+import { paletteAccentColors } from '../../utilities/colorPalettePlugin';
 
 type SbThemeCardProps = Omit<SbVerticalCardProps, 'isSmallHeading'>;
 
@@ -13,7 +15,7 @@ export const SbThemeCard = ({
     body,
     // TODO: seperate alt as separate field
     image: { filename, focus, alt } = {},
-    tabColor,
+    tabColor: { value } = {},
     ctaLabel,
     link,
     animation,
@@ -32,7 +34,7 @@ export const SbThemeCard = ({
     imageFocus={focus}
     alt={alt}
     textColor={isDarkTheme ? 'white' : 'black'}
-    tabColor={tabColor}
+    tabColor={paletteAccentColors[value] as AccentBgColorType}
     ctaLabel={ctaLabel}
     link={link}
     animation={animation}

--- a/src/components/Storyblok/SbVerticalCard.tsx
+++ b/src/components/Storyblok/SbVerticalCard.tsx
@@ -5,6 +5,7 @@ import { HeadingType } from '../Typography';
 import { VerticalCard } from '../VerticalCard';
 import { SbImageType, SbLinkType } from './Storyblok.types';
 import { AccentBgColorType } from '../../utilities/datasource';
+import { paletteAccentColors, PaletteAccentColorType } from '../../utilities/colorPalettePlugin';
 
 export type SbVerticalCardProps = {
   blok: {
@@ -14,7 +15,9 @@ export type SbVerticalCardProps = {
     isSmallHeading?: boolean;
     body?: string;
     image?: SbImageType;
-    tabColor?: AccentBgColorType;
+    tabColor?: {
+      value?: PaletteAccentColorType;
+    }
     ctaLabel?: string;
     link?: SbLinkType;
     animation?: AnimationType;
@@ -32,7 +35,7 @@ export const SbVerticalCard = ({
     body,
     // TODO: seperate alt as separate field
     image: { filename, focus, alt } = {},
-    tabColor,
+    tabColor: { value } = {},
     ctaLabel,
     link,
     animation,
@@ -52,7 +55,7 @@ export const SbVerticalCard = ({
     imageFocus={focus}
     alt={alt}
     textColor={isDarkTheme ? 'white' : 'black'}
-    tabColor={tabColor}
+    tabColor={paletteAccentColors[value] as AccentBgColorType}
     ctaLabel={ctaLabel}
     link={link}
     animation={animation}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -381,7 +381,7 @@ const IndexPage = ({ data }) => {
             href="/about-test"
             variant="ghostLeaf"
             icon="triangle-right"
-            className="!su-rs-px-5 !su-rs-py-2 su-text-20 md:su-text-[4.6rem] !su-font-bold !su-text-white !su-bg-black-true/40 hocus:su-rounded-tl-none hocus:su-rounded-br-none hocus:!su-bg-sapphire/80"
+            className="!su-rs-px-5 !su-rs-py-2 !su-text-20 md:!su-text-[4.6rem] !su-font-bold !su-text-white !su-bg-black-true/40 hocus:su-rounded-tl-none hocus:su-rounded-br-none hocus:!su-bg-sapphire/80"
           >
             See our new initiative
           </CtaLink>

--- a/src/utilities/colorPalettePlugin.ts
+++ b/src/utilities/colorPalettePlugin.ts
@@ -1,0 +1,18 @@
+/**
+ * Maps of color utilities for the Storyblok palette plugin
+ */
+export const paletteAccentColors = {
+  '#ECC7CD': 'flamingo',
+  '#DAD7CB': 'fog',
+  '#E31C79': 'fuchsia',
+  '#C5B4E3': 'lavender',
+  '#DBE442': 'lime',
+  '#175E54': 'palo-alto',
+  '#485CC7': 'periwinkle',
+  '#E98300': 'poppy',
+  '#77C5D5': 'robins-egg',
+  '#005776': 'sapphire',
+  '#4E4B48': 'slate',
+  '#E04F39': 'spirited',
+};
+export type PaletteAccentColorType = keyof typeof paletteAccentColors;


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Support for new Storyblok plugin custom color picker for bracket card, vertical card, theme card tab colors

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and see that all the card tab colors are still there. The tab color field has been replaced with the new Storyblok palette plugin instead of datasource on the backend.
![Screenshot 2023-05-05 at 3 22 55 PM](https://user-images.githubusercontent.com/42749717/236578369-400be187-d658-495d-826e-a92c1c57681e.png)
