### PR TITLE
GIVCAMP-112 | Triangle icon update; minor CTA update

### DIFF
--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -89,7 +89,7 @@ export const iconAnimation = {
 };
 
 // Leading icons have right margins
-// Only add to this map if right margin is different from default class su-mr-02em
+// Only add to this map if right margin is different from default class su-mr-03em
 export const iconRightMargin = {
   default: 'su-mr-03em',
   'arrow-left': 'su-mr-04em',
@@ -97,7 +97,7 @@ export const iconRightMargin = {
 };
 
 // Trailing icons have left margins
-// Only add to this map if left margin is different from default class su-ml-02em
+// Only add to this map if left margin is different from default class su-ml-03em
 export const iconLeftMargin = {
   default: 'su-ml-03em',
   'arrow-right': 'su-ml-04em',

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -32,7 +32,7 @@ export const ctaColors = {
 };
 
 export const ctaSizes = {
-  default: 'su-px-20 su-pt-9 su-pb-10 lg:su-px-30 xl:su-px-40 lg:su-pt-13 lg:su-pb-14 su-text-16 md:su-text-18 xl:su-text-21',
+  default: 'su-pt-9 su-pb-10 su-pl-[2.4rem] su-pr-19 lg:su-pt-12 lg:su-pb-13 su-text-16 md:su-text-18 xl:su-text-20',
   small: 'su-px-13 su-pt-8 su-pb-9 lg:su-px-15 lg:su-pt-10 lg:su-pb-11 su-text-16',
   masthead: 'su-text-14 md:su-text-16',
   footer: '',
@@ -91,18 +91,18 @@ export const iconAnimation = {
 // Leading icons have right margins
 // Only add to this map if right margin is different from default class su-mr-02em
 export const iconRightMargin = {
-  default: 'su-mr-02em',
-  'arrow-left': 'su-mr-03em',
-  back: 'su-mr-03em',
-  camera: 'su-mr-03em',
-  'user-circle': 'su-mr-04em',
+  default: 'su-mr-03em',
+  'arrow-left': 'su-mr-04em',
+  back: 'su-mr-04em',
 };
 
 // Trailing icons have left margins
 // Only add to this map if left margin is different from default class su-ml-02em
 export const iconLeftMargin = {
-  default: 'su-ml-02em',
-  'arrow-right': 'su-ml-03em',
-  back: 'su-ml-03em',
-  'back-external': 'su-ml-03em',
+  default: 'su-ml-03em',
+  'arrow-right': 'su-ml-04em',
+  back: 'su-ml-04em',
+  'triangle-right': 'su-ml-04em',
+  'triangle-down': 'su-ml-04em',
+  'triangle-up': 'su-ml-04em',
 };

--- a/src/components/HeroIcon/HeroIcon.styles.tsx
+++ b/src/components/HeroIcon/HeroIcon.styles.tsx
@@ -11,7 +11,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 
-import { PlayCircleIcon, PauseCircleIcon } from '@heroicons/react/24/solid';
+import { PlayCircleIcon, PauseCircleIcon, PlayIcon } from '@heroicons/react/24/solid';
 
 export const iconMap = {
   action: ChevronRightIcon,
@@ -20,9 +20,10 @@ export const iconMap = {
   'arrow-up': ArrowUpIcon,
   back: ArrowLeftIcon,
   'chevron-down': ChevronDownIcon,
-  'triangle-down': ChevronDownIcon,
+  'triangle-down': PlayIcon,
   'chevron-right': ChevronRightIcon,
-  'triangle-right': ChevronRightIcon,
+  'triangle-right': PlayIcon,
+  'triangle-up': PlayIcon,
   close: XMarkIcon,
   email: EnvelopeIcon,
   external: ArrowUpRightIcon,
@@ -37,8 +38,6 @@ export const iconMap = {
 };
 export type IconType = keyof typeof iconMap;
 
-export const triangleFill = 'su-fill-current su-stroke-0';
-
 /**
  * Normalized base size and position of each icon (finetuned manually) for use in eg, buttons
  * Only add to this map if different from default class su-w-1em
@@ -52,8 +51,9 @@ export const iconBaseStyle = {
   back: 'su-w-1em',
   'chevron-right': 'su-w-1em',
   'chevron-down': 'su-w-1em',
-  'triangle-right': 'su-w-[1.1em] su-scale-x-[1.4]',
-  'triangle-down': 'su-w-[1.2em] su-scale-y-[1.4]',
+  'triangle-right': 'su-w-09em su-scale-x-[0.9] su-mt-01em',
+  'triangle-down': 'su-w-09em su-scale-x-[0.9] su-rotate-90 su-mt-01em',
+  'triangle-up': 'su-w-09em su-scale-x-[0.9] su--rotate-90 su-mt-02em',
   email: 'su-w-[1.2em]',
   external: 'su-w-08em',
   left: 'su-w-08em',

--- a/src/components/HeroIcon/HeroIcon.tsx
+++ b/src/components/HeroIcon/HeroIcon.tsx
@@ -22,8 +22,7 @@ export const HeroIcon = ({
   // Set default base style so icon has reasonable size if used out of the box
   // noBaseStyle boolean allows for user to not attach any base styles if needed
   const baseStyle = noBaseStyle ? '' : styles.iconBaseStyle[icon] || styles.iconBaseStyle.default;
-  const triangleStyle = icon.includes('triangle') ? styles.triangleFill : '';
-  const heroIconStyle = dcnb('su-transition', baseStyle, triangleStyle);
+  const heroIconStyle = dcnb('su-transition su-will-change-transform', baseStyle);
 
   return (
     <Icon

--- a/src/components/Temporary/DemoContent.tsx
+++ b/src/components/Temporary/DemoContent.tsx
@@ -242,7 +242,8 @@ export const DemoContent = () => (
           href="/about-test"
           variant="ghostSwipe"
           color="black"
-          icon="triangle-right"
+          icon="triangle-up"
+          animate="up"
           className="after:!su-bg-robins-egg"
         >
           Swipe right
@@ -251,7 +252,8 @@ export const DemoContent = () => (
           href="/about-test"
           variant="ghostSwipe"
           color="black"
-          icon="triangle-right"
+          icon="triangle-up"
+          animate="up"
           className="after:!su-bg-robins-egg"
           uppercase
         >

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -88,7 +88,6 @@ export const VerticalCard = ({
           animate="right"
           sbLink={link}
           href={href}
-          uppercase
           className={styles.ctaLink}
         >
           {ctaLabel}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Replace original triangle icon with rounder icon (trying PlayIcon from HeroIcons) and addd "triangle-up" option
- Update CTA padding

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview
2. See that the CTAs with the solid triangles are now slightly rounder; check that they all look good
Note: We're getting rid of all the all caps buttons so no need to worry about positioning of icons for those uppercase buttons.
![Screenshot 2023-05-19 at 10 01 38 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/65ec5059-9ff2-4f23-a8cd-fddd83172176)
![Screenshot 2023-05-19 at 10 01 30 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/44ed3c46-356a-4ff4-ba3d-c3e5c080edec)
![Screenshot 2023-05-19 at 10 01 19 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e8aa6ec9-0400-4707-a05e-cf8dc1c607f1)
![Screenshot 2023-05-19 at 10 01 14 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/97f133a0-2de5-4299-9281-00154fd89b0f)



# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-112