### PR TITLE
GIVCAMP-149 | Responsive CTAs

### DIFF
--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -58,8 +58,9 @@ export const ctaCurves = {
 };
 
 export const ctaSizes = {
-  default: 'pt-9 pb-10 pl-22 pr-20 lg:pt-10 lg:pb-11 text-16 md:text-18 xl:text-20',
-  large: 'pl-22 pr-20 pt-10 pb-11 lg:pr-34 lg:pl-40 lg:pt-20 lg:pb-22 text-18 md:text-20 xl:text-24',
+  default: 'pt-9 pb-10 pl-18 pr-16 lg:pl-22 lg:pr-20 lg:pt-10 lg:pb-11 text-16 lg:text-20',
+  large: 'pl-28 pr-26 pt-16 pb-17 lg:pr-40 lg:pl-44 lg:pt-20 lg:pb-22 text-18 lg:text-24',
+  link: 'text-16 lg:text-20',
   mainNav: 'text-14 px-10 pt-8 pb-9 lg:px-24 lg:pt-18 lg:pb-19 lg:text-20',
   'footer-featured': 'ma-intro',
   card: 'ma-card',

--- a/components/HeroIcon/HeroIcon.styles.tsx
+++ b/components/HeroIcon/HeroIcon.styles.tsx
@@ -53,8 +53,8 @@ export type IconType = keyof typeof iconMap;
 // TODO: Adjust these base styles as they were ported over when we were using v1 of Heroicons
 export const iconBaseStyle = {
   default: 'w-1em',
-  'arrow-left': 'w-08em',
-  'arrow-right': 'w-08em',
+  'arrow-left': 'w-09em -mt-01em',
+  'arrow-right': 'w-09em -mt-01em',
   'triangle-right': 'w-09em scale-x-[0.9] mt-01em',
   'triangle-down': 'w-09em scale-x-[0.9] rotate-90 mt-01em',
   'triangle-up': 'w-09em scale-x-[0.9] -rotate-90 mt-02em',

--- a/components/Masthead/Masthead.tsx
+++ b/components/Masthead/Masthead.tsx
@@ -75,36 +75,30 @@ export const Masthead = ({ isLight, className }: MastheadProps) => {
           className={cnb('w-170 sm:w-240 transition-[width] !duration-100', isAtTop ? 'lg:w-[32rem]' : 'lg:w-280')}
         />
         {/* The scale3d here solves a Firefox only rendering bug with blurry curved borders when using transform */}
-        <m.div
-          animate={{ scale: isAtTop ? 1 : 0.75 }}
-          transition={{ duration: 0.1, ease: 'easeInOut' }}
-          className="origin-right"
-        >
-          <FlexBox alignItems="center">
-            <CtaLink
-              href={ood.give}
-              variant={ctaVariant}
-              color="current"
-              className={cnb(
-                'rounded-bl-[1.4rem] lg:rounded-bl-[2rem]',
-                isAtTop ? 'mt-10 lg:mt-26' : 'mt-5 lg:mt-16',
-              )}
-            >
-              Make a gift
-            </CtaLink>
-            <CtaButton
-              onClick={() => alert('Hello world')}
-              variant={ctaVariant}
-              color="current"
-              className={cnb(
-                '-ml-2 rounded-tr-[1.4rem] lg:rounded-tr-[2rem]',
-                isAtTop ? '-mt-10 lg:-mt-26' : '-mt-5 lg:-mt-10',
-              )}
-            >
-              <HeroIcon icon="menu" title="Main menu" noBaseStyle className="w-20 lg:w-32 group-hocus:scale-y-75 will-change-transform" />
-            </CtaButton>
-          </FlexBox>
-        </m.div>
+        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'origin-right lg:[transform:scale3d(0.75,0.75,0.75)]')}>
+          <CtaLink
+            href={ood.give}
+            variant={ctaVariant}
+            color="current"
+            className={cnb(
+              'rounded-bl-[1.4rem] lg:rounded-bl-[2rem]',
+              isAtTop ? 'mt-10 lg:mt-26' : 'mt-5 lg:mt-16',
+            )}
+          >
+            Make a gift
+          </CtaLink>
+          <CtaButton
+            onClick={() => alert('Hello world')}
+            variant={ctaVariant}
+            color="current"
+            className={cnb(
+              '-ml-2 rounded-tr-[1.4rem] lg:rounded-tr-[2rem]',
+              isAtTop ? '-mt-10 lg:-mt-26' : '-mt-5 lg:-mt-10',
+            )}
+          >
+            <HeroIcon icon="menu" title="Main menu" noBaseStyle className="w-20 lg:w-32 group-hocus:scale-y-75 will-change-transform" />
+          </CtaButton>
+        </FlexBox>
       </FlexBox>
     </m.div>
   );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Put in the real CTA responsive now that they're in
- Don't scale down the masthead CTAs on scrolling up on mobile (only do that for desktop)

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at code
2. At mobile breakpoint, scroll down, then scroll back up - check that the menu buttons should not change size (when the solid black background masthead reappears on scrolling up)

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-149
