### PR TITLE
GIVCAMP-122 | Update play pause buttons in Hero; change intro bracket to outline

### DIFF
--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -28,7 +28,7 @@ export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
 export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
   'su-h-full su-border-y-2',
   {
-    'su-w-[19%] su-bg-current': isSolid,
+    'su-w-[20%] su-bg-current': isSolid,
     'su-w-[17%]': !isSolid,
     'su-border-r-2': corner === 'tl' || corner === 'bl',
     'su-border-l-2 su-order-1': corner === 'tr' || corner === 'br',

--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -26,9 +26,10 @@ export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
   },
 );
 export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
-  'su-w-[17%] su-h-full su-border-y-2',
+  'su-h-full su-border-y-2',
   {
-    'su-bg-current': isSolid,
+    'su-w-[18%] su-bg-current': isSolid,
+    'su-w-[17%]': !isSolid,
     'su-border-r-2': corner === 'tl' || corner === 'bl',
     'su-border-l-2 su-order-1': corner === 'tr' || corner === 'br',
   },

--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -28,7 +28,7 @@ export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
 export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
   'su-h-full su-border-y-2',
   {
-    'su-w-[18%] su-bg-current': isSolid,
+    'su-w-[19%] su-bg-current': isSolid,
     'su-w-[17%]': !isSolid,
     'su-border-r-2': corner === 'tl' || corner === 'bl',
     'su-border-l-2 su-order-1': corner === 'tr' || corner === 'br',

--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -1,7 +1,7 @@
 import { dcnb } from 'cnbuilder';
 
 // Bracket Curve styles
-export const root = 'su-border-current';
+export const root = 'su-border-current su-backface-hidden';
 
 export type CornerType = 'tl' | 'bl' | 'tr' | 'br';
 

--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -26,10 +26,9 @@ export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
   },
 );
 export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
