### PR TITLE
GIVCAMP-111 | Text and link color updates

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -21,11 +21,12 @@ export const onRenderBody: GatsbySSR['onRenderBody'] = ({
       crossOrigin="anonymous"
       key="drukwide-bold-woff2"
     />,
-    <link rel="preconnect" href="https://fonts.googleapis.com" />,
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />,
+    <link rel="preconnect" href="https://fonts.googleapis.com" key="google-apis" />,
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" key="gstatic" />,
     <link
       href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap"
       rel="stylesheet"
+      key="google-fonts"
     />,
   ]);
 };

--- a/src/components/Container/Container.styles.ts
+++ b/src/components/Container/Container.styles.ts
@@ -6,5 +6,5 @@ export const widths = {
 
 export const bgColors = {
   black: 'su-bg-saa-black su-text-white',
-  white: 'su-bg-white su-text-black',
+  white: 'su-bg-white su-text-saa-black',
 };

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -19,12 +19,12 @@ export const ctaVariants = {
   footer: 'su-inline-block su-font-normal su-leading-display su-underline-offset-[3px] su-text-black-20 hocus:su-text-black-20 su-decoration-digital-red-xlight hocus:su-decoration-digital-red-xlight',
   close: 'su-inline-block su-font-semibold su-leading-none su-text-lagunita hocus:su-text-lagunita-dark focus:su-outline-none',
   'close-x': 'su-leading-none',
-  dismiss: 'su-inline-block su-font-bold su-uppercase su-tracking-widest su-leading-none su-text-black hocus:su-text-black focus:su-outline-none',
+  dismiss: 'su-inline-block su-font-bold su-uppercase su-tracking-widest su-leading-none su-text-saa-black hocus:su-text-saa-black focus:su-outline-none',
   unset: '',
 };
 
 export const ctaColors = {
-  black: 'su-text-black',
+  black: 'su-text-saa-black',
   white: 'su-text-white',
   // TODO: These are for ghost buttons and link variants. Will remove if we don't need.
   'digital-red': 'su-text-digital-red',
@@ -70,7 +70,7 @@ export const iconStyles = {
   close: 'su-text-lagunita-light group-hocus:su-text-lagunita-dark !su-w-[2.2rem] su--mt-4',
   'close-x': 'su-text-current hocus:su-text-current su-w-[2.2rem] group-hocus:su-underline',
   chip: 'su--mt-3',
-  dismiss: 'su-text-black !su-w-[2.2rem] su--mt-4',
+  dismiss: 'su-text-saa-black !su-w-[2.2rem] su--mt-4',
 };
 
 export const ctaIconMap = {

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -1,7 +1,8 @@
 import { dcnb } from 'cnbuilder';
 
 export type LogoVariantType = 'horizontal' | 'stacked';
-export type LogoColorType = 'black' | 'white' | 'off-white' | 'soft-black';
+
+export type LogoColorType = 'black' | 'white';
 
 export const link = 'su-no-underline focus-visible:su-outline-none focus-visible:su-ring-2 focus-visible:su-ring-spirited';
 

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -26,7 +26,7 @@ export const RichText = ({
   textAlign,
   className,
 }: RichTextProps) => {
-  const textColor = isLightText ? 'su-text-white print:su-text-black' : 'su-text-black';
+  const textColor = isLightText ? 'su-text-white print:su-text-saa-black' : 'su-text-saa-black';
 
   const rendered = render(wysiwyg, {
     markResolvers: {

--- a/src/components/StanfordLogo/StanfordLogo.styles.ts
+++ b/src/components/StanfordLogo/StanfordLogo.styles.ts
@@ -1,9 +1,7 @@
 export const logoColors = {
   'cardinal-red': 'su-text-cardinal-red hocus:su-text-cardinal-red',
   'digital-red': 'su-text-digital-red hocus:su-text-digital-red',
-  black: 'su-text-black hocus:su-text-black',
+  black: 'su-text-saa-black hocus:su-text-saa-black',
   white: 'su-text-white hocus:su-text-white',
-  'off-white': 'su-text-black-10 hocus:su-text-black-10',
-  'soft-black': 'su-text-black-90 hocus:su-text-black-90',
 };
 export type LogoColorType = keyof typeof logoColors;

--- a/src/components/Typography/typography.styles.ts
+++ b/src/components/Typography/typography.styles.ts
@@ -53,11 +53,9 @@ export const textAligns = {
 
 export const textColors = {
   default: '', // Interit from the base
-  black: 'su-text-black',
+  black: 'su-text-saa-black',
   'cool-grey': 'su-text-cool-grey',
   white: 'su-text-white',
-  'off-white': 'su-text-black-10',
-  'soft-black': 'su-text-black-90',
 };
 
 export const textVariants = {

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -10,7 +10,7 @@ export const headingLink = 'su-stretched-link su-no-underline !su-font-bold';
 
 export const textColors = {
   white: 'su-text-white',
-  black: 'su-text-black',
+  black: 'su-text-saa-black',
 };
 export type TextColorType = keyof typeof textColors;
 

--- a/src/tailwind/plugins/base/gc-base.js
+++ b/src/tailwind/plugins/base/gc-base.js
@@ -23,11 +23,11 @@ module.exports = function () {
         },
       },
       a: {
-        color: config('theme.colors.digital-red.light'),
+        color: config('theme.colors.digital-red.DEFAULT'),
         transition: 'color 0.25s ease-in-out',
 
         '&:hover, &:focus': {
-          color: config('theme.colors.cardinal-red.DEFAULT'),
+          color: config('theme.colors.digital-red.dark'),
         },
       },
     });

--- a/src/utilities/datasource.ts
+++ b/src/utilities/datasource.ts
@@ -33,8 +33,8 @@ export type AccentBorderColorType = keyof typeof accentBorderColors;
 export const bgTextColorPairs = {
   black: 'su-bg-saa-black su-text-white',
   'black-70': 'su-bg-black-true/70 su-text-white',
-  white: 'su-bg-white su-text-black',
-  'white-80': 'su-bg-white/80 su-text-black',
+  white: 'su-bg-white su-text-saa-black',
+  'white-80': 'su-bg-white/80 su-text-saa-black',
 };
 export type BgTextColorPairType = keyof typeof bgTextColorPairs;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Inline links should be digital red (regular) and digital red dark on hocus (can see in WYSIWYG)
- Use SAA Black for text color instead of decanter black everywhere that it's used

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview
https://deploy-preview-58--giving-campaign.netlify.app/
https://deploy-preview-58--giving-campaign.netlify.app/about-test/ (WYSIWYG on this page - light and dark mode)
3. Check that everywhere you see black text (section heading, card heading, body, WYSIWYG etc, it uses the SAA black color (#181D1C)
4. See that the light mode WYSIWYG, and that the link color is digital red, hocus to digital red dark.

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-111