### PR TITLE
GIVCAMP-148 | Explore dark theme masthead + reduce button offset when scrolling up

### DIFF
--- a/src/components/Cta/Cta.styles.ts
+++ b/src/components/Cta/Cta.styles.ts
@@ -14,7 +14,7 @@ export const ctaVariants = {
   link: 'su-font-normal su-decoration-transparent hocus:su-decoration-current su-leading-display su-text-current hocus:su-text-current hocus:su-decoration-2 focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-outline-none focus-visible:su-rounded su-underline-offset-4',
   back: 'su-inline-block su-font-normal su-no-underline su-leading-none group-hocus:su-underline su-text-black hocus:su-text-lagunita focus-visible:su-ring-2 focus-visible:su-ring-lagunita-light focus-visible:su-ring-offset-4 focus:su-outline-none su-rounded-[1px]',
   mainNav: `${mainNavBase} hocus-visible:su-bg-sapphire/50`, // Main nav buttons at the top of the page
-  mainNavBlack: `${mainNavBase} su-bg-gc-black hocus-visible:su-bg-digital-red`, // Main nav buttons when scrolling up
+  mainNavUp: `${mainNavBase} hocus-visible:su-bg-digital-red`, // Main nav buttons when scrolling up
   close: 'su-inline-block su-font-semibold su-leading-none su-text-lagunita hocus:su-text-lagunita-dark focus:su-outline-none',
   'close-x': 'su-leading-none',
   dismiss: 'su-inline-block su-font-bold su-uppercase su-tracking-widest su-leading-none su-text-gc-black hocus:su-text-gc-black focus:su-outline-none',
@@ -71,7 +71,7 @@ export const ctaSizeMap = {
   'ghost-swipe': 'default',
   'ghost-swipe-overlay': 'default',
   mainNav: 'mainNav',
-  mainNavBlack: 'mainNav',
+  mainNavUp: 'mainNav',
   link: 'unset',
   dismiss: 'dismiss',
   close: 'close',

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -63,7 +63,7 @@ export const Masthead = ({ className }: MastheadProps) => {
           className={cnb('su-w-[17rem] sm:su-w-[24rem] su-transition-all', isAtTop ? 'lg:su-w-[32rem]' : 'lg:su-w-[28rem]')}
         />
         {/* The scale3d here solves a Firefox only rendering bug with blurry curved borders when using transform */}
-        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'lg:[transform:scale3d(0.75,0.75,0.75)]')}>
+        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'su-origin-right lg:[transform:scale3d(0.75,0.75,0.75)]')}>
           <CtaLink
             href={ood.give}
             variant={!isAtTop && isScrollingBack ? 'mainNavUp' : 'mainNav'}

--- a/src/components/Masthead/Masthead.tsx
+++ b/src/components/Masthead/Masthead.tsx
@@ -12,7 +12,7 @@ import { HeroIcon } from '../HeroIcon';
 type MastheadProps = HTMLAttributes<HTMLDivElement>;
 
 export const Masthead = ({ className }: MastheadProps) => {
-  const slideDistance = 96;
+  const slideDistance = 86;
   const threshold = 200;
 
   const { scrollY } = useScroll();
@@ -46,7 +46,7 @@ export const Masthead = ({ className }: MastheadProps) => {
     <m.div
       className={cnb(
         'su-w-full su-fixed su-top-0 su-z-50 su-transition-colors',
-        !isAtTop && isScrollingBack ? 'su-bg-white su-border-b su-border-b-black-20' : 'su-bg-transparent su-border-b-transparent',
+        !isAtTop && isScrollingBack ? 'su-bg-gc-black su-border-b su-border-b-black-80' : 'su-bg-transparent su-border-b-transparent',
         className,
       )}
       animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
@@ -61,23 +61,28 @@ export const Masthead = ({ className }: MastheadProps) => {
         <Logo
           isLink
           className={cnb('su-w-[17rem] sm:su-w-[24rem] su-transition-all', isAtTop ? 'lg:su-w-[32rem]' : 'lg:su-w-[28rem]')}
-          color={!isAtTop && isScrollingBack ? 'black' : 'white'}
         />
         {/* The scale3d here solves a Firefox only rendering bug with blurry curved borders when using transform */}
         <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'lg:[transform:scale3d(0.75,0.75,0.75)]')}>
           <CtaLink
             href={ood.give}
-            variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
-            className="su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem] su-mt-10 lg:su-mt-26"
+            variant={!isAtTop && isScrollingBack ? 'mainNavUp' : 'mainNav'}
+            className={cnb(
+              'su-rounded-bl-[1.4rem] lg:su-rounded-bl-[2rem]',
+              isAtTop ? 'su-mt-10 lg:su-mt-26' : 'su-mt-5 lg:su-mt-16',
+            )}
           >
             Make a gift
           </CtaLink>
           <CtaButton
             onClick={() => alert('Hello world')}
-            variant={!isAtTop && isScrollingBack ? 'mainNavBlack' : 'mainNav'}
-            className="su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem] su--mt-10 lg:su--mt-26"
+            variant={!isAtTop && isScrollingBack ? 'mainNavUp' : 'mainNav'}
+            className={cnb(
+              'su--ml-2 su-rounded-tr-[1.4rem] lg:su-rounded-tr-[2rem]',
+              isAtTop ? 'su--mt-10 lg:su--mt-26' : 'su--mt-5 lg:su--mt-10',
+            )}
           >
-            <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32 group-hover:su-scale-y-75" />
+            <HeroIcon icon="menu" title="Main menu" noBaseStyle className="su-w-20 lg:su-w-32 group-hocus:su-scale-y-75 su-will-change-transform" />
           </CtaButton>
         </FlexBox>
       </FlexBox>


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Masthead - on scrolling up, use dark color schedule (black bg with white logo and buttons), with reduced vertical offset between the 2 buttons (which shrinks the height of the masthead)
- Other minor fixups
- Responsive and spacing finetune will be dealt with later after design is finalized

# Review By (Date)
- Approved by clients


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview and scroll down
2. Scroll back up to see the masthead reappearing like this
![Screenshot 2023-06-26 at 12 14 58 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/67933611-0b1f-45e1-bc30-759bd6c6ff7f)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-148