-  'su-h-full su-border-y-2',
+  'su-h-full su-w-[17%] su-border-y-2',
   {
-    'su-w-[20%] su-bg-current': isSolid,
-    'su-w-[17%]': !isSolid,
+    'su-bg-current': isSolid,
     'su-border-r-2': corner === 'tl' || corner === 'bl',
     'su-border-l-2 su-order-1': corner === 'tr' || corner === 'br',
   },

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -108,7 +108,7 @@ export const HomepageHero = () => {
               <HeroIcon
                 icon="play-outline"
                 title="Play full video"
-                className="su-type-5"
+                className="su-type-5 su-fill-gc-black/70"
               />
             </button>
             <Text font="serif" weight="bold" color="white" align="center" italic className="su-hidden sm:su-block">

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -108,12 +108,12 @@ export const HomepageHero = () => {
               <HeroIcon
                 icon="play-outline"
                 title="Play full video"
-                className="su-type-5 su-fill-gc-black/70 group-hocus:su-fill-digital-red"
+                className="su-type-5 su-fill-gc-black/70 group-hocus:su-fill-digital-red su-mx-auto"
               />
+              <Text weight="bold" color="white" align="center" size={1} className="su-hidden sm:su-block">
+                Play video
+              </Text>
             </button>
-            <Text font="serif" weight="bold" color="white" align="center" italic className="su-hidden sm:su-block">
-              play video
-            </Text>
           </m.div>
           <div className="su-h-[10vw] 2xl:su-h-[15rem]">
             <Ose className="su-fill-white su-h-full su--ml-2" />

--- a/src/components/Hero/HomepageHero.tsx
+++ b/src/components/Hero/HomepageHero.tsx
@@ -103,12 +103,12 @@ export const HomepageHero = () => {
             <button
               type="button"
               onClick={toggleVideo}
-              className="su-block su-text-white hocus-visible:su-text-digital-red-light su-transition su-mx-auto"
+              className="su-group su-block su-text-white su-transition su-mx-auto"
             >
               <HeroIcon
                 icon="play-outline"
                 title="Play full video"
-                className="su-type-5 su-fill-gc-black/70"
+                className="su-type-5 su-fill-gc-black/70 group-hocus:su-fill-digital-red"
               />
             </button>
             <Text font="serif" weight="bold" color="white" align="center" italic className="su-hidden sm:su-block">
@@ -123,12 +123,15 @@ export const HomepageHero = () => {
       <button
         type="button"
         onClick={toggleVideo}
-        className="su-text-white/50 su-absolute su-bottom-[6%] su-left-[50%] su-translate-x-[-50%] su-type-5 hocus:su-text-white su-transition"
+        className="su-w-fit su-group su-text-white su-absolute su-bottom-[4%] su-left-20 sm:su-left-30 md:su-left-50 hocus:su-text-white su-transition"
       >
         <HeroIcon
           icon={isPlaying ? 'pause' : 'play'}
-          title={`${isPlaying ? 'Pause' : 'Play'} background video`}
+          className="su-inline-block su-type-3 su-fill-gc-black/70 group-hocus:su-fill-digital-red su-mr-02em"
         />
+        <Text as="span" variant="card" weight="semibold">
+          {`${isPlaying ? 'Pause' : 'Play'} background video`}
+        </Text>
       </button>
     </div>
   );

--- a/src/components/HeroIcon/HeroIcon.styles.tsx
+++ b/src/components/HeroIcon/HeroIcon.styles.tsx
@@ -13,7 +13,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 
-import { PlayCircleIcon as PlayCircleSolidIcon, PlayIcon } from '@heroicons/react/24/solid';
+import { PlayIcon } from '@heroicons/react/24/solid';
 
 export const iconMap = {
   action: ChevronRightIcon,

--- a/src/components/HeroIcon/HeroIcon.styles.tsx
+++ b/src/components/HeroIcon/HeroIcon.styles.tsx
@@ -7,12 +7,13 @@ import {
   ChevronRightIcon,
   EnvelopeIcon,
   LinkIcon,
+  PauseCircleIcon,
   PlayCircleIcon,
   PlusIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
 
-import { PlayCircleIcon as PlayCircleSolidIcon, PauseCircleIcon, PlayIcon } from '@heroicons/react/24/solid';
+import { PlayCircleIcon as PlayCircleSolidIcon, PlayIcon } from '@heroicons/react/24/solid';
 
 export const iconMap = {
   action: ChevronRightIcon,
@@ -32,7 +33,7 @@ export const iconMap = {
   link: LinkIcon,
   more: ArrowRightIcon,
   pause: PauseCircleIcon,
-  play: PlayCircleSolidIcon,
+  play: PlayCircleIcon,
   'play-outline': PlayCircleIcon,
   plus: PlusIcon,
   right: ArrowRightIcon,

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -34,7 +34,6 @@ export const Intro = () => {
             style={{ left: prefersReduceMotion ? '0' : bracketPosition, willChange }}
           >
             <Bracket
-              isSolid
               className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full"
               curveClassName="su-h-[7vw] 2xl:su-h-[10.5rem]"
             />
@@ -55,7 +54,6 @@ export const Intro = () => {
           >
             <Bracket
               isClose
-              isSolid
               className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full"
               curveClassName="su-h-[7vw] 2xl:su-h-[10.5rem]"
             />

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -1,13 +1,12 @@
 import React, { useRef } from 'react';
 import {
-  m, useReducedMotion, useScroll, useTransform, useWillChange, useSpring, SpringOptions,
+  m, useReducedMotion, useScroll, useTransform, useSpring, SpringOptions,
 } from 'framer-motion';
 import { Bracket } from '../Bracket';
 import { FlexBox } from '../FlexBox';
 
 export const Intro = () => {
   const prefersReduceMotion = useReducedMotion();
-  const willChange = useWillChange();
   const springSetting: SpringOptions = {
     stiffness: 130,
     damping: 22,
@@ -24,7 +23,6 @@ export const Intro = () => {
   // We want the text opacity to increase at a slower rate than the bracket opacity
   const textOpacity = useTransform(scrollYProgress, [0, 0.4, 0.7, 1], [0, 0, 0.6, 1]);
   const bracketPosition = useTransform(scrollSpring, [0, 1], ['-20vw', '0vw']);
-  const bracketRightPosition = useTransform(scrollSpring, [0, 1], ['20vw', '0vw']);
 
   return (
     <div ref={sectionRef} className="su-bg-gc-black su-cc su-rs-pt-10 su-rs-pb-6 su-text-white su-relative">
@@ -32,7 +30,7 @@ export const Intro = () => {
         <FlexBox justifyContent="between">
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ x: prefersReduceMotion ? '0' : bracketPosition, willChange }}
+            style={{ left: prefersReduceMotion ? '0' : bracketPosition }}
           >
             <Bracket
               isSolid
@@ -52,7 +50,7 @@ export const Intro = () => {
           </m.p>
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ x: prefersReduceMotion ? '0' : bracketRightPosition, willChange }}
+            style={{ right: prefersReduceMotion ? '0' : bracketPosition }}
           >
             <Bracket
               isClose

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -24,15 +24,14 @@ export const Intro = () => {
   // We want the text opacity to increase at a slower rate than the bracket opacity
   const textOpacity = useTransform(scrollYProgress, [0, 0.4, 0.7, 1], [0, 0, 0.6, 1]);
   const bracketPosition = useTransform(scrollSpring, [0, 1], ['-20vw', '0vw']);
-  const bracketRightPosition = useTransform(scrollSpring, [0, 1], ['20vw', '0vw']);
 
   return (
     <div ref={sectionRef} className="su-bg-gc-black su-cc su-rs-pt-10 su-rs-pb-6 su-text-white su-relative su-overflow-hidden">
-      <m.div className="su-relative su-mx-auto su-w-fit" style={{ opacity: bracketOpacity }}>
+      <m.div className="su-relative su-mx-auto su-w-fit" style={{ opacity: bracketOpacity, willChange }}>
         <FlexBox justifyContent="between">
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ x: prefersReduceMotion ? '0' : bracketPosition, willChange }}
+            style={{ left: prefersReduceMotion ? '0' : bracketPosition, willChange }}
           >
             <Bracket
               isSolid
@@ -42,7 +41,7 @@ export const Intro = () => {
           </m.div>
           <m.p
             className="su-font-serif su-font-semibold su-text-21 md:su-text-27 xl:su-text-[3.4rem] su-max-w-1000 su-rs-py-7 su-px-30 lg:su-px-72 su-mb-0"
-            style={{ opacity: textOpacity }}
+            style={{ opacity: textOpacity, willChange }}
           >
             The present demands immediate action—and the future demands immediate impact.
             Looking at the challenges we face today—some of which threaten the future of
@@ -52,7 +51,7 @@ export const Intro = () => {
           </m.p>
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ x: prefersReduceMotion ? '0' : bracketRightPosition, willChange }}
+            style={{ right: prefersReduceMotion ? '0' : bracketPosition, willChange }}
           >
             <Bracket
               isClose

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -27,7 +27,7 @@ export const Intro = () => {
   const bracketRightPosition = useTransform(scrollSpring, [0, 1], ['20vw', '0vw']);
 
   return (
-    <div ref={sectionRef} className="su-bg-gc-black su-cc su-rs-pt-10 su-rs-pb-6 su-text-white su-relative">
+    <div ref={sectionRef} className="su-bg-gc-black su-cc su-rs-pt-10 su-rs-pb-6 su-text-white su-relative su-overflow-hidden">
       <m.div className="su-relative su-mx-auto su-w-fit" style={{ opacity: bracketOpacity }}>
         <FlexBox justifyContent="between">
           <m.div

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -1,12 +1,13 @@
 import React, { useRef } from 'react';
 import {
-  m, useReducedMotion, useScroll, useTransform, useSpring, SpringOptions,
+  m, useReducedMotion, useScroll, useTransform, useSpring, useWillChange, SpringOptions,
 } from 'framer-motion';
 import { Bracket } from '../Bracket';
 import { FlexBox } from '../FlexBox';
 
 export const Intro = () => {
   const prefersReduceMotion = useReducedMotion();
+  const willChange = useWillChange();
   const springSetting: SpringOptions = {
     stiffness: 130,
     damping: 22,
@@ -23,6 +24,7 @@ export const Intro = () => {
   // We want the text opacity to increase at a slower rate than the bracket opacity
   const textOpacity = useTransform(scrollYProgress, [0, 0.4, 0.7, 1], [0, 0, 0.6, 1]);
   const bracketPosition = useTransform(scrollSpring, [0, 1], ['-20vw', '0vw']);
+  const bracketRightPosition = useTransform(scrollSpring, [0, 1], ['20vw', '0vw']);
 
   return (
     <div ref={sectionRef} className="su-bg-gc-black su-cc su-rs-pt-10 su-rs-pb-6 su-text-white su-relative">
@@ -30,7 +32,7 @@ export const Intro = () => {
         <FlexBox justifyContent="between">
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ left: prefersReduceMotion ? '0' : bracketPosition }}
+            style={{ x: prefersReduceMotion ? '0' : bracketPosition }}
           >
             <Bracket
               isSolid
@@ -40,7 +42,7 @@ export const Intro = () => {
           </m.div>
           <m.p
             className="su-font-serif su-font-semibold su-text-21 md:su-text-27 xl:su-text-[3.4rem] su-max-w-1000 su-rs-py-7 su-px-30 lg:su-px-72 su-mb-0"
-            style={{ opacity: textOpacity }}
+            style={{ opacity: textOpacity, willChange }}
           >
             The present demands immediate action—and the future demands immediate impact.
             Looking at the challenges we face today—some of which threaten the future of
@@ -50,7 +52,7 @@ export const Intro = () => {
           </m.p>
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ right: prefersReduceMotion ? '0' : bracketPosition }}
+            style={{ x: prefersReduceMotion ? '0' : bracketRightPosition, willChange }}
           >
             <Bracket
               isClose

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -24,6 +24,7 @@ export const Intro = () => {
   // We want the text opacity to increase at a slower rate than the bracket opacity
   const textOpacity = useTransform(scrollYProgress, [0, 0.4, 0.7, 1], [0, 0, 0.6, 1]);
   const bracketPosition = useTransform(scrollSpring, [0, 1], ['-20vw', '0vw']);
+  const bracketRightPosition = useTransform(scrollSpring, [0, 1], ['20vw', '0vw']);
 
   return (
     <div ref={sectionRef} className="su-bg-gc-black su-cc su-rs-pt-10 su-rs-pb-6 su-text-white su-relative su-overflow-hidden">
@@ -31,7 +32,7 @@ export const Intro = () => {
         <FlexBox justifyContent="between">
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ left: prefersReduceMotion ? '0' : bracketPosition, willChange }}
+            style={{ x: prefersReduceMotion ? '0' : bracketPosition, willChange }}
           >
             <Bracket
               className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full"
@@ -50,7 +51,7 @@ export const Intro = () => {
           </m.p>
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ right: prefersReduceMotion ? '0' : bracketPosition, willChange }}
+            style={{ x: prefersReduceMotion ? '0' : bracketRightPosition, willChange }}
           >
             <Bracket
               isClose

--- a/src/components/Intro/Intro.tsx
+++ b/src/components/Intro/Intro.tsx
@@ -32,7 +32,7 @@ export const Intro = () => {
         <FlexBox justifyContent="between">
           <m.div
             className="su-relative su-h-auto su-shrink-0"
-            style={{ x: prefersReduceMotion ? '0' : bracketPosition }}
+            style={{ x: prefersReduceMotion ? '0' : bracketPosition, willChange }}
           >
             <Bracket
               isSolid
@@ -42,7 +42,7 @@ export const Intro = () => {
           </m.div>
           <m.p
             className="su-font-serif su-font-semibold su-text-21 md:su-text-27 xl:su-text-[3.4rem] su-max-w-1000 su-rs-py-7 su-px-30 lg:su-px-72 su-mb-0"
-            style={{ opacity: textOpacity, willChange }}
+            style={{ opacity: textOpacity }}
           >
             The present demands immediate action—and the future demands immediate impact.
             Looking at the challenges we face today—some of which threaten the future of


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This PR originally was meant to update the animation behavior of the hero. I only include the play/pause button updates because I think the on scroll change isn't good for usability. I'll put that work into a different PR so we can merge this in.
- Use the outline version of the bracket in intro, since the solid one combined with the animation creates visual artifacts that can't seem to go away

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the hero play button inside the bracket as you scroll down, and the background video play pause at the left right corner of the hero

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-122