### PR TITLE
GIVCAMP-189 | Masthead changes and add lockup

### DIFF
--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -69,7 +69,7 @@ export const ctaSizes: CtaSizeObjectType = {
   default: 'pt-9 pb-10 pl-18 pr-16 lg:pl-22 lg:pr-20 lg:pt-10 lg:pb-11 text-16 lg:text-20',
   large: 'pl-28 pr-26 pt-16 pb-17 lg:pr-40 lg:pl-44 lg:pt-20 lg:pb-22 text-18 lg:text-24',
   link: 'text-16 lg:text-20',
-  mainNav: 'text-14 px-10 pt-8 pb-9 lg:px-24 lg:pt-18 lg:pb-19 lg:text-20',
+  mainNav: 'text-14 px-10 pt-8 pb-9 lg:px-22 lg:py-15 lg:text-20',
   back: 'text-16',
   close: 'text-18 md:text-21',
   chip: 'py-7 px-22 text-18',

--- a/components/Logo/Logo.styles.ts
+++ b/components/Logo/Logo.styles.ts
@@ -13,3 +13,17 @@ export const link = (color: LogoColorType) => cnb('group block no-underline focu
   'focus-visible:ring-gc-black': color === 'black',
   'focus-visible:ring-white': color === 'white',
 });
+
+// Giving Logo styles
+export const root = 'lockup no-underline inline-block font-normal';
+export const logo = 'text-[1.43em] leading-half mt-[0.27em]';
+export const bar = 'w-1 h-1em mx-03em';
+export const text = 'text-[0.95em] sm:text-[1.1em] mt-[0.25em]';
+export const textColor = {
+  default: 'text-gc-black',
+  white: 'text-white',
+};
+export const barColor = {
+  default: 'bg-gc-black',
+  white: 'bg-white',
+};

--- a/components/Logo/LogoLockup.tsx
+++ b/components/Logo/LogoLockup.tsx
@@ -1,0 +1,61 @@
+import React, { AllHTMLAttributes } from 'react';
+import { cnb } from 'cnbuilder';
+import { StanfordLogo } from '@/components/StanfordLogo';
+import Link from 'next/link';
+import { FlexBox } from '@/components/FlexBox';
+import * as styles from './Logo.styles';
+
+/**
+ * Stanford Department Branding Component.
+ */
+type LogoLockupProps = {
+  text: string;
+  isLink?: boolean;
+  color?: 'default' | 'white';
+  className?: string;
+}
+
+export const LogoLockup = ({
+  text,
+  isLink,
+  color = 'default',
+  className,
+  ...rest
+}: LogoLockupProps) => {
+  const levers: { [key: string]: string } = {};
+  levers.textColor = styles.textColor[color];
+  levers.bar = styles.barColor[color];
+
+  // Partials
+  const LockupContent = (
+    <FlexBox alignItems="center">
+      <StanfordLogo
+        color={color === 'white' ? 'white' : 'cardinal-red'}
+        isLink={false}
+        className={cnb(styles.logo)}
+      />
+      <div className={cnb(styles.bar, levers.bar)} aria-hidden />
+      <div className={cnb(styles.text, levers.textColor)}>
+        {text}
+      </div>
+    </FlexBox>
+  );
+
+  if (isLink) {
+    return (
+      <Link
+        className={cnb(styles.root, className)}
+        href="/"
+        {...rest}
+      >
+        {LockupContent}
+      </Link>
+    );
+  }
+
+  return (
+    <div className={cnb(styles.root, className)} {...rest}>
+      {LockupContent}
+    </div>
+  );
+};

--- a/components/Logo/index.ts
+++ b/components/Logo/index.ts
@@ -1,4 +1,5 @@
 export * from './Logo';
+export * from './LogoLockup';
 export * from './OnPurpo';
 export * from './Ose';
 export * from './LogoHorizontal';

--- a/components/Masthead/Masthead.tsx
+++ b/components/Masthead/Masthead.tsx
@@ -5,17 +5,16 @@ import {
 } from 'framer-motion';
 import { cnb } from 'cnbuilder';
 import { FlexBox } from '../FlexBox';
-import { Logo } from '../Logo';
-import { CtaLink, CtaButton, type CtaVariantType } from '../Cta';
+import { LogoLockup } from '@/components/Logo/LogoLockup';
+import { CtaLink, type CtaVariantType } from '../Cta';
 import { ood } from '@/utilities/externalLinks';
