### PR TITLE
GIVCAMP-134 | Allow double curved CTAs and add white ghost with dark overlay variant; split poster CTA group align fixup

### DIFF
--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -25,19 +25,28 @@ export const ctaColors = {
   'digital-red': 'su-text-digital-red',
 };
 
+const tlBase = 'su-rounded-tl-[1.6rem] lg:su-rounded-tl-[2rem]';
+const trBase = 'su-rounded-tr-[1.6rem] lg:su-rounded-tr-[2rem]';
+const blBase = 'su-rounded-bl-[1.6rem] lg:su-rounded-bl-[2rem]';
+const brBase = 'su-rounded-br-[1.6rem] lg:su-rounded-br-[2rem]';
+const tlLargeBase = 'su-rounded-tl-[2rem] lg:su-rounded-tl-[3rem]';
+const trLargeBase = 'su-rounded-tr-[2rem] lg:su-rounded-tr-[3rem]';
+const blLargeBase = 'su-rounded-bl-[2rem] lg:su-rounded-bl-[3rem]';
+const brLargeBase = 'su-rounded-br-[2rem] lg:su-rounded-br-[3rem]';
+
 export const ctaCurves = {
-  tl: 'su-rounded-tl-[1.6rem] xl:su-rounded-tl-[2rem]',
-  'tl-large': 'su-rounded-tl-[2rem] xl:su-rounded-tl-[3rem]',
-  tr: 'su-rounded-tr-[1.6rem] xl:su-rounded-tr-[2rem]',
-  'tr-large': 'su-rounded-tr-[2rem] xl:su-rounded-tr-[3rem]',
-  bl: 'su-rounded-bl-[1.6rem] xl:su-rounded-bl-[2rem]',
-  'bl-large': 'su-rounded-bl-[2rem] xl:su-rounded-bl-[3rem]',
-  br: 'su-rounded-br-[1.6rem] xl:su-rounded-br-[2rem]',
-  'br-large': 'su-rounded-br-[2rem] xl:su-rounded-br-[3rem]',
-  tlbr: 'su-rounded-tl-[1.6rem] xl:su-rounded-tl-[2rem] su-rounded-br-[1.6rem] xl:su-rounded-br-[2rem]',
-  'tlbr-large': 'su-rounded-tl-[2rem] xl:su-rounded-tl-[3rem] su-rounded-br-[2rem] xl:su-rounded-br-[3rem]',
-  trbl: 'su-rounded-tr-[1.6rem] xl:su-rounded-tr-[2rem] su-rounded-bl-[1.6rem] xl:su-rounded-bl-[2rem]',
-  'trbl-large': 'su-rounded-tr-[2rem] xl:su-rounded-tr-[3rem] su-rounded-bl-[2rem] xl:su-rounded-bl-[3rem]',
+  tl: tlBase,
+  'tl-large': tlLargeBase,
+  tr: trBase,
+  'tr-large': trLargeBase,
+  bl: blBase,
+  'bl-large': blLargeBase,
+  br: brBase,
+  'br-large': brLargeBase,
+  tlbr: `${tlBase} ${brBase}`,
+  'tlbr-large': `${tlLargeBase} ${brLargeBase}`,
+  trbl: `${trBase} ${blBase}`,
+  'trbl-large': `${trLargeBase} ${blLargeBase}`,
 };
 
 export const ctaSizes = {

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -1,11 +1,14 @@
 export const cta = 'su-group hocus:su-underline su-transition-all';
 
+const ghostSwipeBase = 'su-relative su-z-[10] su-inline-block su-no-underline hocus:su-no-underline su-font-normal su-leading-display hocus:su-text-white su-border-2 su-border-current hocus:su-border-digital-red-light focus-visible:su-outline-none after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-digital-red after:su-to-cardinal-red after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden';
+
 export const ctaVariants = {
   solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red su-text-white hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/80 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
   inline: 'su-inline su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   inlineDark: 'su-inline su-text-digital-red-xlight hocus:su-text-white su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   ghost: 'su-inline-block su-font-normal su-leading-display su-bg-transparent hocus:su-text-current su-border-2 su-border-current focus-visible:su-outline-none su-underline-offset-4 su-decoration-transparent hocus:su-decoration-current',
-  'ghost-swipe': 'su-relative su-z-[10] su-inline-block su-no-underline hocus:su-no-underline su-font-normal su-leading-display su-bg-transparent hocus:su-text-white su-border-2 su-border-current hocus:su-border-digital-red-light focus-visible:su-outline-none after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-digital-red after:su-to-cardinal-red after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
+  'ghost-swipe': `${ghostSwipeBase} su-bg-transparent`,
+  'ghost-swipe-overlay': `${ghostSwipeBase} su-bg-black/60`, // Use for split poster over images
   link: 'su-font-normal su-decoration-transparent hocus:su-decoration-current su-leading-display su-text-current hocus:su-text-current hocus:su-decoration-2 focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-outline-none focus-visible:su-rounded su-underline-offset-4',
   back: 'su-inline-block su-font-normal su-no-underline su-leading-none group-hocus:su-underline su-text-black hocus:su-text-lagunita focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-ring-offset-4 focus:su-outline-none su-rounded-[1px]',
   mainNav: 'su-inline-block su-border-2 su-font-normal su-decoration-transparent su-text-white hocus:su-border-white hocus-visible:su-bg-sapphire/50 hocus:su-text-white',
@@ -54,6 +57,7 @@ export const ctaSizeMap = {
   solid: 'default',
   ghost: 'default',
   'ghost-swipe': 'default',
+  'ghost-swipe-overlay': 'default',
   mainNav: 'mainNav',
   link: 'unset',
   dismiss: 'dismiss',

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -31,6 +31,10 @@ export const ctaCurves = {
   'bl-large': 'su-rounded-bl-[2rem] xl:su-rounded-bl-[3rem]',
   br: 'su-rounded-br-[1.6rem] xl:su-rounded-br-[2rem]',
   'br-large': 'su-rounded-br-[2rem] xl:su-rounded-br-[3rem]',
+  tlbr: 'su-rounded-tl-[1.6rem] xl:su-rounded-tl-[2rem] su-rounded-br-[1.6rem] xl:su-rounded-br-[2rem]',
+  'tlbr-large': 'su-rounded-tl-[2rem] xl:su-rounded-tl-[3rem] su-rounded-br-[2rem] xl:su-rounded-br-[3rem]',
+  trbl: 'su-rounded-tr-[1.6rem] xl:su-rounded-tr-[2rem] su-rounded-bl-[1.6rem] xl:su-rounded-bl-[2rem]',
+  'trbl-large': 'su-rounded-tr-[2rem] xl:su-rounded-tr-[3rem] su-rounded-bl-[2rem] xl:su-rounded-bl-[3rem]',
 };
 
 export const ctaSizes = {

--- a/src/components/ImageOverlay.tsx
+++ b/src/components/ImageOverlay.tsx
@@ -5,7 +5,7 @@ export const overlays = {
   'black-30': 'su-bg-black-true/30',
   'black-40': 'su-bg-black-true/40',
   'black-60': 'su-bg-black-true/60',
-  'black-gradient': 'su-bg-gradient-to-b su-from-transparent su-via-black-true/20 su-to-black-true/70',
+  'black-gradient': 'su-bg-gradient-to-b su-from-transparent su-via-black-true/20 su-to-black-true/50',
 };
 export type OverlayType = keyof typeof overlays | '';
 

--- a/src/components/SplitPoster/SplitPoster.tsx
+++ b/src/components/SplitPoster/SplitPoster.tsx
@@ -79,7 +79,7 @@ export const SplitPoster = ({
             bgColor={bgColorLeft}
             className={styles.posterContentLeft}
           >
-            <FlexBox direction="col" className={styles.ctaWrapper}>
+            <FlexBox direction="col" alignItems="end" className={styles.ctaWrapper}>
               {ctaLeft}
             </FlexBox>
           </PosterContent>
@@ -96,7 +96,7 @@ export const SplitPoster = ({
             bgColor={bgColorRight}
             className={styles.posterContentRight}
           >
-            <FlexBox direction="col" className={styles.ctaWrapper}>
+            <FlexBox direction="col" alignItems="start" className={styles.ctaWrapper}>
               {ctaRight}
             </FlexBox>
           </PosterContent>

--- a/src/components/Temporary/DemoContent.tsx
+++ b/src/components/Temporary/DemoContent.tsx
@@ -19,7 +19,7 @@ export const DemoContent = () => (
     </div>
     <Container bgColor="black" py={9}>
       <Grid md={2} xl={3} xxl={4} gap="card" alignItems="center" justifyItems="center">
-        <CtaLink href="/about-test" variant="ghost" color="white" icon="chevron-right" animate="right" curve="tr">Ghost</CtaLink>
+        <CtaLink href="/about-test" variant="ghost" color="white" icon="chevron-right" animate="right" curve="trbl">Ghost</CtaLink>
         <CtaLink href="/about-test" variant="ghost" color="white" icon="chevron-right" animate="right" size="large" curve="tr-large">Ghost</CtaLink>
         <CtaLink
           href="/about-test"
@@ -36,7 +36,7 @@ export const DemoContent = () => (
           color="white"
           icon="arrow-right"
           size="large"
-          curve="br-large"
+          curve="tlbr-large"
         >
           Ghost swipe
         </CtaLink>
@@ -45,7 +45,7 @@ export const DemoContent = () => (
           variant="solid"
           icon="arrow-right"
           animate="right"
-          curve="br"
+          curve="tlbr"
         >
           Solid red
         </CtaLink>
@@ -63,7 +63,7 @@ export const DemoContent = () => (
     </Container>
     <Container bgColor="white" py={9}>
       <Grid md={2} xl={3} xxl={4} gap="card" alignItems="center" justifyItems="center">
-        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" color="black" curve="tr">Ghost</CtaLink>
+        <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" color="black" curve="trbl">Ghost</CtaLink>
         <CtaLink href="/about-test" variant="ghost" icon="chevron-right" animate="right" color="black" curve="tr-large" size="large">Ghost</CtaLink>
         <CtaLink
           href="/about-test"
@@ -100,7 +100,7 @@ export const DemoContent = () => (
           variant="solid"
           icon="arrow-right"
           animate="right"
-          curve="br-large"
+          curve="trbl-large"
           size="large"
         >
           Solid red


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Add option to have 2 curves on opposite corners for CTAs (options added in Storyblok also), ie, top left + bottom right, or top right + botton left (in addition to the current options to have 1 curved corner or no curved corners at all)
- Play with the idea to add a variant of white ghost button with a translucent black overlay. This helps with text contrast over images, eg, in the split posters.
- Fix flex alignment when there are multiple CTAS so they don't stretch to the same width

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to 
https://deploy-preview-83--giving-campaign.netlify.app/about-test/

2. Scroll down to see the 1st split poster with a button with 2 curves

![Screenshot 2023-06-15 at 5 35 33 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/d2cb1da9-228e-4c57-956e-293d807fc4e5)

2. Look at the split poster with ghost button over images, see the variant with black overlay
![Screenshot 2023-06-15 at 5 31 00 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/2befdbc4-0eda-4b71-ae07-e22847900594)

4. Scroll further down to see the demo CTA sections, eg, 
![Screenshot 2023-06-15 at 5 31 24 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/996c114b-bf2b-4867-9d1e-d3418292026e)



# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-134
