### PR TITLE
GIVCAMP-127, GIVCAMP-130 | Story card and theme card updates; Storyblok resolve story relations (new method)

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -6,6 +6,7 @@
 
 import type { GatsbyConfig } from 'gatsby';
 import * as dotenv from 'dotenv';
+import { resolveRelations } from './src/utilities/resolveRelations';
 
 dotenv.config();
 
@@ -66,7 +67,7 @@ const config: GatsbyConfig = {
         accessToken: process.env.STORYBLOK_ACCESS_TOKEN,
         version: activeEnv === 'production' ? 'published' : 'draft',
         region: 'us',
-        resolveRelations: ['sbStoryCard.storyPicker'],
+        resolveRelations,
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -66,6 +66,7 @@ const config: GatsbyConfig = {
         accessToken: process.env.STORYBLOK_ACCESS_TOKEN,
         version: activeEnv === 'production' ? 'published' : 'draft',
         region: 'us',
+        resolveRelations: ['sbStoryCard.storyPicker'],
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/src/components/BracketCard/BracketCard.styles.ts
+++ b/src/components/BracketCard/BracketCard.styles.ts
@@ -63,4 +63,4 @@ export type TextColorType = keyof typeof textColors;
 
 export const tab = 'su-mt-[50vw] su-mb-26 su-h-14 lg:su-h-16 xl:su-h-20 2xl:su-h-[2.4rem] su-max-w-full su-w-200 xl:su-w-300 2xl:su-w-[35rem] sm:su-my-16 xl:su-my-36 2xl:su-my-48';
 
-export const ctaLink = 'su-inline-block su-w-fit su-rs-mt-0 su-relative su-top-2';
+export const ctaLink = 'su-inline-block su-w-fit su-rs-mt-0 su-relative su-top-2 su-text-current';

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -20,6 +20,7 @@ export const ctaVariants = {
 export const ctaColors = {
   black: 'su-text-gc-black',
   white: 'su-text-white',
+  'digital-red': 'su-text-digital-red',
 };
 
 export const ctaCurves = {

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -1,12 +1,11 @@
 export const cta = 'su-group hocus:su-underline su-transition-all';
 
 export const ctaVariants = {
-  solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/80 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
+  solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red su-text-white hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/80 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
   inline: 'su-inline su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   inlineDark: 'su-inline su-text-digital-red-xlight hocus:su-text-white su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   ghost: 'su-inline-block su-font-normal su-leading-display su-bg-transparent hocus:su-text-current su-border-2 su-border-current focus-visible:su-outline-none su-underline-offset-4 su-decoration-transparent hocus:su-decoration-current',
   'ghost-swipe': 'su-relative su-z-[10] su-inline-block su-no-underline hocus:su-no-underline su-font-normal su-leading-display su-bg-transparent hocus:su-text-white su-border-2 su-border-current hocus:su-border-digital-red-light focus-visible:su-outline-none after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-digital-red after:su-to-cardinal-red after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
-  chip: 'su-inline-block su-font-normal su-rounded-full su-text-white hover:su-shadow-md su-no-underline su-leading-display hocus:su-bg-periwinkle su-text-white hocus:su-text-white su-border su-border-white focus:su-ring-2 active:su-ring-2 focus:su-ring-lagunita-40 active:su-ring-lagunita-40 focus:su-outline-none hocus:su-decoration-1',
   link: 'su-font-normal su-decoration-transparent hocus:su-decoration-current su-leading-display su-text-current hocus:su-text-current hocus:su-decoration-2 focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-outline-none focus-visible:su-rounded su-underline-offset-4',
   back: 'su-inline-block su-font-normal su-no-underline su-leading-none group-hocus:su-underline su-text-black hocus:su-text-lagunita focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-ring-offset-4 focus:su-outline-none su-rounded-[1px]',
   mainNav: 'su-inline-block su-border-2 su-font-normal su-decoration-transparent su-text-white hocus:su-border-white hocus-visible:su-bg-sapphire/50 hocus:su-text-white',
@@ -40,7 +39,6 @@ export const ctaSizes = {
   mainNav: 'su-text-16 su-px-14 su-py-10 lg:su-px-[2.4rem] lg:su-pt-18 lg:su-pb-19 lg:su-text-20',
   'footer-featured': 'su-ma-intro',
   card: 'su-ma-card',
-  chip: 'su-text-15 su-pt-3 su-pb-4 su-px-10',
   back: 'su-text-16',
   close: 'su-text-18 md:su-text-21',
   dismiss: 'su-text-17',

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -13,6 +13,7 @@ export const ctaVariants = {
   close: 'su-inline-block su-font-semibold su-leading-none su-text-lagunita hocus:su-text-lagunita-dark focus:su-outline-none',
   'close-x': 'su-leading-none',
   dismiss: 'su-inline-block su-font-bold su-uppercase su-tracking-widest su-leading-none su-text-gc-black hocus:su-text-gc-black focus:su-outline-none',
+  storyCardTag: 'su-inline-block su-text-current hocus:su-text-current su-font-normal su-decoration-2 su-underline-offset-4 su-decoration-black-50 hocus:su-decoration-current',
   unset: '',
 };
 
@@ -42,6 +43,7 @@ export const ctaSizes = {
   back: 'su-text-16',
   close: 'su-text-18 md:su-text-21',
   dismiss: 'su-text-17',
+  storyCardTag: 'su-text-16 lg:su-text-18',
   unset: '',
 };
 
@@ -55,6 +57,7 @@ export const ctaSizeMap = {
   close: 'close',
   back: 'back',
   chip: 'chip',
+  storyCardTag: 'storyCardTag',
   unset: 'unset',
 };
 

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -1,7 +1,7 @@
 export const cta = 'su-group hocus:su-underline su-transition-all';
 
 export const ctaVariants = {
-  solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/70 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
+  solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/80 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
   inline: 'su-inline su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   inlineDark: 'su-inline su-text-digital-red-xlight hocus:su-text-white su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   ghost: 'su-inline-block su-font-normal su-leading-display su-bg-transparent hocus:su-text-current su-border-2 su-border-current focus-visible:su-outline-none su-underline-offset-4 su-decoration-transparent hocus:su-decoration-current',
@@ -13,7 +13,7 @@ export const ctaVariants = {
   close: 'su-inline-block su-font-semibold su-leading-none su-text-lagunita hocus:su-text-lagunita-dark focus:su-outline-none',
   'close-x': 'su-leading-none',
   dismiss: 'su-inline-block su-font-bold su-uppercase su-tracking-widest su-leading-none su-text-gc-black hocus:su-text-gc-black focus:su-outline-none',
-  storyCardTag: 'su-inline-block su-text-current hocus:su-text-current su-font-normal su-decoration-2 su-underline-offset-4 su-decoration-black-50 hocus:su-decoration-current',
+  storyCardTag: 'su-inline-block su-text-current hocus:su-text-current su-font-normal su-decoration-2 su-underline-offset-4 su-decoration-black-50 hocus:su-decoration-current hocus:su-decoration-4',
   unset: '',
 };
 

--- a/src/components/Cta/CtaGatsbyLink.tsx
+++ b/src/components/Cta/CtaGatsbyLink.tsx
@@ -9,7 +9,7 @@ export type CtaGatsbyLinkProps = CtaCommonProps & GatsbyLinkProps<{}>;
 export const CtaGatsbyLink = (props) => {
   const {
     variant = 'link',
-    color = variant !== 'inline' && variant !== 'inlineDark' ? 'white' : '',
+    color,
     size,
     curve,
     icon,

--- a/src/components/Grid/Grid.styles.ts
+++ b/src/components/Grid/Grid.styles.ts
@@ -54,6 +54,7 @@ export const gridGaps = {
   default: 'su-grid-gap',
   card: 'su-grid-gap su-gap-y-[5rem] xl:su-gap-y-[7rem]',
   split: 'md:su-gap-x-[6rem] lg:su-gap-x-[10rem] xl:su-gap-x-[20rem] 2xl:su-gap-x-[28rem]',
+  xs: 'su-gap-x-[0.4rem] su-gap-y-[5rem] xl:su-gap-y-[7rem]',
 };
 
 export const gridJustifyContent = {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,7 +12,7 @@ import { SbLogo } from './Storyblok/SbLogo';
 import { SbSection } from './Storyblok/SbSection';
 import { SbSplitPoster } from './Storyblok/SbSplitPoster';
 import { SbThemeCard } from './Storyblok/SbThemeCard';
-import { SbVerticalCard } from './Storyblok/SbVerticalCard';
+import { SbStoryCard } from './Storyblok/SbStoryCard';
 import { SbWysiwyg } from './Storyblok/SbWysiwyg';
 import { Skiplink } from './SkipLink';
 
@@ -35,7 +35,7 @@ storyblokInit({
     sbSection: SbSection,
     sbSplitPoster: SbSplitPoster,
     sbThemeCard: SbThemeCard,
-    sbVerticalCard: SbVerticalCard,
+    sbStoryCard: SbStoryCard,
     sbWysiwyg: SbWysiwyg,
   },
 });

--- a/src/components/Storyblok/SbGrid.tsx
+++ b/src/components/Storyblok/SbGrid.tsx
@@ -6,12 +6,19 @@ import { CreateBloks } from '../CreateBloks';
 type SbGridProps = {
   blok: {
     _uid: string;
-    columns: any[];
+    gap?: 'default' | 'card' | 'xs'
+    items: any[];
   };
 };
 
-export const SbGrid = ({ blok: { columns }, blok }: SbGridProps) => (
-  <Grid md={2} xl={3} gap="card" {...storyblokEditable(blok)} key={blok._uid}>
-    <CreateBloks blokSection={columns} />
+export const SbGrid = ({
+  blok: {
+    items,
+    gap,
+  },
+  blok,
+}: SbGridProps) => (
+  <Grid md={2} xl={3} gap={gap} {...storyblokEditable(blok)} key={blok._uid}>
+    <CreateBloks blokSection={items} />
   </Grid>
 );

--- a/src/components/Storyblok/SbStoryCard.tsx
+++ b/src/components/Storyblok/SbStoryCard.tsx
@@ -7,7 +7,7 @@ import { SbImageType, SbLinkType } from './Storyblok.types';
 import { AccentBgColorType } from '../../utilities/datasource';
 import { paletteAccentColors, PaletteAccentColorType } from '../../utilities/colorPalettePlugin';
 
-export type SbVerticalCardProps = {
+export type SbStoryCardProps = {
   blok: {
     _uid: string;
     heading?: string;
@@ -18,15 +18,13 @@ export type SbVerticalCardProps = {
     tabColor?: {
       value?: PaletteAccentColorType;
     }
-    ctaLabel?: string;
-    ctaSrText?: string;
     link?: SbLinkType;
     animation?: AnimationType;
     delay?: number;
   };
 };
 
-export const SbVerticalCard = ({
+export const SbStoryCard = ({
   blok: {
     _uid,
     heading,
@@ -35,14 +33,12 @@ export const SbVerticalCard = ({
     body,
     image: { filename, focus } = {},
     tabColor: { value } = {},
-    ctaLabel,
-    ctaSrText,
     link,
     animation,
     delay,
   },
   blok,
-}: SbVerticalCardProps) => (
+}: SbStoryCardProps) => (
   <VerticalCard
     {...storyblokEditable(blok)}
     key={_uid}
@@ -53,8 +49,6 @@ export const SbVerticalCard = ({
     imageSrc={filename}
     imageFocus={focus}
     tabColor={paletteAccentColors[value] as AccentBgColorType}
-    ctaLabel={ctaLabel}
-    ctaSrText={ctaSrText}
     link={link}
     animation={animation}
     delay={delay}

--- a/src/components/Storyblok/SbStoryCard.tsx
+++ b/src/components/Storyblok/SbStoryCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { AnimationType } from '../Animate';
 import { HeadingType } from '../Typography';
-import { VerticalCard } from '../VerticalCard';
+import { StoryCard } from '../VerticalCard';
 import { SbImageType, SbLinkType } from './Storyblok.types';
 import { AccentBgColorType } from '../../utilities/datasource';
 import { paletteAccentColors, PaletteAccentColorType } from '../../utilities/colorPalettePlugin';
@@ -55,7 +55,7 @@ export const SbStoryCard = ({
   },
   blok,
 }: SbStoryCardProps) => (
-  <VerticalCard
+  <StoryCard
     {...storyblokEditable(blok)}
     key={_uid}
     heading={cardTitle || title || heading}

--- a/src/components/Storyblok/SbStoryCard.tsx
+++ b/src/components/Storyblok/SbStoryCard.tsx
@@ -10,10 +10,17 @@ import { paletteAccentColors, PaletteAccentColorType } from '../../utilities/col
 export type SbStoryCardProps = {
   blok: {
     _uid: string;
+    storyPicker?: {
+      content?: {
+        title?: string;
+        cardTitle?: string;
+        topics?: string[];
+      },
+      full_slug?: string;
+    };
     heading?: string;
     headingLevel?: HeadingType;
     isSmallHeading?: boolean;
-    body?: string;
     image?: SbImageType;
     tabColor?: {
       value?: PaletteAccentColorType;
@@ -27,10 +34,17 @@ export type SbStoryCardProps = {
 export const SbStoryCard = ({
   blok: {
     _uid,
+    storyPicker: {
+      content: {
+        title,
+        cardTitle,
+        topics,
+      },
+      full_slug,
+    } = {},
     heading,
     headingLevel,
     isSmallHeading,
-    body,
     image: { filename, focus } = {},
     tabColor: { value } = {},
     link,
@@ -42,16 +56,16 @@ export const SbStoryCard = ({
   <VerticalCard
     {...storyblokEditable(blok)}
     key={_uid}
-    heading={heading}
+    heading={cardTitle || title || heading}
     headingLevel={headingLevel}
     isSmallHeading={isSmallHeading}
-    body={body}
     imageSrc={filename}
     imageFocus={focus}
     tabColor={paletteAccentColors[value] as AccentBgColorType}
     link={link}
+    href={`/${full_slug}`}
     animation={animation}
     delay={delay}
-    taxonomy={['Science', 'Technology', 'Ethics']}
+    taxonomy={topics}
   />
 );

--- a/src/components/Storyblok/SbStoryCard.tsx
+++ b/src/components/Storyblok/SbStoryCard.tsx
@@ -15,6 +15,7 @@ export type SbStoryCardProps = {
         title?: string;
         cardTitle?: string;
         topics?: string[];
+        heroImage?: SbImageType;
       },
       full_slug?: string;
     };
@@ -39,13 +40,14 @@ export const SbStoryCard = ({
         title,
         cardTitle,
         topics,
+        heroImage: { filename: heroImage, focus: heroFocus } = {},
       },
       full_slug,
     } = {},
     heading,
     headingLevel,
     isSmallHeading,
-    image: { filename, focus } = {},
+    image: { filename: cardImage, focus: cardFocus } = {},
     tabColor: { value } = {},
     link,
     animation,
@@ -59,8 +61,8 @@ export const SbStoryCard = ({
     heading={cardTitle || title || heading}
     headingLevel={headingLevel}
     isSmallHeading={isSmallHeading}
-    imageSrc={filename}
-    imageFocus={focus}
+    imageSrc={cardImage || heroImage}
+    imageFocus={cardFocus || heroFocus}
     tabColor={paletteAccentColors[value] as AccentBgColorType}
     link={link}
     href={`/${full_slug}`}

--- a/src/components/Storyblok/SbStoryCard.tsx
+++ b/src/components/Storyblok/SbStoryCard.tsx
@@ -52,5 +52,6 @@ export const SbStoryCard = ({
     link={link}
     animation={animation}
     delay={delay}
+    taxonomy={['Science', 'Technology', 'Ethics']}
   />
 );

--- a/src/components/Storyblok/SbStoryCard.tsx
+++ b/src/components/Storyblok/SbStoryCard.tsx
@@ -41,7 +41,7 @@ export const SbStoryCard = ({
         cardTitle,
         topics,
         heroImage: { filename: heroImage, focus: heroFocus } = {},
-      },
+      } = {},
       full_slug,
     } = {},
     heading,
@@ -58,7 +58,7 @@ export const SbStoryCard = ({
   <StoryCard
     {...storyblokEditable(blok)}
     key={_uid}
-    heading={cardTitle || title || heading}
+    heading={heading || cardTitle || title}
     headingLevel={headingLevel}
     isSmallHeading={isSmallHeading}
     imageSrc={cardImage || heroImage}

--- a/src/components/Storyblok/SbThemeCard.tsx
+++ b/src/components/Storyblok/SbThemeCard.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { ThemeCard } from '../VerticalCard';
-import { SbVerticalCardProps } from './SbVerticalCard';
+import { SbStoryCardProps } from './SbStoryCard';
 import { AccentBgColorType } from '../../utilities/datasource';
 import { paletteAccentColors } from '../../utilities/colorPalettePlugin';
 
-export type SbThemeCardProps = Omit<SbVerticalCardProps, 'isSmallHeading'>;
+export type SbThemeCardProps = Omit<SbStoryCardProps, 'isSmallHeading'> & {
+  blok: {
+    ctaLabel?: string;
+    ctaSrText?: string;
+  };
+};
 
 export const SbThemeCard = ({
   blok: {

--- a/src/components/Storyblok/SbThemeCard.tsx
+++ b/src/components/Storyblok/SbThemeCard.tsx
@@ -7,6 +7,7 @@ import { paletteAccentColors } from '../../utilities/colorPalettePlugin';
 
 export type SbThemeCardProps = Omit<SbStoryCardProps, 'isSmallHeading'> & {
   blok: {
+    body?: string;
     ctaLabel?: string;
     ctaSrText?: string;
   };

--- a/src/components/Temporary/DemoContent.tsx
+++ b/src/components/Temporary/DemoContent.tsx
@@ -19,11 +19,12 @@ export const DemoContent = () => (
     </div>
     <Container bgColor="black" py={9}>
       <Grid md={2} xl={3} xxl={4} gap="card" alignItems="center" justifyItems="center">
-        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" curve="tr">Ghost</CtaLink>
-        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" size="large" curve="tr-large">Ghost</CtaLink>
+        <CtaLink href="/about-test" variant="ghost" color="white" icon="chevron-right" animate="right" curve="tr">Ghost</CtaLink>
+        <CtaLink href="/about-test" variant="ghost" color="white" icon="chevron-right" animate="right" size="large" curve="tr-large">Ghost</CtaLink>
         <CtaLink
           href="/about-test"
           variant="ghost-swipe"
+          color="white"
           icon="arrow-right"
           curve="br"
         >
@@ -32,6 +33,7 @@ export const DemoContent = () => (
         <CtaLink
           href="/about-test"
           variant="ghost-swipe"
+          color="white"
           icon="arrow-right"
           size="large"
           curve="br-large"

--- a/src/components/Temporary/DemoContent.tsx
+++ b/src/components/Temporary/DemoContent.tsx
@@ -20,7 +20,7 @@ export const DemoContent = () => (
     <Container bgColor="black" py={9}>
       <Grid md={2} xl={3} xxl={4} gap="card" alignItems="center" justifyItems="center">
         <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" curve="tr">Ghost</CtaLink>
-        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" size="large" curve="tr">Ghost</CtaLink>
+        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" size="large" curve="tr-large">Ghost</CtaLink>
         <CtaLink
           href="/about-test"
           variant="ghost-swipe"
@@ -34,7 +34,7 @@ export const DemoContent = () => (
           variant="ghost-swipe"
           icon="arrow-right"
           size="large"
-          curve="br"
+          curve="br-large"
         >
           Ghost swipe
         </CtaLink>
@@ -53,7 +53,7 @@ export const DemoContent = () => (
           icon="arrow-right"
           animate="right"
           size="large"
-          curve="br"
+          curve="br-large"
         >
           Solid red
         </CtaLink>
@@ -62,7 +62,7 @@ export const DemoContent = () => (
     <Container bgColor="white" py={9}>
       <Grid md={2} xl={3} xxl={4} gap="card" alignItems="center" justifyItems="center">
         <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" color="black" curve="tr">Ghost</CtaLink>
-        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" color="black" curve="tr" size="large">Ghost</CtaLink>
+        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" color="black" curve="tr-large" size="large">Ghost</CtaLink>
         <CtaLink
           href="/about-test"
           variant="ghost-swipe"
@@ -79,7 +79,7 @@ export const DemoContent = () => (
           color="black"
           icon="chevron-right"
           animate="right"
-          curve="br"
+          curve="br-large"
           size="large"
         >
           Ghost swipe
@@ -98,7 +98,7 @@ export const DemoContent = () => (
           variant="solid"
           icon="arrow-right"
           animate="right"
-          curve="br"
+          curve="br-large"
           size="large"
         >
           Solid red

--- a/src/components/VerticalCard/StoryCard.tsx
+++ b/src/components/VerticalCard/StoryCard.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { VerticalCard, VerticalCardProps } from './VerticalCard';
+
+export type StoryCardProps = Omit<VerticalCardProps, 'ctaLabel' | 'ctaSrText'>;
+
+export const StoryCard = (props: StoryCardProps) => (
+  <VerticalCard {...props} />
+);

--- a/src/components/VerticalCard/ThemeCard.tsx
+++ b/src/components/VerticalCard/ThemeCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { VerticalCard, VerticalCardProps } from './VerticalCard';
 
-export type ThemeCardProps = Omit<VerticalCardProps, 'isSmallHeading'>;
+export type ThemeCardProps = Omit<VerticalCardProps, 'isSmallHeading' | 'taxonomy'>;
 
 export const ThemeCard = (props: ThemeCardProps) => (
   <VerticalCard {...props} isSmallHeading />

--- a/src/components/VerticalCard/ThemeCard.tsx
+++ b/src/components/VerticalCard/ThemeCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { VerticalCard, VerticalCardProps } from './VerticalCard';
 
-export type ThemeCardProps = Omit<VerticalCardProps, 'headingFont' | 'isSmallHeading'>;
+export type ThemeCardProps = Omit<VerticalCardProps, 'isSmallHeading'>;
 
 export const ThemeCard = (props: ThemeCardProps) => (
   <VerticalCard {...props} isSmallHeading />

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -4,9 +4,9 @@ export const root = 'su-relative su-z-10 sm:su-max-w-500 md:su-max-w-full su-mx-
 
 export const cardWrapper = 'su-relative su-group';
 
-export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none group-hover:su-rounded-br-[20rem] group-focus-within:su-rounded-br-[20rem] su-overflow-hidden';
+export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none su-overflow-hidden';
 
-export const image = 'su-object-cover su-w-full su-h-full';
+export const image = 'su-object-cover su-w-full su-h-full group-hover:su-scale-105 group-focus-within:su-scale-105 su-transition-transform';
 
 export const heading = (hasTabColor: boolean) => cnb('su-rs-mt-1 su-pr-18 su-rs-mb-neg1 su-text-current', {
   'su-border-l-[1.8rem] su-px-18': hasTabColor,

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -1,13 +1,23 @@
-export const root = 'su-group su-relative su-z-10 sm:su-max-w-500 md:su-max-w-full su-mx-auto';
+import { cnb } from 'cnbuilder';
+
+export const root = 'su-relative su-z-10 sm:su-max-w-500 md:su-max-w-full su-mx-auto';
+
+export const cardWrapper = 'su-relative su-group';
 
 export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none group-hover:su-rounded-br-[20rem] group-focus-within:su-rounded-br-[20rem] su-overflow-hidden';
 
 export const image = 'su-object-cover su-w-full su-h-full';
 
-export const heading = 'su-rs-mt-1 su-rs-mb-neg1 su-text-current';
+export const heading = (tabColor) => cnb('su-rs-mt-1 su-pr-18 su-rs-mb-neg1 su-text-current', {
+  'su-border-l-[1.8rem] su-px-18': tabColor,
+});
 
-export const headingLink = 'su-stretched-link su-no-underline !su-font-bold';
+export const headingLink = 'su-stretched-link su-no-underline !su-font-bold !su-leading-tight';
 
 export const tab = 'su-h-[2.4rem] su-w-70 su-rs-my-0';
 
 export const ctaLink = 'su-inline-block su-w-fit su-stretched-link su-rs-mt-1 hocus:su-bg-gradient-to-l hocus:su-from-transparent hocus:su-to-digital-red';
+
+export const taxonomy = 'su-list-unstyled su-space-x-12 su-ml-36';
+
+export const taxonomyItem = 'su-inline-block';

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -18,6 +18,6 @@ export const tab = 'su-h-[2.4rem] su-w-70 su-rs-my-0';
 
 export const ctaLink = 'su-inline-block su-w-fit su-stretched-link su-rs-mt-1 hocus:su-bg-gradient-to-l hocus:su-from-transparent hocus:su-to-digital-red';
 
-export const taxonomy = 'su-list-unstyled su-space-x-12 su-ml-36';
+export const taxonomy = 'su-list-unstyled su-leading-display children:su-mr-12 last:children:su-ml-0 su-ml-36';
 
-export const taxonomyItem = 'su-inline-block';
+export const taxonomyItem = 'su-inline-block su-mb-0';

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -8,8 +8,8 @@ export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-ro
 
 export const image = 'su-object-cover su-w-full su-h-full';
 
-export const heading = (tabColor) => cnb('su-rs-mt-1 su-pr-18 su-rs-mb-neg1 su-text-current', {
-  'su-border-l-[1.8rem] su-px-18': tabColor,
+export const heading = (hasTabColor: boolean) => cnb('su-rs-mt-1 su-pr-18 su-rs-mb-neg1 su-text-current', {
+  'su-border-l-[1.8rem] su-px-18': hasTabColor,
 });
 
 export const headingLink = 'su-stretched-link su-no-underline !su-font-bold !su-leading-tight';
@@ -18,6 +18,8 @@ export const tab = 'su-h-[2.4rem] su-w-70 su-rs-my-0';
 
 export const ctaLink = 'su-inline-block su-w-fit su-stretched-link su-rs-mt-1 hocus:su-bg-gradient-to-l hocus:su-from-transparent hocus:su-to-digital-red';
 
-export const taxonomy = 'su-list-unstyled su-leading-display children:su-mr-12 last:children:su-ml-0 su-ml-36 su-pr-18';
+export const taxonomy = (hasTabColor: boolean) => cnb('su-list-unstyled su-leading-display children:su-mr-12 last:children:su-ml-0 su-pr-18', {
+  'su-ml-36': hasTabColor,
+});
 
 export const taxonomyItem = 'su-inline-block su-mb-0';

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -4,7 +4,7 @@ export const root = 'su-relative su-z-10 sm:su-max-w-500 md:su-max-w-full su-mx-
 
 export const cardWrapper = 'su-relative su-group';
 
-export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-rounded-none su-overflow-hidden';
+export const imageWrapper = 'su-transition-all su-aspect-w-1 su-aspect-h-1 su-overflow-hidden';
 
 export const image = 'su-object-cover su-w-full su-h-full group-hover:su-scale-105 group-focus-within:su-scale-105 su-transition-transform';
 

--- a/src/components/VerticalCard/VerticalCard.styles.tsx
+++ b/src/components/VerticalCard/VerticalCard.styles.tsx
@@ -18,6 +18,6 @@ export const tab = 'su-h-[2.4rem] su-w-70 su-rs-my-0';
 
 export const ctaLink = 'su-inline-block su-w-fit su-stretched-link su-rs-mt-1 hocus:su-bg-gradient-to-l hocus:su-from-transparent hocus:su-to-digital-red';
 
-export const taxonomy = 'su-list-unstyled su-leading-display children:su-mr-12 last:children:su-ml-0 su-ml-36';
+export const taxonomy = 'su-list-unstyled su-leading-display children:su-mr-12 last:children:su-ml-0 su-ml-36 su-pr-18';
 
 export const taxonomyItem = 'su-inline-block su-mb-0';

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -99,9 +99,10 @@ export const VerticalCard = ({
           </CtaLink>
         )}
       </div>
+      {/* Display max 3 topic tags; TODO: Sort tags after clients decide on order */}
       {taxonomy?.length > 0 && (
         <ul className={styles.taxonomy(!!tabColor)}>
-          {taxonomy.map((item) => (
+          {taxonomy.slice(0, 3).map((item) => (
             <li key={item} className={styles.taxonomyItem}>
               <CtaLink href={`/topics/${slugify(item)}`} variant="storyCardTag">{item}</CtaLink>
             </li>

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -5,8 +5,9 @@ import { CtaLink } from '../Cta/CtaLink';
 import { Heading, HeadingType, Paragraph } from '../Typography';
 import { SbLinkType } from '../Storyblok/Storyblok.types';
 import { getProcessedImage } from '../../utilities/getProcessedImage';
-import * as styles from './VerticalCard.styles';
+import { slugify } from '../../utilities/slugify';
 import { accentBorderColors, AccentBorderColorType } from '../../utilities/datasource';
+import * as styles from './VerticalCard.styles';
 
 /**
  * Currently, both Theme Card and Story Card use this component.
@@ -19,7 +20,6 @@ export type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
   body?: string;
   imageSrc?: string;
   imageFocus?: string;
-  alt?: string;
   tabColor?: AccentBorderColorType;
   ctaLabel?: string;
   ctaSrText?: string;
@@ -103,7 +103,7 @@ export const VerticalCard = ({
         <ul className={styles.taxonomy}>
           {taxonomy.map((item) => (
             <li key={item} className={styles.taxonomyItem}>
-              <CtaLink href={`/tag/${item}`} variant="storyCardTag">{item}</CtaLink>
+              <CtaLink href={`/topics/${slugify(item)}`} variant="storyCardTag">{item}</CtaLink>
             </li>
           ))}
         </ul>

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -103,7 +103,7 @@ export const VerticalCard = ({
         <ul className={styles.taxonomy}>
           {taxonomy.map((item) => (
             <li key={item} className={styles.taxonomyItem}>
-              <CtaLink href={`tag/${item}`} variant="storyCardTag">{item}</CtaLink>
+              <CtaLink href={`/tag/${item}`} variant="storyCardTag">{item}</CtaLink>
             </li>
           ))}
         </ul>

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -6,22 +6,26 @@ import { Heading, HeadingType, Paragraph } from '../Typography';
 import { SbLinkType } from '../Storyblok/Storyblok.types';
 import { getProcessedImage } from '../../utilities/getProcessedImage';
 import * as styles from './VerticalCard.styles';
-import { accentBgColors, AccentBgColorType } from '../../utilities/datasource';
+import { accentBorderColors, AccentBorderColorType } from '../../utilities/datasource';
+
+/**
+ * Currently, both Theme Card and Story Card use this component.
+ */
 
 export type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;
   headingLevel?: HeadingType;
-  headingFont?: 'serif' | 'druk';
   isSmallHeading?: boolean;
   body?: string;
   imageSrc?: string;
   imageFocus?: string;
   alt?: string;
-  tabColor?: AccentBgColorType;
+  tabColor?: AccentBorderColorType;
   ctaLabel?: string;
   ctaSrText?: string;
   href?: string;
   link?: SbLinkType;
+  taxonomy?: string[];
   animation?: AnimationType;
   delay?: number;
 };
@@ -29,7 +33,6 @@ export type VerticalCardProps = HTMLAttributes<HTMLDivElement> & {
 export const VerticalCard = ({
   heading,
   headingLevel = 'h3',
-  headingFont = 'serif',
   isSmallHeading,
   body,
   imageSrc,
@@ -39,6 +42,7 @@ export const VerticalCard = ({
   ctaSrText,
   link,
   href,
+  taxonomy,
   animation = 'none',
   delay,
   className,
@@ -49,50 +53,60 @@ export const VerticalCard = ({
       className={cnb(styles.root, className)}
       {...props}
     >
-      {imageSrc && (
-        <div className={styles.imageWrapper}>
-          <img
-            alt=""
-            src={getProcessedImage(imageSrc, '600x600', imageFocus)}
-            className={styles.image}
-          />
-        </div>
-      )}
-      {heading && (
-        <Heading
-          as={headingLevel}
-          font={headingFont}
-          size={isSmallHeading ? 3 : 4}
-          leading="tight"
-          className={styles.heading}
-        >
-          {(!ctaLabel && (link || href))
-            ? (
-              <CtaLink sbLink={link} href={href} className={styles.headingLink}>
-                {heading}
-              </CtaLink>
-            ) : heading}
-        </Heading>
-      )}
-      {tabColor && (
+      <div className={styles.cardWrapper}>
+        {imageSrc && (
+          <div className={styles.imageWrapper}>
+            <img
+              alt=""
+              src={getProcessedImage(imageSrc, '600x600', imageFocus)}
+              className={styles.image}
+            />
+          </div>
+        )}
+        {heading && (
+          <Heading
+            as={headingLevel}
+            size={isSmallHeading ? 3 : 4}
+            leading="tight"
+            className={cnb(styles.heading(tabColor), accentBorderColors[tabColor])}
+          >
+            {(!ctaLabel && (link || href))
+              ? (
+                <CtaLink sbLink={link} href={href} className={styles.headingLink}>
+                  {heading}
+                </CtaLink>
+              ) : heading}
+          </Heading>
+        )}
+        {/* {tabColor && (
         <div className={cnb(styles.tab, accentBgColors[tabColor])} />
-      )}
-      {body && (
-        <Paragraph variant="card" noMargin>{body}</Paragraph>
-      )}
-      {ctaLabel && (link || href) && (
-        <CtaLink
-          variant="solid"
-          curve="br"
-          icon="arrow-right"
-          animate="right"
-          srText={ctaSrText}
-          sbLink={link}
-          href={href}
-          className={styles.ctaLink}
-        >
-          {ctaLabel}
-        </CtaLink>
+      )} */}
+        {body && (
+          <Paragraph variant="card" noMargin>{body}</Paragraph>
+        )}
+        {ctaLabel && (link || href) && (
+          <CtaLink
+            variant="solid"
+            curve="br"
+            icon="arrow-right"
+            animate="right"
+            srText={ctaSrText}
+            sbLink={link}
+            href={href}
+            className={styles.ctaLink}
+          >
+            {ctaLabel}
+          </CtaLink>
+        )}
+      </div>
+      {taxonomy?.length > 0 && (
+        <ul className={styles.taxonomy}>
+          {taxonomy.map((item) => (
+            <li key={item} className={styles.taxonomyItem}>
+              <CtaLink href={`tag/${item}`} variant="storyCardTag">{item}</CtaLink>
+            </li>
+          ))}
+        </ul>
       )}
     </article>
   </AnimateInView>

--- a/src/components/VerticalCard/VerticalCard.tsx
+++ b/src/components/VerticalCard/VerticalCard.tsx
@@ -68,7 +68,7 @@ export const VerticalCard = ({
             as={headingLevel}
             size={isSmallHeading ? 3 : 4}
             leading="tight"
-            className={cnb(styles.heading(tabColor), accentBorderColors[tabColor])}
+            className={cnb(styles.heading(!!tabColor), accentBorderColors[tabColor])}
           >
             {(!ctaLabel && (link || href))
               ? (
@@ -100,7 +100,7 @@ export const VerticalCard = ({
         )}
       </div>
       {taxonomy?.length > 0 && (
-        <ul className={styles.taxonomy}>
+        <ul className={styles.taxonomy(!!tabColor)}>
           {taxonomy.map((item) => (
             <li key={item} className={styles.taxonomyItem}>
               <CtaLink href={`/topics/${slugify(item)}`} variant="storyCardTag">{item}</CtaLink>

--- a/src/components/VerticalCard/index.ts
+++ b/src/components/VerticalCard/index.ts
@@ -1,3 +1,4 @@
+export * from './StoryCard';
 export * from './ThemeCard';
 export * from './VerticalCard';
 export * from './VerticalCard.styles';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,7 +18,9 @@ import { Banner } from '../components/Banner';
 
 const IndexPage = ({ data }) => {
   let story = data.storyblokEntry;
-  story = useStoryblokState(story);
+  story = useStoryblokState(story, {
+    resolveRelations: ['sbStoryCard.storyPicker'],
+  });
   const blok = story.content;
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import { PageHead } from '../components/PageHead';
 import { CreateBloks } from '../components/CreateBloks';
 import { Layout } from '../components/Layout';
 import { Banner } from '../components/Banner';
+import { resolveRelations } from '../utilities/resolveRelations';
 
 /**
  * This is the layout for the homepage
@@ -18,9 +19,7 @@ import { Banner } from '../components/Banner';
 
 const IndexPage = ({ data }) => {
   let story = data.storyblokEntry;
-  story = useStoryblokState(story, {
-    resolveRelations: ['sbStoryCard.storyPicker'],
-  });
+  story = useStoryblokState(story, { resolveRelations });
   const blok = story.content;
 
   return (

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -7,6 +7,7 @@ import { CreateBloks } from '../components/CreateBloks';
 import { PageHead } from '../components/PageHead';
 import { Layout } from '../components/Layout';
 import { DemoContent } from '../components/Temporary/DemoContent';
+import { resolveRelations } from '../utilities/resolveRelations';
 
 type DataProps = {
   storyblokEntry: SbGatsbyStory;
@@ -16,9 +17,7 @@ const StoryblokEntry: React.FC<PageProps<DataProps>> = ({
   data,
 }) => {
   let story = data.storyblokEntry;
-  story = useStoryblokState(story, {
-    resolveRelations: ['sbStoryCard.storyPicker'],
-  });
+  story = useStoryblokState(story, { resolveRelations });
   const blok = story.content;
 
   return (

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -24,9 +24,9 @@ const StoryblokEntry: React.FC<PageProps<DataProps>> = ({
     <Layout>
       {/* Place holder hero below - going to extract into component */}
       <Hero heading={blok.title} />
-      <DemoContent />
       <CreateBloks blokSection={blok.hero} />
       <CreateBloks blokSection={blok.content} />
+      <DemoContent />
     </Layout>
   );
 };

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -16,7 +16,9 @@ const StoryblokEntry: React.FC<PageProps<DataProps>> = ({
   data,
 }) => {
   let story = data.storyblokEntry;
-  story = useStoryblokState(story);
+  story = useStoryblokState(story, {
+    resolveRelations: ['sbStoryCard.storyPicker'],
+  });
   const blok = story.content;
 
   return (

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -22,7 +22,7 @@ const StoryblokEntry: React.FC<PageProps<DataProps>> = ({
   return (
     <Layout>
       {/* Place holder hero below - going to extract into component */}
-      <Hero heading={story.name} />
+      <Hero heading={blok.title} />
       <DemoContent />
       <CreateBloks blokSection={blok.hero} />
       <CreateBloks blokSection={blok.content} />

--- a/src/utilities/resolveRelations.ts
+++ b/src/utilities/resolveRelations.ts
@@ -1,0 +1,8 @@
+/**
+ * Central place for all the Storyblok relations that we want to resolve
+ * It is used in gatsby-config.ts and page components in src/pages/
+ */
+
+export const resolveRelations = [
+  'sbStoryCard.storyPicker',
+];

--- a/src/utilities/routes.ts
+++ b/src/utilities/routes.ts
@@ -4,7 +4,7 @@
  */
 
 // Initiatives
-export const initiativesRoot = 'initiatives';
+export const initiativesRoot = '/initiatives';
 
 export const initiatives = {
   changingHumanExperience: {
@@ -70,7 +70,7 @@ export const initiatives = {
 };
 
 // Themes
-export const themesRoot = 'themes';
+export const themesRoot = '/themes';
 
 export const themes = {
   sustainingLife: {

--- a/src/utilities/slugify.ts
+++ b/src/utilities/slugify.ts
@@ -1,0 +1,9 @@
+/**
+ * @param str Any string
+ * @returns A string that can be used as a URL slug or id
+ */
+export const slugify = (str = '') => str
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/i, '-')
+  .replace(/^-/, '')
+  .replace(/-$/, '');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Story cards that supports story picking (referencing published story) and manual field entering (card title, image, link)
- Strategy for resolving Storyblok relations using the new method
- Story card style updates
- Grid gap options added

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-81--giving-campaign.netlify.app/about-test/ and look at the story card section
![Screenshot 2023-06-14 at 2 53 24 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/5300d232-99d0-4600-9c41-68f361742929)

2. The 1st 3 cards are currently referencing Storyblok published stories. The 4th one with the handsome cat is the manual one (no manual taxonomy at the moment), also, heading is set to use the larger font size

![Screenshot 2023-06-14 at 3 09 01 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/6c57c4f1-575e-482b-9051-4f8bd7285be8)

3. Scroll further down to see light mode
![Screenshot 2023-06-15 at 11 05 45 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/771adf12-4981-44b0-bff2-d4256dcca9a2)


3. Look at code


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-127, GIVCAMP-130