### PR TITLE
GIVCAMP-117 | Masthead CTA Firefox rendering bug fix

### DIFF
--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -2,7 +2,7 @@ export const cta = 'su-group hocus:su-underline su-transition-all';
 
 const ghostSwipeBase = 'su-relative su-z-[10] su-inline-block su-no-underline hocus:su-no-underline su-font-normal su-leading-display hocus:su-text-white su-border-2 su-border-current hocus:su-border-digital-red-light focus-visible:su-outline-none after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-digital-red after:su-to-cardinal-red after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden';
 
-const mainNavBase = 'su-group su-inline-block su-border-2 su-font-normal su-decoration-transparent su-decoration-1 su-underline-offset-4 su-text-white hocus:su-text-white hocus:su-decoration-white hocus:su-ring-1 hocus:su-ring-inset hocus:su-ring-white';
+const mainNavBase = 'su-group su-bg-clip-padding su-inline-block su-border-2 su-border-white su-font-normal su-decoration-transparent su-decoration-1 su-underline-offset-4 su-text-white hocus:su-text-white hocus:su-decoration-white hocus:su-ring-1 hocus:su-ring-inset hocus:su-ring-white';
 
 export const ctaVariants = {
   solid: 'su-relative su-z-[10] su-font-normal su-inline-block su-decoration-2 su-decoration-transparent su-underline-offset-4 su-leading-display su-bg-digital-red su-text-white hocus:su-text-white su-border-2 su-border-digital-red-light focus-visible:su-outline-none hocus:su-decoration-white/80 after:su-block after:su-content-[""] after:su-absolute after:su-top-0 after:su-left-0 after:su-w-[0] after:su-h-full after:su-bg-gradient-to-r after:su-from-cardinal-red after:su-to-cardinal-red-dark after:su-transition-all after:su-z-[-1] hocus:after:su-w-full su-overflow-hidden',

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -13,7 +13,7 @@ type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
 export const Masthead = ({ className }: MastheadProps) => {
   const slideDistance = 96;
-  const threshold = 300;
+  const threshold = 200;
 
   const { scrollY } = useScroll();
   const scrollVelocity = useVelocity(scrollY);
@@ -34,7 +34,7 @@ export const Masthead = ({ className }: MastheadProps) => {
   });
 
   useMotionValueEvent(scrollY, 'change', (latest) => {
-    setIsAtTop(latest <= 200);
+    setIsAtTop(latest <= 100);
   });
 
   useEffect(() => setIsVisible(isScrollingBack || isAtTop), [

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -63,7 +63,8 @@ export const Masthead = ({ className }: MastheadProps) => {
           className={cnb('su-w-[17rem] sm:su-w-[24rem] su-transition-all', isAtTop ? 'lg:su-w-[32rem]' : 'lg:su-w-[28rem]')}
           color={!isAtTop && isScrollingBack ? 'black' : 'white'}
         />
-        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'lg:su-scale-75')}>
+        {/* The scale3d here solves a Firefox only rendering bug with blurry curved borders when using transform */}
+        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'lg:[transform:scale3d(0.75,0.75,0.75)]')}>
           <CtaLink
             href={ood.give}
             variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Firefox's long time bug when combining transform and curved radius
https://stackoverflow.com/questions/71123245/firefox-scaling-issues-causes-pixelated-blurry-borders
- This PR should fix it

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Use Firefox
2. Scroll down and then up to see the white background version of the masthead
3. The button should be ok now

Before:
![Screenshot 2023-06-20 at 3 38 26 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/34aa9ef4-ccec-4787-99a6-8a8dc1e23c6b)

After (now):

![Screenshot 2023-06-20 at 3 10 01 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/9b10ead2-ba6a-4c95-b7a3-f37a7d74a6dd)

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-117