### PR TITLE
GIVCAMP-154 | Add Storyblok Grid options

### DIFF
--- a/src/components/Grid/Grid.styles.ts
+++ b/src/components/Grid/Grid.styles.ts
@@ -54,7 +54,8 @@ export const gridGaps = {
   default: 'su-grid-gap',
   card: 'su-grid-gap su-gap-y-[5rem] xl:su-gap-y-[7rem]',
   split: 'md:su-gap-x-[6rem] lg:su-gap-x-[10rem] xl:su-gap-x-[20rem] 2xl:su-gap-x-[28rem]',
-  xs: 'su-gap-x-[0.4rem] su-gap-y-[5rem] xl:su-gap-y-[7rem]',
+  xs: 'su-gap-[0.4rem]',
+  'xs-horizontal': 'su-gap-x-[0.4rem] su-gap-y-[5rem] xl:su-gap-y-[7rem]',
 };
 
 export const gridJustifyContent = {

--- a/src/components/Storyblok/SbGrid.tsx
+++ b/src/components/Storyblok/SbGrid.tsx
@@ -1,24 +1,50 @@
 import React from 'react';
 import { storyblokEditable } from 'gatsby-source-storyblok';
-import { Grid } from '../Grid';
+import { Grid, GridGapType, GridNumColsType } from '../Grid';
 import { CreateBloks } from '../CreateBloks';
 
 type SbGridProps = {
   blok: {
     _uid: string;
-    gap?: 'default' | 'card' | 'xs'
+    gap?: GridGapType;
     items: any[];
+    /**
+     * Currently we're only providing 1-4 columns in Storyblok even though GridNumColsType also supports 6 and 12
+     * We could add support for 6 and 12 in the future if needed
+     */
+    xs?: GridNumColsType
+    sm?: GridNumColsType
+    md?: GridNumColsType
+    lg?: GridNumColsType
+    xl?: GridNumColsType
+    xxl?: GridNumColsType
   };
 };
 
 export const SbGrid = ({
   blok: {
-    items,
     gap,
+    items,
+    xs = 1,
+    sm = 1,
+    md = 2,
+    lg = 2,
+    xl = 3,
+    xxl = 3,
   },
   blok,
 }: SbGridProps) => (
-  <Grid md={2} xl={3} gap={gap} {...storyblokEditable(blok)} key={blok._uid}>
+  <Grid
+    xs={xs}
+    sm={sm}
+    md={md}
+    lg={lg}
+    xl={xl}
+    xxl={xxl}
+    gap={gap}
+    {...storyblokEditable(blok)}
+    key={blok._uid}
+  >
     <CreateBloks blokSection={items} />
   </Grid>
 );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding grid column and extra grid gap options to the Storyblok Grid

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the Initiative page https://deploy-preview-91--giving-campaign.netlify.app/initiatives/
2. Look at the card grid
3. It should have a grid gap of 4px (both horizontal and vertical)
4. on LG+, there should be 4 columns
5. SM-MD = 2 columns
6. XS = 1 column

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-154