### PR TITLE
GIVCAMP-92 | Storyblok Banner component

### DIFF
--- a/src/components/Banner/Banner.styles.ts
+++ b/src/components/Banner/Banner.styles.ts
@@ -1,0 +1,6 @@
+export const wrapper = 'su-mr-0 au-ml-auto su-flex-col lg:su-flex-row';
+export const contentWrapper = 'lg:su-rs-pr-9 su-ml-0';
+export const heading = 'su-whitespace-pre-line su--mt-01em su-rs-mb-2 xl:su-max-w-1200';
+export const body = 'su-max-w-[50ch] su-rs-mb-3';
+export const imageWrapper = 'su-self-end lg:su-self-start su-shrink-0';
+export const image = 'su-rs-mt-3 lg:su-mt-0 su-rounded-bl-[12rem] su-w-[25rem] xl:su-w-[36rem]';

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -26,16 +26,16 @@ export const Banner = ({
   bgColor = 'white',
   ...props
 }: BannerProps) => (
-  <Container {...props} as="section" bgColor={bgColor} className="lg:su-pr-0" py={9}>
+  <Container {...props} as="section" bgColor={bgColor} width="full" py={9}>
     <FlexBox alignItems="start" justifyContent="between" className="su-mr-0 au-ml-auto su-flex-col lg:su-flex-row">
-      <div className="su-rs-pr-9 lg:su-max-w-[70%]">
+      <div className="su-cc lg:su-rs-pr-9 su-ml-0">
         <AnimateInView duration={0.6} animation="slideUp">
           {heading && (
             <Heading
               size={isSmallHeading ? 'f6' : 'f7'}
               font="druk"
               leading="none"
-              className="su-whitespace-pre-line su--mt-02em su-rs-mb-2"
+              className="su-whitespace-pre-line su--mt-01em su-rs-mb-2 su-max-w-1000"
             >
               {heading}
             </Heading>
@@ -48,13 +48,17 @@ export const Banner = ({
           {cta}
         </AnimateInView>
       </div>
-      <AnimateInView duration={0.4} delay={0.7} animation="slideInFromRight">
-        <img
-          alt=""
-          src={getProcessedImage(imageSrc, '360x360', imageFocus)}
-          className="su-rounded-bl-[12rem] su-w-[25rem] xl:su-w-[36rem]"
-        />
-      </AnimateInView>
+      {imageSrc && (
+        <div className="su-self-end lg:su-self-start su-shrink-0">
+          <AnimateInView duration={0.4} delay={0.7} animation="slideInFromRight">
+            <img
+              alt=""
+              src={getProcessedImage(imageSrc, '360x360', imageFocus)}
+              className="su-rs-mt-3 lg:su-mt-0 su-rounded-bl-[12rem] su-w-[25rem] xl:su-w-[36rem]"
+            />
+          </AnimateInView>
+        </div>
+      )}
     </FlexBox>
   </Container>
 );

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,58 +1,60 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
 import { Heading, Paragraph } from '../Typography';
 import { FlexBox } from '../FlexBox';
-import { CtaLink } from '../Cta';
 import { getProcessedImage } from '../../utilities/getProcessedImage';
+import { BgTextColorPairBlackWhiteType } from '../../utilities/datasource';
 
-type BannerProps = {
+type BannerProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;
-  body?: string;
-  ctaText?: string;
-  href?: string;
+  isSmallHeading?: boolean;
+  body?: React.ReactNode;
+  cta?: React.ReactNode;
+  imageSrc?: string;
+  imageFocus?: string;
+  bgColor?: BgTextColorPairBlackWhiteType;
 };
 
 export const Banner = ({
   heading,
+  isSmallHeading,
   body,
-  ctaText,
-  href,
+  cta,
+  imageSrc,
+  imageFocus,
+  bgColor = 'white',
+  ...props
 }: BannerProps) => (
-  <div>
-    <img
-      alt=""
-      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/f23b53c0e4/steve-johnson-cropped-2000x40-02.jpg')}
-      className="su-w-full"
-    />
-    <Container bgColor="white" className="lg:su-pr-0" py={9}>
-      <FlexBox alignItems="start" justifyContent="between" className="su-mr-0 au-ml-auto su-flex-col lg:su-flex-row">
-        <div className="su-rs-pr-9 lg:su-max-w-[70%]">
-          <AnimateInView duration={0.6} animation="slideUp">
-            <Heading size="f7" font="druk" leading="none" className="su-whitespace-pre-line su--mt-02em su-rs-mb-2">
+  <Container {...props} as="section" bgColor={bgColor} className="lg:su-pr-0" py={9}>
+    <FlexBox alignItems="start" justifyContent="between" className="su-mr-0 au-ml-auto su-flex-col lg:su-flex-row">
+      <div className="su-rs-pr-9 lg:su-max-w-[70%]">
+        <AnimateInView duration={0.6} animation="slideUp">
+          {heading && (
+            <Heading
+              size={isSmallHeading ? 'f6' : 'f7'}
+              font="druk"
+              leading="none"
+              className="su-whitespace-pre-line su--mt-02em su-rs-mb-2"
+            >
               {heading}
             </Heading>
+          )}
+          {body && (
             <Paragraph font="serif" variant="overview" weight="semibold" className="su-max-w-[50ch] su-rs-mb-3">
               {body}
             </Paragraph>
-            <CtaLink variant="ghost-swipe" color="black" curve="br-large" icon="arrow-right" animate="right" href={href} size="large">
-              {ctaText}
-            </CtaLink>
-          </AnimateInView>
-        </div>
-        <AnimateInView duration={0.4} delay={0.7} animation="slideInFromRight">
-          <img
-            alt=""
-            src={getProcessedImage('https://a-us.storyblok.com/f/1005200/7539x5029/df3ccadc57/20200219_diamonds_sra7839.jpg', '360x360')}
-            className="su-rounded-bl-[12rem] su-w-[25rem] xl:su-w-[36rem]"
-          />
+          )}
+          {cta}
         </AnimateInView>
-      </FlexBox>
-    </Container>
-    <img
-      alt=""
-      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
-      className="su-w-full"
-    />
-  </div>
+      </div>
+      <AnimateInView duration={0.4} delay={0.7} animation="slideInFromRight">
+        <img
+          alt=""
+          src={getProcessedImage(imageSrc, '360x360', imageFocus)}
+          className="su-rounded-bl-[12rem] su-w-[25rem] xl:su-w-[36rem]"
+        />
+      </AnimateInView>
+    </FlexBox>
+  </Container>
 );

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -5,6 +5,7 @@ import { Heading, Paragraph } from '../Typography';
 import { FlexBox } from '../FlexBox';
 import { getProcessedImage } from '../../utilities/getProcessedImage';
 import { BgTextColorPairBlackWhiteType } from '../../utilities/datasource';
+import * as styles from './Banner.styles';
 
 type BannerProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;
@@ -27,34 +28,34 @@ export const Banner = ({
   ...props
 }: BannerProps) => (
   <Container {...props} as="section" bgColor={bgColor} width="full" py={9}>
-    <FlexBox alignItems="start" justifyContent="between" className="su-mr-0 au-ml-auto su-flex-col lg:su-flex-row">
-      <div className="su-cc lg:su-rs-pr-9 su-ml-0">
+    <FlexBox alignItems="start" justifyContent="between" className={styles.wrapper}>
+      <Container className={styles.contentWrapper}>
         <AnimateInView duration={0.6} animation="slideUp">
           {heading && (
             <Heading
               size={isSmallHeading ? 'f6' : 'f7'}
               font="druk"
               leading="none"
-              className="su-whitespace-pre-line su--mt-01em su-rs-mb-2 su-max-w-1000"
+              className={styles.heading}
             >
               {heading}
             </Heading>
           )}
           {body && (
-            <Paragraph font="serif" variant="overview" weight="semibold" className="su-max-w-[50ch] su-rs-mb-3">
+            <Paragraph font="serif" variant="overview" weight="semibold" className={styles.body}>
               {body}
             </Paragraph>
           )}
           {cta}
         </AnimateInView>
-      </div>
+      </Container>
       {imageSrc && (
-        <div className="su-self-end lg:su-self-start su-shrink-0">
+        <div className={styles.imageWrapper}>
           <AnimateInView duration={0.4} delay={0.7} animation="slideInFromRight">
             <img
               alt=""
               src={getProcessedImage(imageSrc, '360x360', imageFocus)}
-              className="su-rs-mt-3 lg:su-mt-0 su-rounded-bl-[12rem] su-w-[25rem] xl:su-w-[36rem]"
+              className={styles.image}
             />
           </AnimateInView>
         </div>

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes } from 'react';
 import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
-import { Heading, Paragraph } from '../Typography';
+import { Heading, Text } from '../Typography';
 import { FlexBox } from '../FlexBox';
 import { getProcessedImage } from '../../utilities/getProcessedImage';
 import { BgTextColorPairBlackWhiteType } from '../../utilities/datasource';
@@ -42,9 +42,9 @@ export const Banner = ({
             </Heading>
           )}
           {body && (
-            <Paragraph font="serif" variant="overview" weight="semibold" className={styles.body}>
+            <Text font="serif" variant="overview" weight="semibold" className={styles.body}>
               {body}
-            </Paragraph>
+            </Text>
           )}
           {cta}
         </AnimateInView>

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,1 +1,2 @@
 export * from './Banner';
+export * from './Banner.styles';

--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -10,7 +10,7 @@ export const ctaVariants = {
   inlineDark: 'su-inline su-text-digital-red-xlight hocus:su-text-white su-underline su-decoration-1 hocus:su-decoration-2 su-underline-offset-2',
   ghost: 'su-inline-block su-font-normal su-leading-display su-bg-transparent hocus:su-text-current su-border-2 su-border-current focus-visible:su-outline-none su-underline-offset-4 su-decoration-transparent hocus:su-decoration-current',
   'ghost-swipe': `${ghostSwipeBase} su-bg-transparent`,
-  'ghost-swipe-overlay': `${ghostSwipeBase} su-bg-black/60`, // Use for split poster over images
+  'ghost-swipe-overlay': `${ghostSwipeBase} su-bg-black-true/40`, // Use for split poster over images
   link: 'su-font-normal su-decoration-transparent hocus:su-decoration-current su-leading-display su-text-current hocus:su-text-current hocus:su-decoration-2 focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-outline-none focus-visible:su-rounded su-underline-offset-4',
   back: 'su-inline-block su-font-normal su-no-underline su-leading-none group-hocus:su-underline su-text-black hocus:su-text-lagunita focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-ring-offset-4 focus:su-outline-none su-rounded-[1px]',
   mainNav: `${mainNavBase} hocus-visible:su-bg-sapphire/50`, // Main nav buttons at the top of the page

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { storyblokInit, apiPlugin } from 'gatsby-source-storyblok';
 import { FlexBox } from './FlexBox';
 import { Masthead } from './Masthead';
 import { LocalFooter } from './LocalFooter';
+import { SbBanner } from './Storyblok/SbBanner';
 import { SbBracketCard } from './Storyblok/SbBracketCard';
 import { SbCta } from './Storyblok/SbCta';
 import { SbGrid } from './Storyblok/SbGrid';
@@ -27,6 +28,7 @@ storyblokInit({
   },
   use: [apiPlugin],
   components: {
+    sbBanner: SbBanner,
     sbBracketCard: SbBracketCard,
     sbCta: SbCta,
     sbGrid: SbGrid,

--- a/src/components/LocalFooter/LocalFooter.tsx
+++ b/src/components/LocalFooter/LocalFooter.tsx
@@ -5,97 +5,105 @@ import { Grid } from '../Grid';
 import { Logo } from '../Logo';
 import { CtaLink } from '../Cta';
 import { schools } from '../../utilities/externalLinks';
+import { getProcessedImage } from '../../utilities/getProcessedImage';
 import { initiatives, themes } from '../../utilities/routes';
 
 export const LocalFooter = () => (
-  <Container bgColor="white" py={8}>
-    <Logo isLink className="su-w-300 md:su-w-400 2xl:su-w-[56rem] su-fill-gc-black" />
-    <Grid gap="default" as="nav" aria-label="Local footer" xl={3} pt={7}>
-      <div>
-        <section>
-          <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
-            About
-          </Heading>
-          <Text as="address" leading="normal">
-            <Text weight="semibold" className="su-whitespace-pre-line">Stanford Office of Development</Text>
-            P.O. Box 20466<br />
-            Stanford, CA 94309-0466<br />
-            (650) 724-0627<br />
-          </Text>
-          <Text className="su-rs-mt-0 su-rs-mb-3">Tax ID: 94-1156365</Text>
-          <ul className="su-list-unstyled children:su-mb-04em">
-            <li><CtaLink color="black" icon="arrow-right" href="contact-us" className="su-inline-block">Contact us</CtaLink></li>
-            <li><CtaLink color="black" icon="arrow-right" href="faq" className="su-inline-block">FAQs</CtaLink></li>
-          </ul>
-          <CtaLink
-            color="black"
-            variant="ghost-swipe"
-            icon="arrow-right"
-            curve="br"
-            href="faq"
-            className="su-rs-mt-2"
-          >
-            How to give
-          </CtaLink>
-        </section>
-        <section className="su-rs-mt-4">
-          <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
-            The Latest
-          </Heading>
-          <Paragraph noMargin>
-            Sign up to receive Stanford’s On Purpose campaign newsletter.
-          </Paragraph>
-          <CtaLink
-            variant="solid"
-            icon="arrow-right"
-            curve="br"
-            href="faq"
-            className="su-rs-mt-0"
-          >
-            Sign up
-          </CtaLink>
-        </section>
-      </div>
-      <div>
-        <section>
-          <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
-            Initiatives
-          </Heading>
-          <ul className="su-list-unstyled children:su-mb-06em">
-            {Object.values(initiatives).map((initiative) => (
-              <li key={initiative.name}>
-                <CtaLink color="black" href={initiative.path} className="su-inline-block">{initiative.name}</CtaLink>
-              </li>
-            ))}
-          </ul>
-        </section>
-      </div>
-      <div>
-        <section>
-          <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
-            Themes
-          </Heading>
-          <ul className="su-list-unstyled children:su-mb-06em">
-            {Object.values(themes).map((theme) => (
-              <li key={theme.name}>
-                <CtaLink color="black" href={theme.path} className="su-inline-block">{theme.name}</CtaLink>
-              </li>
-            ))}
-          </ul>
-        </section>
-        <section className="su-rs-mt-6">
-          <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
-            Schools
-          </Heading>
-          <ul className="su-list-unstyled children:su-mb-06em">
-            {Object.values(schools).map((school) => (
-              <li key={school.name}>
-                <CtaLink color="black" href={school.href} className="su-inline-block">{school.name}</CtaLink>
-              </li>
-            ))}
-          </ul>
-        </section>
-      </div>
-    </Grid>
-  </Container>
+  <>
+    <img
+      alt=""
+      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/f23b53c0e4/steve-johnson-cropped-2000x40-02.jpg')}
+      className="su-w-full"
+    />
+    <Container bgColor="white" py={8}>
+      <Logo isLink className="su-w-300 md:su-w-400 2xl:su-w-[56rem] su-fill-gc-black" />
+      <Grid gap="default" as="nav" aria-label="Local footer" xl={3} pt={7}>
+        <div>
+          <section>
+            <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
+              About
+            </Heading>
+            <Text as="address" leading="normal">
+              <Text weight="semibold" className="su-whitespace-pre-line">Stanford Office of Development</Text>
+              P.O. Box 20466<br />
+              Stanford, CA 94309-0466<br />
+              (650) 724-0627<br />
+            </Text>
+            <Text className="su-rs-mt-0 su-rs-mb-3">Tax ID: 94-1156365</Text>
+            <ul className="su-list-unstyled children:su-mb-04em">
+              <li><CtaLink color="black" icon="arrow-right" href="contact-us" className="su-inline-block">Contact us</CtaLink></li>
+              <li><CtaLink color="black" icon="arrow-right" href="faq" className="su-inline-block">FAQs</CtaLink></li>
+            </ul>
+            <CtaLink
+              color="black"
+              variant="ghost-swipe"
+              icon="arrow-right"
+              curve="br"
+              href="faq"
+              className="su-rs-mt-2"
+            >
+              How to give
+            </CtaLink>
+          </section>
+          <section className="su-rs-mt-4">
+            <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
+              The Latest
+            </Heading>
+            <Paragraph noMargin>
+              Sign up to receive Stanford’s On Purpose campaign newsletter.
+            </Paragraph>
+            <CtaLink
+              variant="solid"
+              icon="arrow-right"
+              curve="br"
+              href="faq"
+              className="su-rs-mt-0"
+            >
+              Sign up
+            </CtaLink>
+          </section>
+        </div>
+        <div>
+          <section>
+            <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
+              Initiatives
+            </Heading>
+            <ul className="su-list-unstyled children:su-mb-06em">
+              {Object.values(initiatives).map((initiative) => (
+                <li key={initiative.name}>
+                  <CtaLink color="black" href={initiative.path} className="su-inline-block">{initiative.name}</CtaLink>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+        <div>
+          <section>
+            <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
+              Themes
+            </Heading>
+            <ul className="su-list-unstyled children:su-mb-06em">
+              {Object.values(themes).map((theme) => (
+                <li key={theme.name}>
+                  <CtaLink color="black" href={theme.path} className="su-inline-block">{theme.name}</CtaLink>
+                </li>
+              ))}
+            </ul>
+          </section>
+          <section className="su-rs-mt-6">
+            <Heading as="h3" size={1} font="druk-wide" uppercase className="su-rs-mb-0">
+              Schools
+            </Heading>
+            <ul className="su-list-unstyled children:su-mb-06em">
+              {Object.values(schools).map((school) => (
+                <li key={school.name}>
+                  <CtaLink color="black" href={school.href} className="su-inline-block">{school.name}</CtaLink>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </Grid>
+    </Container>
+  </>
 );

--- a/src/components/LocalFooter/LocalFooter.tsx
+++ b/src/components/LocalFooter/LocalFooter.tsx
@@ -12,11 +12,11 @@ export const LocalFooter = () => (
   <>
     <img
       alt=""
-      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/f23b53c0e4/steve-johnson-cropped-2000x40-02.jpg')}
+      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
       className="su-w-full"
     />
     <Container bgColor="white" py={8}>
-      <Logo isLink className="su-w-300 md:su-w-400 2xl:su-w-[56rem] su-fill-gc-black" />
+      <Logo isLink color="black" className="su-w-300 md:su-w-400 2xl:su-w-[56rem] su-fill-gc-black" />
       <Grid gap="default" as="nav" aria-label="Local footer" xl={3} pt={7}>
         <div>
           <section>

--- a/src/components/LocalFooter/LocalFooter.tsx
+++ b/src/components/LocalFooter/LocalFooter.tsx
@@ -12,7 +12,7 @@ export const LocalFooter = () => (
   <>
     <img
       alt=""
-      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
+      src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/f23b53c0e4/steve-johnson-cropped-2000x40-02.jpg')}
       className="su-w-full"
     />
     <Container bgColor="white" py={8}>

--- a/src/components/Storyblok/SbBanner.tsx
+++ b/src/components/Storyblok/SbBanner.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { storyblokEditable } from 'gatsby-source-storyblok';
+import { StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
+import { Banner } from '../Banner';
+import { CreateBloks } from '../CreateBloks';
+import { RichText } from '../RichText';
+import { SbImageType } from './Storyblok.types';
+import { BgTextColorPairBlackWhiteType } from '../../utilities/datasource';
+
+type SbBannerProps = {
+  blok: {
+    _uid: string;
+    heading?: string;
+    isSmallHeading?: boolean;
+    body?: StoryblokRichtext;
+    cta?: any[];
+    image?: SbImageType;
+    bgColor?: BgTextColorPairBlackWhiteType;
+  };
+};
+
+export const SbBanner = ({
+  blok: {
+    _uid,
+    heading,
+    isSmallHeading,
+    body,
+    cta,
+    image: { filename, focus } = {},
+    bgColor,
+  },
+  blok,
+}: SbBannerProps) => {
+  const Cta = <CreateBloks blokSection={cta} />;
+  const Body = <RichText wysiwyg={body} isLightText={bgColor === 'black'} />;
+
+  return (
+    <Banner
+      {...storyblokEditable(blok)}
+      key={_uid}
+      heading={heading}
+      isSmallHeading={isSmallHeading}
+      body={Body}
+      cta={Cta}
+      imageSrc={filename}
+      imageFocus={focus}
+      bgColor={bgColor}
+    />
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,7 +28,7 @@ const IndexPage = ({ data }) => {
       <HomepageHero />
       <img
         alt=""
-        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
+        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/f23b53c0e4/steve-johnson-cropped-2000x40-02.jpg')}
         className="su-w-full"
       />
       <Intro text={blok.intro} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,6 +26,11 @@ const IndexPage = ({ data }) => {
     <Layout>
       <Heading as="h1" srOnly>{blok.title || 'Homepage'}</Heading>
       <HomepageHero />
+      <img
+        alt=""
+        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
+        className="su-w-full"
+      />
       <Intro text={blok.intro} />
       <ThemeSection
         themeCardDiscovery={blok.themeCardDiscovery}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,8 +10,8 @@ import { ProgressSection } from '../components/Homepage/ProgressSection';
 import { PageHead } from '../components/PageHead';
 import { CreateBloks } from '../components/CreateBloks';
 import { Layout } from '../components/Layout';
-import { Banner } from '../components/Banner';
 import { resolveRelations } from '../utilities/resolveRelations';
+import { getProcessedImage } from '../utilities/getProcessedImage';
 
 /**
  * This is the layout for the homepage
@@ -39,12 +39,12 @@ const IndexPage = ({ data }) => {
       <FindPurposeSection>
         <CreateBloks blokSection={blok.findPurpose} />
       </FindPurposeSection>
-      <Banner
-        heading="Join the conversation in Chicago."
-        body="Chicago Conversation on Purpose. October XX, 2024. This is text that describes the event in a super exciting way."
-        ctaText="Learn how"
-        href="about-test"
+      <img
+        alt=""
+        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
+        className="su-w-full"
       />
+      <CreateBloks blokSection={blok.ankle} />
     </Layout>
   );
 };

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -8,6 +8,7 @@ import { PageHead } from '../components/PageHead';
 import { Layout } from '../components/Layout';
 import { DemoContent } from '../components/Temporary/DemoContent';
 import { resolveRelations } from '../utilities/resolveRelations';
+import { getProcessedImage } from '../utilities/getProcessedImage';
 
 type DataProps = {
   storyblokEntry: SbGatsbyStory;
@@ -27,6 +28,12 @@ const StoryblokEntry: React.FC<PageProps<DataProps>> = ({
       <CreateBloks blokSection={blok.hero} />
       <CreateBloks blokSection={blok.content} />
       <DemoContent />
+      <img
+        alt=""
+        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
+        className="su-w-full"
+      />
+      <CreateBloks blokSection={blok.ankle} />
     </Layout>
   );
 };

--- a/src/pages/{storyblokEntry.full_slug}.tsx
+++ b/src/pages/{storyblokEntry.full_slug}.tsx
@@ -9,6 +9,7 @@ import { Layout } from '../components/Layout';
 import { DemoContent } from '../components/Temporary/DemoContent';
 import { resolveRelations } from '../utilities/resolveRelations';
 import { getProcessedImage } from '../utilities/getProcessedImage';
+import { getNumBloks } from '../utilities/getNumBloks';
 
 type DataProps = {
   storyblokEntry: SbGatsbyStory;
@@ -28,11 +29,13 @@ const StoryblokEntry: React.FC<PageProps<DataProps>> = ({
       <CreateBloks blokSection={blok.hero} />
       <CreateBloks blokSection={blok.content} />
       <DemoContent />
-      <img
-        alt=""
-        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
-        className="su-w-full"
-      />
+      {getNumBloks(blok.ankle) > 0 && (
+        <img
+          alt=""
+          src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2000x40/c4777a4925/steve-johnson-cropped-2000x40-01.jpg')}
+          className="su-w-full"
+        />
+      )}
       <CreateBloks blokSection={blok.ankle} />
     </Layout>
   );

--- a/src/utilities/datasource.ts
+++ b/src/utilities/datasource.ts
@@ -32,11 +32,22 @@ export const accentBorderColors = {
 };
 export type AccentBorderColorType = keyof typeof accentBorderColors;
 
-export const bgTextColorPairs = {
+// Many components have dark and light themes - these are the basic options
+export const bgTextColorPairsBlackWhite = {
   black: 'su-bg-gc-black su-text-white',
-  'black-70': 'su-bg-black-true/70 su-text-white',
   white: 'su-bg-white su-text-gc-black',
+};
+export type BgTextColorPairBlackWhiteType = keyof typeof bgTextColorPairsBlackWhite;
+
+// Some components, eg, Split Posters, have additional options
+export const bgTextColorPairsAdditional = {
+  'black-70': 'su-bg-black-true/70 su-text-white',
   'white-80': 'su-bg-white/80 su-text-gc-black',
+};
+
+export const bgTextColorPairs = {
+  ...bgTextColorPairsBlackWhite,
+  ...bgTextColorPairsAdditional,
 };
 export type BgTextColorPairType = keyof typeof bgTextColorPairs;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Getting the Banner component connected with Storyblok; add dark mode and clean up props
- Responsive behavior of Banner
- Temporary placements of textured bars on the site (below the hero, above the local footer, and above the ankle if there is an ankle). Will revisit after we create a "bar" component in Storyblok.
- Finalize white ghost button with dark overlay version

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-87--giving-campaign.netlify.app/ and scroll to right above the local footer
2. Look at the Banner (light version) with larger headline
![Screenshot 2023-06-22 at 1 15 19 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/a370afb8-6092-4c71-a10e-9c73ea318bd5)

3. See if responsive behavior seem legit
![Screenshot 2023-06-22 at 1 15 33 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/9f8c965e-24f9-48cf-ad56-ffc95ff71d7a)

4. Go to https://deploy-preview-87--giving-campaign.netlify.app/about-test/ and scroll to above the local footer
5. See the Banner (dark version) with the smaller headline
![Screenshot 2023-06-22 at 1 16 20 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/4233ab10-9948-46b1-aed0-f485d9d19010)
6. Again check responsive

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-92