### PR TITLE
GIVCAMP-117 | Masthead that becomes visible when scrolling up

### DIFF
--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -2,6 +2,8 @@ export const cta = 'su-group hocus:su-underline su-transition-all';
 
 const ghostSwipeBase = 'su-relative su-z-[10] su-inline-block su-no-underline hocus:su-no-underline su-font-normal su-leading-display hocus:su-text-white su-border-2 su-border-current hocus:su-border-digital-red-light focus-visible:su-outline-none after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-digital-red after:su-to-cardinal-red after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden';
 
+const mainNavBase = 'su-group su-inline-block su-border-2 su-font-normal su-decoration-transparent su-decoration-1 su-underline-offset-4 su-text-white hocus:su-text-white hocus:su-decoration-white hocus:su-ring-1 hocus:su-ring-inset hocus:su-ring-white';
+
 export const ctaVariants = {
   solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red su-text-white hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/80 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',
   inline: 'su-inline su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
@@ -11,7 +13,8 @@ export const ctaVariants = {
   'ghost-swipe-overlay': `${ghostSwipeBase} su-bg-black/60`, // Use for split poster over images
   link: 'su-font-normal su-decoration-transparent hocus:su-decoration-current su-leading-display su-text-current hocus:su-text-current hocus:su-decoration-2 focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-outline-none focus-visible:su-rounded su-underline-offset-4',
   back: 'su-inline-block su-font-normal su-no-underline su-leading-none group-hocus:su-underline su-text-black hocus:su-text-lagunita focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-ring-offset-4 focus:su-outline-none su-rounded-[1px]',
-  mainNav: 'su-inline-block su-border-2 su-font-normal su-decoration-transparent su-text-white hocus:su-border-white hocus-visible:su-bg-sapphire/50 hocus:su-text-white',
+  mainNav: `${mainNavBase} hocus-visible:su-bg-sapphire/50`, // Main nav buttons at the top of the page
+  mainNavBlack: `${mainNavBase} su-bg-gc-black hocus-visible:su-bg-digital-red`, // Main nav buttons when scrolling up
   close: 'su-inline-block su-font-semibold su-leading-none su-text-lagunita hocus:su-text-lagunita-dark focus:su-outline-none',
   'close-x': 'su-leading-none',
   dismiss: 'su-inline-block su-font-bold su-uppercase su-tracking-widest su-leading-none su-text-gc-black hocus:su-text-gc-black focus:su-outline-none',
@@ -68,6 +71,7 @@ export const ctaSizeMap = {
   'ghost-swipe': 'default',
   'ghost-swipe-overlay': 'default',
   mainNav: 'mainNav',
+  mainNavBlack: 'mainNav',
   link: 'unset',
   dismiss: 'dismiss',
   close: 'close',

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -55,7 +55,7 @@ export const ctaCurves = {
 export const ctaSizes = {
   default: 'su-pt-9 su-pb-10 su-pl-[2.2rem] su-pr-20 lg:su-pt-10 lg:su-pb-11 su-text-16 md:su-text-18 xl:su-text-20',
   large: 'su-pl-[2.2rem] su-pr-20 su-pt-10 su-pb-11 lg:su-pr-[3.4rem] lg:su-pl-40 lg:su-pt-20 lg:su-pb-[2.2rem] su-text-18 md:su-text-20 xl:su-text-24',
-  mainNav: 'su-text-16 su-px-14 su-py-10 lg:su-px-[2.4rem] lg:su-pt-18 lg:su-pb-19 lg:su-text-20',
+  mainNav: 'su-text-14 su-px-10 su-pt-8 su-pb-9 lg:su-px-[2.4rem] lg:su-pt-18 lg:su-pb-19 lg:su-text-20',
   'footer-featured': 'su-ma-intro',
   card: 'su-ma-card',
   back: 'su-text-16',

--- a/src/components/Homepage/FindPurposeSection.tsx
+++ b/src/components/Homepage/FindPurposeSection.tsx
@@ -5,7 +5,7 @@ import { AnimateInView } from '../Animate';
 import { Triangle } from '../Shapes';
 
 export const FindPurposeSection = ({ children }) => (
-  <Container width="full" bgColor="white" py={9} className="su-relative">
+  <Container width="full" bgColor="white" py={9} className="su-relative su-overflow-hidden">
     <Container>
       <AnimateInView duration={0.6} animation="slideUp">
         <Heading size="splash" font="druk" className="su-max-w-900" leading="none">

--- a/src/components/Homepage/HomepageHero.tsx
+++ b/src/components/Homepage/HomepageHero.tsx
@@ -57,7 +57,7 @@ export const HomepageHero = () => {
   const onPurposeY = useTransform(onPurposeSpring, [0, 1], ['0%', '10%']);
 
   return (
-    <div ref={heroRef} className="su-relative su-w-full su-bg-gc-sky">
+    <div ref={heroRef} className="su-relative su-w-full su-bg-gc-sky su-overflow-hidden">
       <div>
         <Container className="su-h-100 md:su-h-200" />
         <div className="su-relative su-w-full su-bg-gc-sky su--mb-1 2xl:su-max-h-900 3xl:su-overflow-hidden">

--- a/src/components/Homepage/Intro.tsx
+++ b/src/components/Homepage/Intro.tsx
@@ -39,7 +39,7 @@ export const Intro = ({ text }: IntroProps) => {
             style={{ x: prefersReduceMotion ? '0' : bracketPosition, willChange }}
           >
             <Bracket
-              className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full"
+              className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full children:!su-text-lime"
               curveClassName="su-h-[7vw] 2xl:su-h-[10.5rem]"
             />
           </m.div>
@@ -57,7 +57,7 @@ export const Intro = ({ text }: IntroProps) => {
           >
             <Bracket
               isClose
-              className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full"
+              className="su-w-[10vw] 2xl:su-w-[15rem] su-h-full children:!su-text-lavender"
               curveClassName="su-h-[7vw] 2xl:su-h-[10.5rem]"
             />
           </m.div>

--- a/src/components/Homepage/ProgressSection.tsx
+++ b/src/components/Homepage/ProgressSection.tsx
@@ -24,7 +24,7 @@ export const ProgressSection = ({ bgImage, children }: ProgressSectionProps) => 
   });
 
   return (
-    <Container width="full" bgColor="black" pb={10} className="su-relative su--mt-100">
+    <Container width="full" bgColor="black" pb={10} className="su-relative su--mt-100 su-overflow-hidden">
       <div
         className="su-relative su-pb-[7vw] su-bg-black-true"
         style={{ background: `url('${bg}') center center / contain no-repeat` }}

--- a/src/components/Homepage/ThemeSection.tsx
+++ b/src/components/Homepage/ThemeSection.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { cnb } from 'cnbuilder';
 import {
-  m, useScroll, useSpring, useTransform, SpringOptions,
+  m, useScroll, useSpring, useTransform, SpringOptions, useWillChange,
 } from 'framer-motion';
 import { Container } from '../Container';
 import { Grid, GridAlternating } from '../Grid';
@@ -34,6 +34,7 @@ export const ThemeSection = ({
     damping: 30,
     restDelta: 0.001,
   };
+  const willChange = useWillChange();
 
   const { scrollYProgress } = useScroll({
     target: containerRef,
@@ -147,13 +148,13 @@ export const ThemeSection = ({
           <div className="su-max-w-full su-overflow-hidden">
             <m.div
               className="su-h-2 su-bg-white su-origin-left su-mt-300"
-              style={{ scaleX: rightLineSpring }}
+              style={{ scaleX: rightLineSpring, willChange }}
             />
           </div>
           <div className="su-max-w-full su-overflow-hidden">
             <m.div
               className="su-h-2 su-bg-white su-origin-right su-mt-200"
-              style={{ scaleX: leftLineSpring }}
+              style={{ scaleX: leftLineSpring, willChange }}
             />
           </div>
           <div className="su-max-w-full su-overflow-hidden su-mt-300 3xl:su-mt-100">
@@ -170,7 +171,7 @@ export const ThemeSection = ({
         </Grid>
         <div ref={containerRef}>
           <GridAlternating py={7} addCenterLine gridCellStyle={{ marginBottom: spacing }}>
-            <m.div style={{ height: heightWrapper, marginBottom: shiftUp }} className="su-overflow-hidden">
+            <m.div style={{ height: heightWrapper, marginBottom: shiftUp, willChange }} className="su-overflow-hidden">
               <FlexBox direction="col" alignItems="center" className="su-w-fit su-mr-0 su-ml-auto">
                 <Heading as="h3" font="druk" align="right" className="su-mb-01em su-text-[8rem]">
                   Discovery
@@ -193,7 +194,7 @@ export const ThemeSection = ({
                 <CreateBloks blokSection={themeCardDiscovery} />
               </m.div>
             </m.div>
-            <m.div style={{ height: heightWrapper }} className="su-overflow-hidden">
+            <m.div style={{ height: heightWrapper, willChange }} className="su-overflow-hidden">
               <FlexBox direction="col" alignItems="center" className="su-w-fit su-ml-0 su-mr-auto">
                 <Heading as="h3" font="druk" className="su-mb-01em su-text-[8rem]">
                   Citizenry
@@ -206,17 +207,18 @@ export const ThemeSection = ({
                     borderTopColor: redToPoppy,
                     borderLeftColor: transparentToPoppy,
                     borderRightColor: transparentToPoppy,
+                    willChange,
                   }}
                 />
               </FlexBox>
               <m.div
-                style={{ opacity: scrollYProgress, scale: zoom }}
+                style={{ opacity: scrollYProgress, scale: zoom, willChange }}
                 className="su-origin-top-left"
               >
                 <CreateBloks blokSection={themeCardCitizen} />
               </m.div>
             </m.div>
-            <m.div style={{ height: heightWrapper, marginBottom: shiftUp }} className="su-overflow-hidden">
+            <m.div style={{ height: heightWrapper, marginBottom: shiftUp, willChange }} className="su-overflow-hidden">
               <FlexBox direction="col" alignItems="center" className="su-w-fit su-mr-0 su-ml-auto">
                 <Heading as="h3" font="druk" align="right" className="su-mb-01em su-text-[8rem]">
                   Acceleration
@@ -229,17 +231,18 @@ export const ThemeSection = ({
                     borderTopColor: redToPeriwinkle,
                     borderLeftColor: transparentToPeriwinkle,
                     borderRightColor: transparentToPeriwinkle,
+                    willChange,
                   }}
                 />
               </FlexBox>
               <m.div
-                style={{ opacity: scrollYProgress, scale: zoom }}
+                style={{ opacity: scrollYProgress, scale: zoom, willChange }}
                 className="su-origin-top-right"
               >
                 <CreateBloks blokSection={themeCardAcceleration} />
               </m.div>
             </m.div>
-            <m.div style={{ height: heightWrapper }} className="su-overflow-hidden">
+            <m.div style={{ height: heightWrapper, willChange }} className="su-overflow-hidden">
               <FlexBox direction="col" alignItems="center" className="su-w-fit su-ml-0 su-mr-auto">
                 <Heading as="h3" font="druk" className="su-mb-01em su-text-[8rem]">
                   Our planet
@@ -252,11 +255,12 @@ export const ThemeSection = ({
                     borderTopColor: redToRobinsEgg,
                     borderLeftColor: transparentToRobinsEgg,
                     borderRightColor: transparentToRobinsEgg,
+                    willChange,
                   }}
                 />
               </FlexBox>
               <m.div
-                style={{ opacity: scrollYProgress, scale: zoom }}
+                style={{ opacity: scrollYProgress, scale: zoom, willChange }}
                 className="su-origin-top-left"
               >
                 <CreateBloks blokSection={themeCardPlanet} />

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -1,3 +1,5 @@
+import { cnb } from 'cnbuilder';
+
 export type LogoVariantType = 'horizontal' | 'stacked';
 
 export const logoColors = {
@@ -6,4 +8,7 @@ export const logoColors = {
 };
 export type LogoColorType = keyof typeof logoColors;
 
-export const link = 'su-block su-no-underline focus-visible:su-outline-none focus-visible:su-ring-2 focus-visible:su-ring-white';
+export const link = (color: LogoColorType) => cnb('su-group su-block su-no-underline focus-visible:su-ring-2', {
+  'focus-visible:su-ring-gc-black': color === 'black',
+  'focus-visible:su-ring-white': color === 'white',
+});

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -1,7 +1,9 @@
-import { cnb } from 'cnbuilder';
-
 export type LogoVariantType = 'horizontal' | 'stacked';
 
-export type LogoColorType = 'black' | 'white';
+export const logoColors = {
+  black: 'su-fill-gc-black',
+  white: 'su-fill-white',
+};
+export type LogoColorType = keyof typeof logoColors;
 
 export const link = 'su-block su-no-underline focus-visible:su-outline-none focus-visible:su-ring-2 focus-visible:su-ring-white';

--- a/src/components/Logo/Logo.styles.ts
+++ b/src/components/Logo/Logo.styles.ts
@@ -5,28 +5,3 @@ export type LogoVariantType = 'horizontal' | 'stacked';
 export type LogoColorType = 'black' | 'white';
 
 export const link = 'su-block su-no-underline focus-visible:su-outline-none focus-visible:su-ring-2 focus-visible:su-ring-white';
-
-export const textWrapper = (variant: LogoVariantType) => cnb('su-flex', {
-  'su-h-[.82em]': variant === 'horizontal',
-});
-
-export const stanford = (variant: LogoVariantType) => cnb('su-leading-none', {
-  'su-text-vertical-lr su-rotate-180 su-text-[.46em] su-relative su-mt-01em': variant === 'stacked',
-  'su-text-[1.08em]': variant === 'horizontal',
-});
-
-export const onPurpose = (variant: LogoVariantType) => cnb('!su-tracking-normal', {
-  'su-ml-[0.15em] su-leading-[.7]': variant === 'horizontal',
-});
-
-export const iBefore = (variant: LogoVariantType) => (variant === 'stacked' ? 'su--ml-[0.025em]' : '');
-
-export const o = (variant: LogoVariantType) => (variant === 'stacked' ? 'su-inline-block su-scale-x-95 su-origin-left' : '');
-
-export const iAfter = 'su-inline-block su--ml-[0.28em] su-scale-x-75';
-
-export const n = 'su-inline-block su-scale-x-[0.65] su-origin-left su--ml-[0.148em]';
-
-export const onSpace = (variant: LogoVariantType) => (variant === 'horizontal' ? 'su-hidden' : '');
-
-export const purpose = (variant: LogoVariantType) => (variant === 'horizontal' ? 'su-ml-[0.14em]' : 'su-block su-mt-[.02em]');

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -12,14 +12,14 @@ type LogoProps = HTMLAttributes<HTMLElement> & {
 };
 
 export const Logo = ({
-  color = 'black',
+  color = 'white',
   variant = 'horizontal',
   isLink,
   className,
   ...rest
 }: LogoProps) => {
   const LogoText = (
-    <LogoHorizontal title="Stanford On Purpose" />
+    <LogoHorizontal color={color} />
   );
 
   const homeLink = useAddUtmParams('/');

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -30,7 +30,7 @@ export const Logo = ({
       <Link
         {...rest}
         to={homeLink}
-        className={cnb(styles.link, className)}
+        className={cnb(styles.link(color), className)}
       >
         {LogoText}
       </Link>

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -2,21 +2,18 @@ import React, { HTMLAttributes } from 'react';
 import { cnb } from 'cnbuilder';
 import { Link } from 'gatsby';
 import { LogoHorizontal } from './LogoHorizontal';
-import { FontSizeType } from '../Typography';
 import * as styles from './Logo.styles';
 import { useAddUtmParams } from '../../hooks/useAddUtmParams';
 
 type LogoProps = HTMLAttributes<HTMLElement> & {
   color?: styles.LogoColorType;
   variant?: styles.LogoVariantType;
-  size?: FontSizeType;
   isLink?: boolean;
 };
 
 export const Logo = ({
   color = 'black',
   variant = 'horizontal',
-  size = 5,
   isLink,
   className,
   ...rest

--- a/src/components/Logo/LogoHorizontal.tsx
+++ b/src/components/Logo/LogoHorizontal.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
+import { logoColors, LogoColorType } from './Logo.styles';
 
-export const LogoHorizontal = (props) => (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="17.95 17.4 299.08 34.04" {...props}>
+type LogoHorizontalProps = {
+  color?: LogoColorType;
+};
+
+export const LogoHorizontal = ({ color = 'white' }: LogoHorizontalProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="17.95 17.4 299.08 34.04"
+    className={logoColors[color]}
+  >
+    <title>Stanford On Purpose</title>
     <path
       d="M294.93 31.3l-4.2-2.96c-1.05-.74-1.32-1.31-1.32-2.35v-2.13h1.77v4.04h8.54v-3.41c0-3.9-2.04-7.04-8.36-7.04h-2.08c-6.19 0-8.84 3.27-8.84 7.79v1.68c0 3.63 1.37 6.41 4.51 8.63l4.2 2.96c1.41 1.07 1.55 1.68 1.55 3.1v2.66h-1.85v-1.22-4.01h-8.67v4.55c0 5.13 2.96 7.74 8.67 7.74h2.08c6.46 0 9.2-3.8 9.2-9.07v-1.72c0-4.34-1.46-6.64-5.18-9.25"
     />

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState, HTMLAttributes } from 'react';
-import { m, useScroll, useVelocity } from 'framer-motion';
+import {
+  m, useMotionValueEvent, useScroll, useVelocity,
+} from 'framer-motion';
 import { cnb } from 'cnbuilder';
 import { Container } from '../Container';
 import { FlexBox } from '../FlexBox';
@@ -18,33 +20,36 @@ export const Masthead = ({ className }: MastheadProps) => {
   const scrollVelocity = useVelocity(scrollY);
 
   const [isScrollingBack, setIsScrollingBack] = useState(false);
-  const [isAtTop, setIsAtTop] = useState(true); // true if the page is not scrolled or fully scrolled back
-  const [isInView, setIsInView] = useState(true);
+  const [isAtTop, setIsAtTop] = useState(true);
+  const [isVisible, setIsVisible] = useState(true);
 
-  useEffect(
-    () => scrollVelocity.onChange((latest) => {
-      if (latest > 0) {
-        setIsScrollingBack(false);
-        return;
-      }
-      if (latest < -threshold) {
-        setIsScrollingBack(true);
-      }
-    }),
-    [scrollVelocity],
-  );
+  useMotionValueEvent(scrollVelocity, 'change', (latest) => {
+    if (latest > 0) {
+      setIsScrollingBack(false);
+      return;
+    }
+    if (latest < -threshold) {
+      setIsScrollingBack(true);
+    }
+  });
 
-  useEffect(() => scrollY.onChange((latest) => setIsAtTop(latest <= 200)), [scrollY]);
+  useMotionValueEvent(scrollY, 'change', (latest) => {
+    setIsAtTop(latest <= 200);
+  });
 
-  useEffect(() => setIsInView(isScrollingBack || isAtTop), [
+  useEffect(() => setIsVisible(isScrollingBack || isAtTop), [
     isScrollingBack,
     isAtTop,
   ]);
 
   return (
     <m.div
-      className={cnb('su-bg-transparent su-w-full su-fixed su-top-0 su-z-[100] su-transition-all', !isAtTop && isScrollingBack ? 'su-bg-white' : '', className)}
-      animate={{ y: isInView ? 0 : -slideDistance, opacity: isInView ? 1 : 0 }}
+      className={cnb(
+        'su-w-full su-fixed su-top-0 su-z-[100] su-transition-all',
+        !isAtTop && isScrollingBack ? 'su-bg-white su-border-b su-border-b-black-20' : 'su-bg-transparent su-border-b-transparent',
+        className,
+      )}
+      animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
       transition={{ duration: 0.3, delay: 0.1, ease: 'easeInOut' }}
       style={{ height: slideDistance }}
     >
@@ -54,7 +59,11 @@ export const Masthead = ({ className }: MastheadProps) => {
           alignItems="center"
           className="su-rs-py-1"
         >
-          <Logo isLink className="su-w-160 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white" color={!isAtTop && isScrollingBack ? 'black' : 'white'} />
+          <Logo
+            isLink
+            className="su-w-160 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
+            color={!isAtTop && isScrollingBack ? 'black' : 'white'}
+          />
           <FlexBox alignItems="center">
             <CtaLink
               href={ood.give}

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -56,11 +56,11 @@ export const Masthead = ({ className }: MastheadProps) => {
       <FlexBox
         justifyContent="between"
         alignItems="center"
-        className="su-py-26 su-cc"
+        className="su-py-18 md:su-py-26 su-cc"
       >
         <Logo
           isLink
-          className="su-w-160 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
+          className="su-w-[17rem] sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
           color={!isAtTop && isScrollingBack ? 'black' : 'white'}
         />
         <FlexBox alignItems="center">

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -45,12 +45,12 @@ export const Masthead = ({ className }: MastheadProps) => {
   return (
     <m.div
       className={cnb(
-        'su-w-full su-fixed su-top-0 su-z-50',
+        'su-w-full su-fixed su-top-0 su-z-50 su-transition-colors',
         !isAtTop && isScrollingBack ? 'su-bg-white su-border-b su-border-b-black-20' : 'su-bg-transparent su-border-b-transparent',
         className,
       )}
       animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
-      transition={{ duration: 0.5, delay: 0.1, ease: 'easeInOut' }}
+      transition={{ duration: 0.4, delay: 0.1, ease: 'easeInOut' }}
       style={{ height: slideDistance, willChange }}
     >
       <FlexBox

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -12,7 +12,7 @@ import { HeroIcon } from '../HeroIcon';
 type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
 export const Masthead = ({ className }: MastheadProps) => {
-  const slideDistance = 102;
+  const slideDistance = 96;
   const threshold = 300;
 
   const { scrollY } = useScroll();
@@ -56,11 +56,11 @@ export const Masthead = ({ className }: MastheadProps) => {
       <FlexBox
         justifyContent="between"
         alignItems="center"
-        className={cnb('su-cc su-transition-all', !isAtTop ? 'su-py-18 lg:su-py-6' : 'su-py-18 md:su-py-26')}
+        className={cnb('su-cc su-transition-all su-py-18', !isAtTop ? 'lg:su-py-3' : 'md:su-py-26')}
       >
         <Logo
           isLink
-          className="su-w-[17rem] sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
+          className={cnb('su-w-[17rem] sm:su-w-[24rem] su-transition-all', isAtTop ? 'lg:su-w-[32rem]' : 'lg:su-w-[28rem]')}
           color={!isAtTop && isScrollingBack ? 'black' : 'white'}
         />
         <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'lg:su-scale-75')}>

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -67,17 +67,17 @@ export const Masthead = ({ className }: MastheadProps) => {
           <FlexBox alignItems="center">
             <CtaLink
               href={ood.give}
-              variant="mainNav"
+              variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
               className="su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem] su-mt-10 lg:su-mt-26"
             >
               Make a gift
             </CtaLink>
             <CtaButton
               onClick={() => alert('Hello world')}
-              variant="mainNav"
+              variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
               className="su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem] su--mt-10 lg:su--mt-26"
             >
-              <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32" />
+              <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32 group-hover:su-scale-y-75" />
             </CtaButton>
           </FlexBox>
         </FlexBox>

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -1,4 +1,5 @@
-import React, { HTMLAttributes } from 'react';
+import React, { useEffect, useState, HTMLAttributes } from 'react';
+import { m, useScroll, useVelocity } from 'framer-motion';
 import { cnb } from 'cnbuilder';
 import { Container } from '../Container';
 import { FlexBox } from '../FlexBox';
@@ -9,24 +10,69 @@ import { HeroIcon } from '../HeroIcon';
 
 type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
-export const Masthead = ({ className, ...props }: MastheadProps) => (
-  <div className={cnb('su-bg-transparent su-w-full su-absolute su-z-10', className)} {...props}>
-    <Container>
-      <FlexBox
-        justifyContent="between"
-        alignItems="center"
-        className="su-rs-py-4"
-      >
-        <Logo isLink className="su-w-200 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white" />
-        <FlexBox alignItems="center">
-          <CtaLink href={ood.give} variant="mainNav" className="su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem]">
-            Make a gift
-          </CtaLink>
-          <CtaButton onClick={() => alert('Hello world')} variant="mainNav" className="su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem] su--mt-20 lg:su--mt-36">
-            <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32" />
-          </CtaButton>
+export const Masthead = ({ className }: MastheadProps) => {
+  const slideDistance = 144;
+  const threshold = 200;
+
+  const { scrollY } = useScroll();
+  const scrollVelocity = useVelocity(scrollY);
+
+  const [isScrollingBack, setIsScrollingBack] = useState(false);
+  const [isAtTop, setIsAtTop] = useState(true); // true if the page is not scrolled or fully scrolled back
+  const [isInView, setIsInView] = useState(true);
+
+  useEffect(
+    () => scrollVelocity.onChange((latest) => {
+      if (latest > 0) {
+        setIsScrollingBack(false);
+        return;
+      }
+      if (latest < -threshold) {
+        setIsScrollingBack(true);
+      }
+    }),
+    [scrollVelocity],
+  );
+
+  useEffect(() => scrollY.onChange((latest) => setIsAtTop(latest <= 200)), [scrollY]);
+
+  useEffect(() => setIsInView(isScrollingBack || isAtTop), [
+    isScrollingBack,
+    isAtTop,
+  ]);
+
+  return (
+    <m.div
+      className={cnb('su-bg-transparent su-w-full su-fixed su-top-0 su-z-[100] su-transition-all', !isAtTop && isScrollingBack ? 'su-bg-white' : '', className)}
+      animate={{ y: isInView ? 0 : -slideDistance, opacity: isInView ? 1 : 0 }}
+      transition={{ duration: 0.3, delay: 0.1, ease: 'easeInOut' }}
+      style={{ height: slideDistance }}
+    >
+      <Container>
+        <FlexBox
+          justifyContent="between"
+          alignItems="center"
+          className="su-rs-py-1"
+        >
+          <Logo isLink className="su-w-160 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white" color={!isAtTop && isScrollingBack ? 'black' : 'white'} />
+          <FlexBox alignItems="center">
+            <CtaLink
+              href={ood.give}
+              variant="mainNav"
+              className="su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem] su-mt-10 lg:su-mt-26"
+            >
+              Make a gift
+            </CtaLink>
+            <CtaButton
+              onClick={() => alert('Hello world')}
+              variant="mainNav"
+              className="su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem] su--mt-10 lg:su--mt-26"
+            >
+              <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32" />
+            </CtaButton>
+          </FlexBox>
         </FlexBox>
-      </FlexBox>
-    </Container>
-  </div>
-);
+      </Container>
+    </m.div>
+  );
+};

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -33,7 +33,7 @@ export const Masthead = ({ className }: MastheadProps) => {
   });
 
   useMotionValueEvent(scrollY, 'change', (latest) => {
-    setIsAtTop(latest <= 0);
+    setIsAtTop(latest <= 200);
   });
 
   useEffect(() => setIsVisible(isScrollingBack || isAtTop), [
@@ -43,14 +43,15 @@ export const Masthead = ({ className }: MastheadProps) => {
 
   return (
     <m.div
-      className={cnb(
-        'su-w-full su-fixed su-top-0 su-z-50 su-transition-all',
-        !isAtTop && isScrollingBack ? 'su-bg-white su-border-b su-border-b-black-20' : 'su-bg-transparent su-border-b-transparent',
-        className,
-      )}
-      animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
+      className={cnb('su-w-full su-fixed su-top-0 su-z-50 su-transition-all su-border-b', className)}
+      animate={{
+        y: isVisible ? 0 : -slideDistance,
+        opacity: isVisible ? 1 : 0,
+        backgroundColor: isScrollingBack && !isAtTop ? 'rgba(255,255,255)' : 'rgba(255,255,255,0)',
+        borderBottomColor: isScrollingBack && !isAtTop ? 'rgba(0,0,0,0.1)' : 'rgba(0,0,0,0)',
+        height: isVisible ? slideDistance : 0,
+      }}
       transition={{ duration: 0.4, delay: 0.1, ease: 'easeInOut' }}
-      style={{ height: slideDistance }}
     >
       <FlexBox
         justifyContent="between"

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, HTMLAttributes } from 'react';
 import {
-  m, useMotionValueEvent, useScroll, useVelocity,
+  m, useMotionValueEvent, useScroll, useVelocity, useWillChange,
 } from 'framer-motion';
 import { cnb } from 'cnbuilder';
 import { FlexBox } from '../FlexBox';
@@ -17,6 +17,7 @@ export const Masthead = ({ className }: MastheadProps) => {
 
   const { scrollY } = useScroll();
   const scrollVelocity = useVelocity(scrollY);
+  const willChange = useWillChange();
 
   const [isScrollingBack, setIsScrollingBack] = useState(false);
   const [isAtTop, setIsAtTop] = useState(true);
@@ -43,15 +44,14 @@ export const Masthead = ({ className }: MastheadProps) => {
 
   return (
     <m.div
-      className={cnb('su-w-full su-fixed su-top-0 su-z-50 su-transition-all su-border-b', className)}
-      animate={{
-        y: isVisible ? 0 : -slideDistance,
-        opacity: isVisible ? 1 : 0,
-        backgroundColor: isScrollingBack && !isAtTop ? 'rgba(255,255,255)' : 'rgba(255,255,255,0)',
-        borderBottomColor: isScrollingBack && !isAtTop ? 'rgba(0,0,0,0.1)' : 'rgba(0,0,0,0)',
-        height: isVisible ? slideDistance : 0,
-      }}
-      transition={{ duration: 0.4, delay: 0.1, ease: 'easeInOut' }}
+      className={cnb(
+        'su-w-full su-fixed su-top-0 su-z-50',
+        !isAtTop && isScrollingBack ? 'su-bg-white su-border-b su-border-b-black-20' : 'su-bg-transparent su-border-b-transparent',
+        className,
+      )}
+      animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
+      transition={{ duration: 0.5, delay: 0.1, ease: 'easeInOut' }}
+      style={{ height: slideDistance, willChange }}
     >
       <FlexBox
         justifyContent="between"

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -12,7 +12,7 @@ import { HeroIcon } from '../HeroIcon';
 type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
 export const Masthead = ({ className }: MastheadProps) => {
-  const slideDistance = 142;
+  const slideDistance = 102;
   const threshold = 300;
 
   const { scrollY } = useScroll();
@@ -56,14 +56,14 @@ export const Masthead = ({ className }: MastheadProps) => {
       <FlexBox
         justifyContent="between"
         alignItems="center"
-        className="su-py-18 md:su-py-26 su-cc"
+        className={cnb('su-cc su-transition-all', !isAtTop ? 'su-py-18 lg:su-py-6' : 'su-py-18 md:su-py-26')}
       >
         <Logo
           isLink
           className="su-w-[17rem] sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
           color={!isAtTop && isScrollingBack ? 'black' : 'white'}
         />
-        <FlexBox alignItems="center">
+        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'lg:su-scale-75')}>
           <CtaLink
             href={ood.give}
             variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -3,7 +3,6 @@ import {
   m, useMotionValueEvent, useScroll, useVelocity,
 } from 'framer-motion';
 import { cnb } from 'cnbuilder';
-import { Container } from '../Container';
 import { FlexBox } from '../FlexBox';
 import { Logo } from '../Logo';
 import { CtaLink, CtaButton } from '../Cta';
@@ -13,8 +12,8 @@ import { HeroIcon } from '../HeroIcon';
 type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
 export const Masthead = ({ className }: MastheadProps) => {
-  const slideDistance = 144;
-  const threshold = 200;
+  const slideDistance = 142;
+  const threshold = 300;
 
   const { scrollY } = useScroll();
   const scrollVelocity = useVelocity(scrollY);
@@ -34,7 +33,7 @@ export const Masthead = ({ className }: MastheadProps) => {
   });
 
   useMotionValueEvent(scrollY, 'change', (latest) => {
-    setIsAtTop(latest <= 200);
+    setIsAtTop(latest <= 0);
   });
 
   useEffect(() => setIsVisible(isScrollingBack || isAtTop), [
@@ -45,43 +44,41 @@ export const Masthead = ({ className }: MastheadProps) => {
   return (
     <m.div
       className={cnb(
-        'su-w-full su-fixed su-top-0 su-z-[100] su-transition-all',
+        'su-w-full su-fixed su-top-0 su-z-50 su-transition-all',
         !isAtTop && isScrollingBack ? 'su-bg-white su-border-b su-border-b-black-20' : 'su-bg-transparent su-border-b-transparent',
         className,
       )}
       animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
-      transition={{ duration: 0.3, delay: 0.1, ease: 'easeInOut' }}
+      transition={{ duration: 0.4, delay: 0.1, ease: 'easeInOut' }}
       style={{ height: slideDistance }}
     >
-      <Container>
-        <FlexBox
-          justifyContent="between"
-          alignItems="center"
-          className="su-rs-py-1"
-        >
-          <Logo
-            isLink
-            className="su-w-160 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
-            color={!isAtTop && isScrollingBack ? 'black' : 'white'}
-          />
-          <FlexBox alignItems="center">
-            <CtaLink
-              href={ood.give}
-              variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
-              className="su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem] su-mt-10 lg:su-mt-26"
-            >
-              Make a gift
-            </CtaLink>
-            <CtaButton
-              onClick={() => alert('Hello world')}
-              variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
-              className="su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem] su--mt-10 lg:su--mt-26"
-            >
-              <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32 group-hover:su-scale-y-75" />
-            </CtaButton>
-          </FlexBox>
+      <FlexBox
+        justifyContent="between"
+        alignItems="center"
+        className="su-py-26 su-cc"
+      >
+        <Logo
+          isLink
+          className="su-w-160 sm:su-w-[24rem] md:su-w-[32rem] su-fill-white"
+          color={!isAtTop && isScrollingBack ? 'black' : 'white'}
+        />
+        <FlexBox alignItems="center">
+          <CtaLink
+            href={ood.give}
+            variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
+            className="su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem] su-mt-10 lg:su-mt-26"
+          >
+            Make a gift
+          </CtaLink>
+          <CtaButton
+            onClick={() => alert('Hello world')}
+            variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
+            className="su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem] su--mt-10 lg:su--mt-26"
+          >
+            <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32 group-hover:su-scale-y-75" />
+          </CtaButton>
         </FlexBox>
-      </Container>
+      </FlexBox>
     </m.div>
   );
 };

--- a/src/components/Storyblok/SbLogo.tsx
+++ b/src/components/Storyblok/SbLogo.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
 import { Logo, LogoVariantType, LogoColorType } from '../Logo';
-import { FontSizeType } from '../Typography';
 
 type SbLogoProps = {
   blok: {
     _uid: string;
     type?: LogoVariantType;
-    size?: FontSizeType;
     color?: LogoColorType;
   };
 };
@@ -16,10 +14,9 @@ export const SbLogo = ({
   blok: {
     _uid,
     type,
-    size,
     color,
   },
   blok,
 }: SbLogoProps) => (
-  <Logo {...storyblokEditable(blok)} key={_uid} variant={type} size={size} color={color} />
+  <Logo {...storyblokEditable(blok)} key={_uid} variant={type} color={color} />
 );

--- a/src/tailwind/plugins/base/gc-base.js
+++ b/src/tailwind/plugins/base/gc-base.js
@@ -6,7 +6,6 @@ module.exports = function () {
   return function ({ addBase, config }) {
     addBase({
       html: {
-        scrollBehavior: 'smooth',
         overflowY: 'visible !important', // Need this for sticky nav to work
       },
       body: {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Masthead POC (clients want to see this behavior as recommended by Kerri, kind of a meet in the middle solution for a sticky masthead)
- At the top of the page, the background color of the masthead is transparent, logo and buttons are white
- As one scrolls down, the masthead goes away
- When one scrolls back up, the masthead reappear and stay sticky at the top. However, this version has a solid white background with black logo and buttons.
- Some misc tweaks here and there

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview
2. Look at the masthead at the top (without scrolling)
3. Scroll down and see that the masthead goes away
4. Scroll further down, then scroll back up to see the white solid version of the masthead reappears as sticky at the top

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-117