### PR TITLE
GIVCAMP-131 | Replace dcnb with cnb for speed

### DIFF
--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -12,7 +12,7 @@ export const colors = {
 export type ColorType = keyof typeof colors;
 
 export const curve = (corner: CornerType, isSolid: boolean) => cnb(
-  'su-w-[83%] su-h-full su-border-t-2 su-border-l-2 su-rounded-tl-full',
+  'su-w-[83%] su-h-full',
   {
     'su-bg-current': isSolid,
     'su-rounded-tl-full': corner === 'tl',

--- a/src/components/Bracket/Bracket.styles.ts
+++ b/src/components/Bracket/Bracket.styles.ts
@@ -1,4 +1,4 @@
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 
 // Bracket Curve styles
 export const root = 'su-border-current su-backface-hidden';
@@ -11,7 +11,7 @@ export const colors = {
 };
 export type ColorType = keyof typeof colors;
 
-export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
+export const curve = (corner: CornerType, isSolid: boolean) => cnb(
   'su-w-[83%] su-h-full su-border-t-2 su-border-l-2 su-rounded-tl-full',
   {
     'su-bg-current': isSolid,
@@ -25,7 +25,7 @@ export const curve = (corner: CornerType, isSolid: boolean) => dcnb(
     'su-border-r-2 su-order-2': corner === 'tr' || corner === 'br',
   },
 );
-export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
+export const rectangle = (corner: CornerType, isSolid: boolean) => cnb(
   'su-h-full su-w-[17%] su-border-y-2',
   {
     'su-bg-current': isSolid,
@@ -35,7 +35,7 @@ export const rectangle = (corner: CornerType, isSolid: boolean) => dcnb(
 );
 
 // Bracket styles
-export const middle = (isClose: boolean, isSolid: boolean) => dcnb(
+export const middle = (isClose: boolean, isSolid: boolean) => cnb(
   'su-grow su-border-x-2 su-border-current su-w-[calc(83%_+_0.2rem)]',
   {
     'su-self-end': isClose,

--- a/src/components/Bracket/Bracket.tsx
+++ b/src/components/Bracket/Bracket.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { BracketCurve, BracketCurveProps } from './BracketCurve';
 import { FlexBox } from '../FlexBox';
 import * as styles from './Bracket.styles';
@@ -20,7 +20,7 @@ export const Bracket = ({
 }: BracketProps) => (
   <FlexBox
     direction="col"
-    className={dcnb(
+    className={cnb(
       styles.colors[color],
       className,
     )}

--- a/src/components/Bracket/BracketCurve.tsx
+++ b/src/components/Bracket/BracketCurve.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { FlexBox } from '../FlexBox';
 import * as styles from './Bracket.styles';
 
@@ -17,7 +17,7 @@ export const BracketCurve = ({
   ...props
 }: BracketCurveProps) => (
   <FlexBox
-    className={dcnb(
+    className={cnb(
       styles.root,
       styles.colors[color],
       className,

--- a/src/components/BracketCard/BracketCard.styles.ts
+++ b/src/components/BracketCard/BracketCard.styles.ts
@@ -1,56 +1,56 @@
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 
 export const root = 'su-relative su-mx-auto';
-export const grid = (textOnLeft: boolean) => dcnb(
+export const grid = (textOnLeft: boolean) => cnb(
   'su-flex su--mt-[40vw] sm:su-mt-0 sm:su-ml-0 su-w-[calc(100%_+_7rem)] sm:su-w-full sm:su-grid sm:su-grid-cols-12 sm:su-absolute sm:su-top-0 sm:su-bottom-[4vw] 3xl:su-bottom-70',
   textOnLeft ? 'su--mr-70' : 'su--ml-70',
 );
 
-export const bracket = (textOnLeft: boolean) => dcnb(
+export const bracket = (textOnLeft: boolean) => cnb(
   'su-relative su-z-10 su-w-[13rem] su-shrink-0 sm:su-col-span-2 sm:su-w-[120%]',
   textOnLeft ? 'su-order-2 sm:su-col-end-12 sm:su-justify-self-end' : 'sm:su-col-start-2',
 );
 
-export const contentCard = (textOnLeft: boolean) => dcnb(
+export const contentCard = (textOnLeft: boolean) => cnb(
   'su-relative su-z-10 sm:su-col-span-9 su-border-b-2 su-border-white',
   textOnLeft ? 'su-order-1 sm:su-col-start-1' : 'sm:su-col-start-4',
 );
 
-export const imageGrid = (textOnLeft: boolean) => dcnb(
+export const imageGrid = (textOnLeft: boolean) => cnb(
   'sm:su-ml-0 sm:su-pt-[6vw] 3xl:su-pt-100',
   textOnLeft ? 'su--mr-20' : 'su--ml-20',
 );
-export const imageWrapper = (textOnLeft: boolean) => dcnb(
+export const imageWrapper = (textOnLeft: boolean) => cnb(
   'su-relative su-w-[80vw] sm:su-w-full sm:su-col-span-7',
   textOnLeft ? 'su-mr-0 su-ml-auto sm:su-col-start-6' : '',
 );
 export const imageAspectRatio = 'su-aspect-w-6 su-aspect-h-5';
 export const image = 'su-object-cover';
-export const imageOverlay = (textOnLeft: boolean) => dcnb(
+export const imageOverlay = (textOnLeft: boolean) => cnb(
   'su-hidden sm:su-block su-from-black-true/50 su-via-black-true/20 su-to-transparent su-via-20% sm:su-absolute su-w-full su-h-full sm:su-top-0 sm:su-left-0',
   textOnLeft ? 'su-bg-gradient-to-r' : 'su-bg-gradient-to-l',
 );
 
 export const bracketWrapper = 'sm:su-pt-108 su-border-b su-border-white';
-export const contentWrapper = (textOnLeft: boolean, isSmallHeading: boolean) => dcnb(
+export const contentWrapper = (textOnLeft: boolean, isSmallHeading: boolean) => cnb(
   'su-relative su-z-10 sm:su-h-full',
   textOnLeft ? 'sm:su-ml-0 sm:su-mr-auto' : 'sm:su-mr-0 sm:su-ml-auto',
   isSmallHeading ? 'sm:su-pt-[3.8vw] 3xl:su-pt-60' : 'sm:su-pt-[3vw] 3xl:su-pt-50',
 );
 
 // We need heading size to be finetuned and be smoothly responsive so we aren't using modular typography here
-export const heading = (isSmallHeading: boolean) => dcnb(
+export const heading = (isSmallHeading: boolean) => cnb(
   'su-hidden sm:su-block su-text-shadow-lg sm:su-max-w-[85%] su-mb-0',
   isSmallHeading
     ? 'su-text-[3.6rem] sm:su-text-24 md:su-text-[clamp(3rem,5.36vw_-_1.11rem,4.2rem)] lg:su-text-[clamp(4.2rem,5.51vw_-_1.27rem,7rem)]'
     : 'su-text-[4.2rem] sm:su-text-[2.8rem] md:su-text-[clamp(4rem,7.59vw_-_1.83rem,5.7rem)] lg:su-text-[clamp(5.7rem,6.1vw_-_.35rem,8.8rem)]',
 );
-export const headingMobile = (textOnLeft: boolean) => dcnb(
+export const headingMobile = (textOnLeft: boolean) => cnb(
   'sm:su-hidden su-mb-20 su-w-4/5',
   textOnLeft ? 'su-ml-0 su-mr-auto' : 'su-mr-0 su-ml-auto',
 );
 
-export const body = (textOnLeft: boolean) => dcnb(
+export const body = (textOnLeft: boolean) => cnb(
   'su-grow su-mb-48 sm:su-mb-0 sm:su-max-w-[55%] sm:su-text-14 md:su-text-15 lg:su-text-16 xl:su-leading-snug xl:su-text-20 2xl:su-text-23',
   textOnLeft ? 'sm:su-pr-20 xl:su-pr-30' : 'sm:su-pl-20 xl:su-pl-30',
 );

--- a/src/components/BracketCard/BracketCard.tsx
+++ b/src/components/BracketCard/BracketCard.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { AnimateInView } from '../Animate';
 import { Bracket } from '../Bracket';
 import { CtaLink } from '../Cta/CtaLink';
@@ -51,7 +51,7 @@ export const BracketCard = ({
   ...props
 }: BracketCardProps) => (
   <article
-    className={dcnb(
+    className={cnb(
       styles.root,
       marginBottoms[spacingBottom],
       className,
@@ -110,7 +110,7 @@ export const BracketCard = ({
             </Heading>
           )}
           {tabColor && (
-            <div className={dcnb(styles.tab, accentBgColors[tabColor])} />
+            <div className={cnb(styles.tab, accentBgColors[tabColor])} />
           )}
           {body && (
             <Paragraph

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import {
   paddingTops,
   paddingBottoms,
@@ -34,7 +34,7 @@ export const Container = ({
   <AsComponent
     {...props}
     style={style}
-    className={dcnb(
+    className={cnb(
       bgColor ? styles.bgColors[bgColor] : '',
       py ? paddingVerticals[py] : '',
       pt ? paddingTops[pt] : '',

--- a/src/components/Cta/CtaContent.tsx
+++ b/src/components/Cta/CtaContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { FlexBox } from '../FlexBox';
 import { HeroIcon } from '../HeroIcon';
 import { SrOnlyText } from '../Typography';
@@ -30,7 +30,7 @@ export const CtaContent = ({
       {heroicon && (
         <HeroIcon
           icon={heroicon}
-          className={dcnb(styles.icon, iconStyle, iconAnimate, iconMarginLeft, iconMarginRight, iconClasses)}
+          className={cnb(styles.icon, iconStyle, iconAnimate, iconMarginLeft, iconMarginRight, iconClasses)}
           {...iProps}
         />
       )}

--- a/src/components/Cta/getCtaClasses.ts
+++ b/src/components/Cta/getCtaClasses.ts
@@ -1,4 +1,4 @@
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import * as types from './Cta.types';
 import * as styles from './Cta.styles';
 
@@ -9,7 +9,7 @@ export const getCtaClasses = (
   color?: types.CtaColorType,
   className?: string,
 ) => {
-  const ctaClasses = dcnb(
+  const ctaClasses = cnb(
     styles.cta,
     styles.ctaSizes[size] || styles.ctaSizes[styles.ctaSizeMap[variant]],
     styles.ctaVariants[variant],

--- a/src/components/FlexBox/FlexBox.tsx
+++ b/src/components/FlexBox/FlexBox.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import * as styles from './FlexBox.styles';
 import * as types from './FlexBox.types';
 
@@ -28,7 +28,7 @@ export const FlexBox = ({
 }: FlexBoxProps) => (
   <AsComponent
     {...props}
-    className={dcnb(
+    className={cnb(
       'su-flex',
       direction ? styles.flexDirection[direction] : '',
       wrap ? styles.flexWrap[wrap] : '',

--- a/src/components/GlobalFooter/GlobalFooter.tsx
+++ b/src/components/GlobalFooter/GlobalFooter.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { StanfordLogo } from '../StanfordLogo';
 import { SrOnlyText } from '../Typography';
 import { Container } from '../Container';
@@ -13,7 +13,7 @@ type GlobalFooterProps = Omit<HTMLAttributes<HTMLDivElement>, 'className'> & {
 const GlobalFooter = ({ className, ...rest }: GlobalFooterProps) => (
   <Container
     {...rest}
-    className={dcnb(styles.root, className)}
+    className={cnb(styles.root, className)}
     width="site"
   >
     <FlexBox direction="col" className={styles.outerWrapper}>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import {
   paddingTops,
   paddingBottoms,
@@ -49,7 +49,7 @@ export const Grid = ({
 }: GridProps) => (
   <AsComponent
     {...props}
-    className={dcnb(
+    className={cnb(
       'su-grid',
       gap ? styles.gridGaps[gap] : '',
       xs ? styles.gridNumCols.xs[xs] : '',

--- a/src/components/Grid/GridAlternating.tsx
+++ b/src/components/Grid/GridAlternating.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes, useRef } from 'react';
 import {
   useScroll, useSpring, m, MotionStyle,
 } from 'framer-motion';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { Grid, GridProps } from './Grid';
 import { GridNegativeSpacingType, GridWidthType } from './Grid.types';
 import { marginBottoms, MarginType } from '../../utilities/datasource';
@@ -57,14 +57,14 @@ export const GridAlternating = ({
   });
 
   return (
-    <div className={dcnb(styles.alternatingGridWrapper, styles.gridWidths[width])} ref={containerRef}>
+    <div className={cnb(styles.alternatingGridWrapper, styles.gridWidths[width])} ref={containerRef}>
       <Grid as={as} gap="split" md={2} py={py} pt={pt} pb={pb} {...props}>
         {startOnRight && <div />}
         {childrenArray?.map((item, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <React.Fragment key={index}>
             <m.div
-              className={dcnb(
+              className={cnb(
                 marginBottoms[spacing],
                 styles.negativeSpacing[spacing],
                 styles.cellWithContent,

--- a/src/components/HeroIcon/HeroIcon.tsx
+++ b/src/components/HeroIcon/HeroIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import * as styles from './HeroIcon.styles';
 
 export type HeroIconProps = Omit<React.SVGProps<SVGSVGElement>, 'ref'> & {
@@ -22,14 +22,14 @@ export const HeroIcon = ({
   // Set default base style so icon has reasonable size if used out of the box
   // noBaseStyle boolean allows for user to not attach any base styles if needed
   const baseStyle = noBaseStyle ? '' : styles.iconBaseStyle[icon] || styles.iconBaseStyle.default;
-  const heroIconStyle = dcnb('su-transition', baseStyle);
+  const heroIconStyle = cnb('su-transition', baseStyle);
 
   return (
     <Icon
       title={title}
       // If a title for the SVG is provided, unhide the SVG from screen readers
       aria-hidden={!title}
-      className={dcnb(heroIconStyle, className)}
+      className={cnb(heroIconStyle, className)}
       {...props}
     />
   );

--- a/src/components/ImageOverlay.tsx
+++ b/src/components/ImageOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 
 export const overlays = {
   'black-30': 'su-bg-black-true/30',
@@ -30,7 +30,7 @@ export const ImageOverlay = ({
     />
     {overlay && (
       <div
-        className={dcnb(
+        className={cnb(
           'su-absolute su-w-full su-h-full su-top-0 su-left-0',
           overlays[overlay],
         )}

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -1,4 +1,4 @@
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 
 export type LogoVariantType = 'horizontal' | 'stacked';
 
@@ -6,16 +6,16 @@ export type LogoColorType = 'black' | 'white';
 
 export const link = 'su-block su-no-underline focus-visible:su-outline-none focus-visible:su-ring-2 focus-visible:su-ring-white';
 
-export const textWrapper = (variant: LogoVariantType) => dcnb('su-flex', {
+export const textWrapper = (variant: LogoVariantType) => cnb('su-flex', {
   'su-h-[.82em]': variant === 'horizontal',
 });
 
-export const stanford = (variant: LogoVariantType) => dcnb('su-leading-none', {
+export const stanford = (variant: LogoVariantType) => cnb('su-leading-none', {
   'su-text-vertical-lr su-rotate-180 su-text-[.46em] su-relative su-mt-01em': variant === 'stacked',
   'su-text-[1.08em]': variant === 'horizontal',
 });
 
-export const onPurpose = (variant: LogoVariantType) => dcnb('!su-tracking-normal', {
+export const onPurpose = (variant: LogoVariantType) => cnb('!su-tracking-normal', {
   'su-ml-[0.15em] su-leading-[.7]': variant === 'horizontal',
 });
 

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { Link } from 'gatsby';
 import { LogoHorizontal } from './LogoHorizontal';
 import { FontSizeType } from '../Typography';
@@ -33,7 +33,7 @@ export const Logo = ({
       <Link
         {...rest}
         to={homeLink}
-        className={dcnb(styles.link, className)}
+        className={cnb(styles.link, className)}
       >
         {LogoText}
       </Link>

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { Container } from '../Container';
 import { FlexBox } from '../FlexBox';
 import { Logo } from '../Logo';
@@ -10,7 +10,7 @@ import { HeroIcon } from '../HeroIcon';
 type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
 export const Masthead = ({ className, ...props }: MastheadProps) => (
-  <div className={dcnb('su-bg-transparent su-w-full su-absolute su-z-10', className)} {...props}>
+  <div className={cnb('su-bg-transparent su-w-full su-absolute su-z-10', className)} {...props}>
     <Container>
       <FlexBox
         justifyContent="between"

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unstable-nested-components */
 import React from 'react';
 import { render, StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { CtaLink } from './Cta';
 import { SbCta } from './Storyblok/SbCta';
 import {
@@ -94,7 +94,7 @@ export const RichText = ({
 
   return (
     <div
-      className={dcnb(
+      className={cnb(
         'su-wysiwyg',
         textColor,
         textAligns[textAlign] || '',

--- a/src/components/SkipLink.tsx
+++ b/src/components/SkipLink.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 
 type SkiplinkProps = Omit<React.ComponentPropsWithoutRef<'a'>, 'href' | 'className' | 'children'> & {
   href?: string;
@@ -21,7 +21,7 @@ export const Skiplink = ({
       ref={ref}
       href={href}
       onFocus={() => ref.current?.scrollIntoView()}
-      className={dcnb('su-skiplink', className)}
+      className={cnb('su-skiplink', className)}
     >
       {children}
     </a>

--- a/src/components/SplitPoster/PosterContent.tsx
+++ b/src/components/SplitPoster/PosterContent.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { AnimateInView } from '../Animate';
 import { FlexBox } from '../FlexBox';
 import { Heading, Paragraph, HeadingType } from '../Typography';
@@ -40,7 +40,7 @@ export const PosterContent = ({
       {...props}
       alignItems="end"
       justifyContent={contentAlign === 'left' ? 'start' : 'end'}
-      className={dcnb(styles.posterContentRoot(!!imageSrc), bgTextColorPairs[bgColor], className)}
+      className={cnb(styles.posterContentRoot(!!imageSrc), bgTextColorPairs[bgColor], className)}
     >
       {imageSrc && (
         <ImageOverlay

--- a/src/components/SplitPoster/SplitPoster.styles.tsx
+++ b/src/components/SplitPoster/SplitPoster.styles.tsx
@@ -1,20 +1,20 @@
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 
 export const root = 'su-relative su-bg-white su-bg-no-repeat su-bg-cover su-bg-top';
 
 export const panel = 'su-border-white su-bg-no-repeat su-bg-cover su-bg-top';
-export const panelLeft = (isLargeOffset: boolean) => dcnb(
+export const panelLeft = (isLargeOffset: boolean) => cnb(
   panel,
   'su-border-b xl:su-border-b-0 xl:su-border-r',
   isLargeOffset ? 'su-pt-200' : 'su-pt-60',
 );
-export const panelRight = (isLargeOffset: boolean) => dcnb(
+export const panelRight = (isLargeOffset: boolean) => cnb(
   panel,
   'su-border-t xl:su-border-t-0 xl:su-border-l su-pb-60',
   isLargeOffset ? 'su-pb-200' : 'su-pb-60',
 );
 
-export const posterContentRoot = (hasImage: boolean) => dcnb(
+export const posterContentRoot = (hasImage: boolean) => cnb(
   'su-relative su-overflow-hidden su-border-white sm:su-max-w-[53rem] md:su-max-w-[60rem] lg:su-max-w-[75rem] su-px-20 sm:su-px-60 2xl:su-px-126 su-min-h-[45rem] md:su-min-h-[60rem] xl:su-min-h-[75rem] su-pb-60 md:su-pb-100 su-rs-pt-6',
   hasImage ? 'su-text-white' : '',
 );
@@ -23,7 +23,7 @@ export const posterContentRight = 'su-rounded-br-[12rem] sm:su-rounded-br-[20rem
 
 export const content = 'su-relative su-w-full su-break-words su-z-10';
 
-export const heading = (hasImage: boolean) => dcnb('su-rs-mb-3 2xl:su-whitespace-pre-line', hasImage ? 'su-text-shadow-sm' : '');
+export const heading = (hasImage: boolean) => cnb('su-rs-mb-3 2xl:su-whitespace-pre-line', hasImage ? 'su-text-shadow-sm' : '');
 
 export const body = 'su-rs-mb-2 last:su-mb-0';
 

--- a/src/components/StanfordLogo/StanfordLogo.tsx
+++ b/src/components/StanfordLogo/StanfordLogo.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes, ReactNode } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import * as styles from './StanfordLogo.styles';
 
 type StanfordLogoProps = HTMLAttributes<HTMLElement> & {
@@ -44,7 +44,7 @@ export const StanfordLogo = ({
       <a
         {...rest}
         href="https://www.stanford.edu"
-        className={dcnb('su-logo', color ? styles.logoColors[color] : '', className)}
+        className={cnb('su-logo', color ? styles.logoColors[color] : '', className)}
       >
         {logoText}
       </a>
@@ -52,7 +52,7 @@ export const StanfordLogo = ({
   }
 
   return (
-    <div {...rest} className={dcnb('su-logo', color ? styles.logoColors[color] : '', className)}>
+    <div {...rest} className={cnb('su-logo', color ? styles.logoColors[color] : '', className)}>
       {logoText}
     </div>
   );

--- a/src/components/Temporary/ThemeSection.tsx
+++ b/src/components/Temporary/ThemeSection.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import {
   m, useScroll, useSpring, useTransform, SpringOptions,
 } from 'framer-motion';
@@ -110,7 +110,7 @@ export const ThemeSection = () => {
             </Paragraph>
           </div>
         </AnimateInView>
-        <div className={dcnb('su-sr-only focus-within:su-not-sr-only su-w-fit children:su-mx-auto', !shouldAnimate ? 'su-hidden' : '')}>
+        <div className={cnb('su-sr-only focus-within:su-not-sr-only su-w-fit children:su-mx-auto', !shouldAnimate ? 'su-hidden' : '')}>
           <CtaButton onClick={() => setShouldAnimate(false)}>Reveal themes visually</CtaButton>
         </div>
         {/* This grid contains the 4 animated lines behind the theme cards */}

--- a/src/components/Typography/Paragraph.tsx
+++ b/src/components/Typography/Paragraph.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { Text, TypographyProps } from './Text';
 
 type ParagraphProps = Omit<TypographyProps, 'className'> & React.HTMLAttributes<HTMLParagraphElement> & {
@@ -8,5 +8,5 @@ type ParagraphProps = Omit<TypographyProps, 'className'> & React.HTMLAttributes<
 
 // Convenience component for paragraphs
 export const Paragraph = ({ noMargin, className, ...rest }: ParagraphProps) => (
-  <Text {...rest} as="p" className={dcnb(noMargin ? 'su-mb-0' : '', className)} />
+  <Text {...rest} as="p" className={cnb(noMargin ? 'su-mb-0' : '', className)} />
 );

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { HeroIcon, HeroIconProps, IconType } from '../HeroIcon';
 import * as styles from './typography.styles';
 import * as types from './typography.types';
@@ -53,7 +53,7 @@ export const Text = ({
     <AsComponent
       {...rest}
       className={
-        dcnb(
+        cnb(
           font ? styles.fontFamilies[font] : '',
           size ? styles.fontSizes[size] : '',
           weight ? styles.fontWeights[weight] : '',
@@ -74,7 +74,7 @@ export const Text = ({
         <HeroIcon
           icon={icon}
           noBaseStyle
-          className={dcnb(styles.iconStyle, iconClasses)}
+          className={cnb(styles.iconStyle, iconClasses)}
           {...iProps}
         />
       )}

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { AnimateInView, AnimationType } from '../Animate';
 import { CtaLink } from '../Cta/CtaLink';
 import { Heading, HeadingType, Paragraph } from '../Typography';
@@ -47,7 +47,7 @@ export const VerticalCard = ({
 }: VerticalCardProps) => (
   <AnimateInView animation={animation} delay={delay}>
     <article
-      className={dcnb(styles.root, styles.textColors[textColor], className)}
+      className={cnb(styles.root, styles.textColors[textColor], className)}
       {...props}
     >
       {imageSrc && (
@@ -76,7 +76,7 @@ export const VerticalCard = ({
         </Heading>
       )}
       {tabColor && (
-        <div className={dcnb(styles.tab, accentBgColors[tabColor])} />
+        <div className={cnb(styles.tab, accentBgColors[tabColor])} />
       )}
       {body && (
         <Paragraph variant="card" noMargin>{body}</Paragraph>

--- a/src/components/WidthBox/WidthBox.tsx
+++ b/src/components/WidthBox/WidthBox.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { dcnb } from 'cnbuilder';
+import { cnb } from 'cnbuilder';
 import { Container, ContainerProps } from '../Container';
 import { Grid, GridProps } from '../Grid';
 import * as styles from './WidthBox.styles';
@@ -43,9 +43,9 @@ export const WidthBox = ({
   }
 
   return (
-    <Grid {...props as NonFullWidthBoxProps} gap="default" sm={12} className={dcnb('su-cc', className)}>
+    <Grid {...props as NonFullWidthBoxProps} gap="default" sm={12} className={cnb('su-cc', className)}>
       <div
-        className={dcnb(
+        className={cnb(
           styles.widthClasses[width]?.column || '',
           align === 'center' ? styles.widthClasses[width]?.columnStart : '',
         )}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Replace dcnb with cnb because we don't need the dedupe the way we're using it
- Author says dedupe version is much slower. Looking at the benchmark, we don't get much advantage using it over classname package if we use the dcnb version
https://github.com/xobotyi/cnbuilder/tree/master/benchmark

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and see that things still look the same

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-131