### PR TITLE
GIVCAMP-140 | Canonical URL and noindex in page metatags

### DIFF
--- a/src/components/PageHead/SEO.tsx
+++ b/src/components/PageHead/SEO.tsx
@@ -60,7 +60,7 @@ export const SEO = ({
   // Self reference URL is the page's URL without any query params
   const selfReferencingUrl = `${location.origin}${location.pathname}`;
   // If the canonical URL is entered in Storyblok, find the full URL for it
-  const canonicalNotSelf = canonicalUrl?.linktype === 'story' ? `${location.origin}${canonicalUrl?.cached_url}` : canonicalUrl?.url;
+  const canonicalNotSelf = canonicalUrl?.linktype === 'story' ? `${location.origin}/${canonicalUrl?.cached_url}` : canonicalUrl?.url;
   const canonical = canonicalNotSelf || selfReferencingUrl;
 
   return (

--- a/src/components/PageHead/SEO.tsx
+++ b/src/components/PageHead/SEO.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { useLocation } from '@reach/router';
 import { useSiteMetadata } from '../../hooks/useSiteMetadata';
 import { getProcessedImage } from '../../utilities/getProcessedImage';
-import { SbImageType } from '../Storyblok/Storyblok.types';
+import { SbImageType, SbLinkType } from '../Storyblok/Storyblok.types';
 
 export type SEOProps = {
   title: string;
   heroImage?: SbImageType;
+  noindex?: boolean;
+  canonicalUrl?: SbLinkType;
   seo?: {
     title?: string;
     description?: string;
@@ -22,6 +24,8 @@ export type SEOProps = {
 export const SEO = ({
   title,
   heroImage: { filename, focus } = {},
+  noindex,
+  canonicalUrl,
   seo: {
     title: seoTitle,
     description: seoDescription,
@@ -49,13 +53,21 @@ export const SEO = ({
 
   const location = useLocation();
   let ogType = 'website';
-  if (location.pathname.startsWith('/story')) {
+  if (location.pathname.startsWith('/stories')) {
     ogType = 'article';
   }
+
+  // Self reference URL is the page's URL without any query params
+  const selfReferencingUrl = `${location.origin}${location.pathname}`;
+  // If the canonical URL is entered in Storyblok, find the full URL for it
+  const canonicalNotSelf = canonicalUrl?.linktype === 'story' ? `${location.origin}${canonicalUrl?.cached_url}` : canonicalUrl?.url;
+  const canonical = canonicalNotSelf || selfReferencingUrl;
 
   return (
     <>
       <title>{`${seoTitle || title} | ${siteTitle}`}</title>
+      {noindex && <meta name="robots" content="noindex" />}
+      {!noindex && <link rel="canonical" href={canonical} />}
       <meta name="description" content={seoDescription || description} />
       <meta property="og:type" content={ogType} />
       {ogTitle && (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,6 +61,8 @@ export const Head = ({ data }) => {
       title={blok.title || 'Homepage'}
       heroImage={blok.heroImage || blok.hero.image}
       seo={blok.seo}
+      noindex={blok.noindex}
+      canonicalUrl={blok.canonicalUrl}
     />
   );
 };

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -43,6 +43,8 @@ export const Head = ({ data }) => {
       title={blok.title || story.name}
       heroImage={blok.heroImage || blok.hero.image}
       seo={blok.seo}
+      noindex={blok.noindex}
+      canonicalUrl={blok.canonicalUrl}
     />
   );
 };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This is only for metatag in the HTML head - adding support for noindex (boolean) and Canonical URL (Storyblok link field if it's entered, or self-referencing if this is left empty in Storyblok)

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the homepage
https://deploy-preview-86--giving-campaign.netlify.app
`No Canonical URL is entered on Storyblok; noindex is false.`
Look at the page HTML head, and check that the canonical URL is set to the above URL (self-referencing canonical URL)
![Screenshot 2023-06-21 at 1 26 18 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/46a627e4-c07c-49c8-9766-01e9f09e57bf)

2. Go to the about-test page:
https://deploy-preview-86--giving-campaign.netlify.app/about-test/
` noindex is true`
Check that you see the noindex metatag
![Screenshot 2023-06-21 at 1 26 43 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/66591954-7c5f-4897-9f65-27d7738a1e08)

3. Go to this story "The future grows on a farm"
https://deploy-preview-86--giving-campaign.netlify.app/stories/the-future-grows-on-a-farm/
`Canonical URL is entered as "https://example.com/farm" which is an external link on Storyblok; noindex is false.`
Check that you see this canonical URL in the metatag
![Screenshot 2023-06-21 at 1 47 05 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/603f936f-fed9-4d99-a3e0-fcce74c2ba26)

4. go to this story "Accelerators: solutions sped up"
https://deploy-preview-86--giving-campaign.netlify.app/stories/accelerators-solutions-sped-up/
`Canonical URL is entered as an internal link to the "Initiative" page on Storyblok; noindex is false.`
Check that you see this canonical URL in the metatag
Note: instead of under the title tag, this tag sometimes renders much lower in the HTML head
![Screenshot 2023-06-21 at 1 49 37 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/d5381133-96be-4148-9ef5-86cfe23f3fa9)

5. Go to this story "Harnessing satellite......"
https://deploy-preview-86--giving-campaign.netlify.app/stories/harnessing-satellite-imagery-ai-to-help-fight-poverty/
`No Canonical URL is entered on Storyblok; noindex is false.`
Check that the canonical URL is self referencing
![Screenshot 2023-06-21 at 1 50 52 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/a989b74e-cb46-4aa3-819c-2f3087eaa816)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-140
