### PR TITLE
GIVCAMP-176 | Modularize import for heroicons

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,16 @@ const nextConfig = {
       },
     ],
   },
+  // TODO: This has been merged into Next.js canary, but not in v13.4.9 yet
+  // https://github.com/vercel/next.js/pull/53902
+  modularizeImports: {
+    '@heroicons/react/24/solid': {
+      transform: '@heroicons/react/24/solid/{{member}}',
+    },
+    '@heroicons/react/24/outline': {
+      transform: '@heroicons/react/24/outline/{{member}}',
+    },
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Modularize import for HeroIcons to prevent compilation of hundreds the unused icons (HeroIcons use a barrel file)
- See https://nextjs.org/docs/architecture/nextjs-compiler#modularize-imports
- And this discusssion https://github.com/vercel/next.js/issues/48748
- Note: After I looked at it for a while, it looks like next.js made this a default for heroicons - the code is currently in canary and not in the next.js version we're using v13.4.9 (I would like to stay at this version for now). We might be able to remove this in the future, but for now it is good to have. (And it was good for me to look into this)
https://github.com/vercel/next.js/pull/53902

# Review By (Date)
- Whenever


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and see that the arrow icons are still appearing
![Screenshot 2023-08-30 at 10 29 15 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/481d0fdc-f6f4-4def-8cc5-7dc35eaa7c55)


2. Look at code, and the links in the summary of this PR

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-176