-import { HeroIcon } from '../HeroIcon';
 
 type MastheadProps = HTMLAttributes<HTMLDivElement> & {
   isLight?: boolean;
 };
 
 export const Masthead = ({ isLight, className }: MastheadProps) => {
-  const slideDistance = 86;
+  const slideDistance = 76;
   const threshold = 200;
 
   const { scrollY } = useScroll();
@@ -57,47 +56,32 @@ export const Masthead = ({ isLight, className }: MastheadProps) => {
     <m.div
       className={cnb(
         'w-full fixed top-0 z-50 transition-colors will-change-transform',
-        !isAtTop && isScrollingBack ? 'bg-gc-black border-b border-b-black-80' : 'bg-transparent border-b-transparent',
+        !isAtTop && isScrollingBack ? 'bg-gc-black border-b border-b-black-80 h-60 lg:h-[6.8rem]' : 'bg-transparent border-b-transparent h-[7.6rem]',
         className,
       )}
       animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
-      transition={{ duration: 0.2, delay: 0, ease: 'easeInOut' }}
-      style={{ height: slideDistance, willChange }}
+      transition={{ duration: 0.2, delay: !isAtTop && isScrollingBack ? 0.4 : 0, ease: 'easeInOut' }}
     >
       <FlexBox
         justifyContent="between"
         alignItems="center"
-        className={cnb('cc transition py-18 3xl:px-100', !isAtTop ? 'lg:py-3' : 'md:py-26')}
+        className={cnb('cc transition 3xl:px-100 py-12', !isAtTop ? 'lg:py-6' : 'md:py-26')}
       >
-        <Logo
-          color={isLight && isAtTop ? 'black' : 'white'}
+        <LogoLockup
           isLink
-          className={cnb('w-170 sm:w-240 transition-[width] !duration-100', isAtTop ? 'lg:w-[32rem]' : 'lg:w-280')}
+          color={isLight && isAtTop ? 'default' : 'white'}
+          text="Giving"
+          className=""
         />
         {/* The scale3d here solves a Firefox only rendering bug with blurry curved borders when using transform */}
-        <FlexBox alignItems="center" className={cnb('su-transition-all', isAtTop ? '' : 'origin-right lg:[transform:scale3d(0.75,0.75,0.75)]')}>
+        <FlexBox alignItems="center" className={cnb('transition-all', isAtTop ? '' : 'origin-right lg:[transform:scale3d(0.75,0.75,0.75)]')}>
           <CtaLink
             href={ood.give}
             variant={ctaVariant}
             color="current"
-            className={cnb(
-              'rounded-bl-[1.4rem] lg:rounded-bl-[2rem]',
-              isAtTop ? 'mt-10 lg:mt-26' : 'mt-5 lg:mt-16',
-            )}
           >
             Make a gift
           </CtaLink>
-          <CtaButton
-            onClick={() => alert('Hello world')}
-            variant={ctaVariant}
-            color="current"
-            className={cnb(
-              '-ml-2 rounded-tr-[1.4rem] lg:rounded-tr-[2rem]',
-              isAtTop ? '-mt-10 lg:-mt-26' : '-mt-5 lg:-mt-10',
-            )}
-          >
-            <HeroIcon icon="menu" title="Main menu" noBaseStyle className="w-20 lg:w-32 group-hocus:scale-y-75 will-change-transform" />
-          </CtaButton>
         </FlexBox>
       </FlexBox>
     </m.div>

--- a/components/StoryPoC/VideoScrollStory.tsx
+++ b/components/StoryPoC/VideoScrollStory.tsx
@@ -47,14 +47,14 @@ export const VideoScrollStory = () => {
       </div>
       <div ref={contentRef} className="relative w-2/3 lg:w-1/3 mx-auto text-white z-10 rs-py-10 -mt-[80vh]">
         <section>
-          <AnimateInView animation="fadeIn" duration={0.6} className="w-[200%] -ml-[50%] mb-500">
+          <AnimateInView animation="fadeIn" duration={0.6} className="lg:w-[200%] lg:-ml-[50%] mb-500">
             <Heading
               leading="tight"
               align="center"
               font="serif"
               weight="semibold"
               size={6}
-              className="mb-02em"
+              className="mb-02em max-w-1200"
             >
               Heading lorem ipsum universe
             </Heading>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use the Giving lockup for the logo in the masthead, and remove the menu button with style updates.
- Add responsive behavior

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to these 2 pages and see both the light and dark version of the masthead, also, scroll down for a while, then back up to see the compact version of the masthead. Check mobile behavior also.
https://deploy-preview-116--giving-campaign.netlify.app/stories/poc-video-scrolling-story
https://deploy-preview-116--giving-campaign.netlify.app/stories/harnessing-satellite-imagery-ai-to-help-fight-poverty

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-189
