### PR TITLE
GIVCAMP-129 | Update color bar in section to extend to superhead

### DIFF
--- a/src/components/Homepage/ThemeSection.tsx
+++ b/src/components/Homepage/ThemeSection.tsx
@@ -94,19 +94,21 @@ export const ThemeSection = ({
       className="su-relative su-overflow-hidden"
     >
       <AnimateInView duration={0.6} animation="slideUp">
-        <Text size={2} leading="tight" font="serif" className="su-cc su-mb-08em">Themes</Text>
-        <FlexBox className="su-relative su-rs-mb-6">
+        <FlexBox className="su-rs-mb-6">
           <div className="su-block su-bg-digital-red su-w-8 md:su-w-20 lg:su-w-40" />
-          <Heading
-            as="h2"
-            size="splash"
-            leading="none"
-            font="druk"
-            className="su-cc su-mb-0 su--mt-[0.14em] su-whitespace-pre-line su--ml-8 md:su--ml-20 lg:su--ml-40 su-w-full 3xl:su-max-w-3/5"
-          >
-            Square pegs,<br />
-            huge goals.
-          </Heading>
+          <div className="su-cc su-whitespace-pre-line su-w-full 3xl:su-max-w-3/5 su--ml-8 md:su--ml-20 lg:su--ml-40">
+            <Text size={2} leading="tight" font="serif">Themes</Text>
+            <Heading
+              as="h2"
+              size="splash"
+              leading="none"
+              font="druk"
+              className="su-mb-0"
+            >
+              Square pegs,<br />
+              huge goals.
+            </Heading>
+          </div>
         </FlexBox>
       </AnimateInView>
       <Container>

--- a/src/components/Homepage/ThemeSection.tsx
+++ b/src/components/Homepage/ThemeSection.tsx
@@ -5,7 +5,9 @@ import {
 } from 'framer-motion';
 import { Container } from '../Container';
 import { Grid, GridAlternating } from '../Grid';
-import { Heading, Text, Paragraph } from '../Typography';
+import {
+  Heading, Text, Paragraph, SrOnlyText,
+} from '../Typography';
 import { colorNameToHex } from '../../utilities/colorPalettePlugin';
 import { FlexBox } from '../FlexBox';
 import { AnimateInView } from '../Animate';
@@ -97,7 +99,7 @@ export const ThemeSection = ({
         <FlexBox className="su-rs-mb-6">
           <div className="su-block su-bg-digital-red su-w-8 md:su-w-20 lg:su-w-40" />
           <div className="su-cc su-whitespace-pre-line su-w-full 3xl:su-max-w-3/5 su--ml-8 md:su--ml-20 lg:su--ml-40">
-            <Text size={2} leading="tight" font="serif">Themes</Text>
+            <Text size={2} leading="tight" font="serif" aria-hidden>Themes</Text>
             <Heading
               as="h2"
               size="splash"
@@ -105,6 +107,7 @@ export const ThemeSection = ({
               font="druk"
               className="su-mb-0"
             >
+              <SrOnlyText>Themes: </SrOnlyText>
               Square pegs,<br />
               huge goals.
             </Heading>

--- a/src/components/Storyblok/SbSection.tsx
+++ b/src/components/Storyblok/SbSection.tsx
@@ -47,13 +47,8 @@ export const SbSection = ({
     pb={paddingBottom}
     className="su-relative su-overflow-hidden"
   >
-    {superhead && (
-      <Text size={2} leading="tight" font="serif" className="su-cc su-mb-08em">
-        {superhead}
-      </Text>
-    )}
-    {heading && (
-      <FlexBox className="su-relative su-rs-mb-6">
+    {(heading || superhead) && (
+      <FlexBox className="su-rs-mb-6">
         {barColorValue && (
           <div className={cnb(
             'su-block su-w-8 md:su-w-20 lg:su-w-40',
@@ -61,21 +56,30 @@ export const SbSection = ({
           )}
           />
         )}
-        {heading && (
-          <Heading
-            as={headingLevel}
-            size="splash"
-            leading="none"
-            uppercase
-            font="druk"
-            className={cnb(
-              'su-cc su--mt-[0.14em] su-mb-0 su-whitespace-pre-line su-w-full 3xl:su-max-w-3/5',
-              barColorValue ? 'su--ml-8 md:su--ml-20 lg:su--ml-40' : '',
-            )}
-          >
-            {heading}
-          </Heading>
+        <div className={cnb(
+          'su-cc su-whitespace-pre-line su-w-full 3xl:su-max-w-3/5',
+          barColorValue ? 'su--ml-8 md:su--ml-20 lg:su--ml-40' : '',
+          superhead ? '' : 'su--mt-05em',
         )}
+        >
+          {superhead && (
+            <Text size={2} leading="tight" font="serif">
+              {superhead}
+            </Text>
+          )}
+          {heading && (
+            <Heading
+              as={headingLevel}
+              size="splash"
+              leading="none"
+              uppercase
+              font="druk"
+              className="su-mb-0"
+            >
+              {heading}
+            </Heading>
+          )}
+        </div>
       </FlexBox>
     )}
     <Container>

--- a/src/components/Storyblok/SbSection.tsx
+++ b/src/components/Storyblok/SbSection.tsx
@@ -3,7 +3,9 @@ import { cnb } from 'cnbuilder';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { CreateBloks } from '../CreateBloks';
 import { FlexBox } from '../FlexBox';
-import { Heading, HeadingType, Text } from '../Typography';
+import {
+  Heading, HeadingType, SrOnlyText, Text,
+} from '../Typography';
 import { Container, BgColorType } from '../Container';
 import { accentBgColors, PaddingType } from '../../utilities/datasource';
 import { paletteAccentColors, PaletteAccentColorType } from '../../utilities/colorPalettePlugin';
@@ -63,7 +65,7 @@ export const SbSection = ({
         )}
         >
           {superhead && (
-            <Text size={2} leading="tight" font="serif">
+            <Text size={2} leading="tight" font="serif" aria-hidden>
               {superhead}
             </Text>
           )}
@@ -76,7 +78,7 @@ export const SbSection = ({
               font="druk"
               className="su-mb-0"
             >
-              {heading}
+              {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
             </Heading>
           )}
         </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update color bar in section to extend to superhead

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at preview and the /about-test page
2. Check that sections with color bar now extends upward to include the superhead (if there is a superhead)

![Screenshot 2023-06-13 at 11 25 25 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/7d1d51c3-4587-41c1-94b2-c8c86fa18e42)
![Screenshot 2023-06-13 at 11 25 15 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/fef5d315-28d9-4697-9583-d4550c614b1f)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-129
