### PR TITLE
GIVCAMP-201 | Blurry poster options and responsive

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -9,18 +9,20 @@ export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
 });
 
 export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
-  'lg:w-[120%] lg:-ml-[20%] 3xl:w-auto 3xl:-ml-100 lg:mr-0' : imageOnLeft,
+  'lg:w-[120%] lg:-ml-[20%] 3xl:w-auto 3xl:-ml-200 lg:mr-0' : imageOnLeft,
 });
 export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('', {
   '' : imageOnLeft,
   '' : !imageOnLeft,
 });
-export const heading = (imageOnLeft: boolean) => cnb('mb-0', {
+export const heading = (imageOnLeft: boolean, isSmallHeading: boolean) => cnb('mb-0', {
   'border-r-[1rem] md:border-r-[2rem] lg:border-r-[3rem] xl:border-r-[4rem] pr-10 sm:pr-20 md:pr-30 lg:pr-50 xl:pr-60': imageOnLeft,
   'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] pl-10 pr-20 sm:pl-20 sm:pl-30 md:pl-30 md:pr-50 lg:pl-50 xl:pl-60 lg:pr-0 3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[120%]': !imageOnLeft,
+  'fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
+  'fluid-type-9': !isSmallHeading,
 });
 
-export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc', {
+export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc w-full', {
   '3xl:pr-[calc(100%-750px)] lg:pl-60': imageOnLeft,
   '3xl:pl-[calc(100%-750px)] lg:pr-60': !imageOnLeft,
 });

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -1,24 +1,31 @@
 import { cnb } from 'cnbuilder';
 
-export const root = 'relative bg-no-repeat bg-cover bg-center overflow-hidden';
+export const root = 'relative bg-no-repeat bg-cover bg-center overflow-hidden break-words';
 export const blurWrapper = 'w-full h-full backdrop-blur-md';
-
-export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
-  'flex-row-reverse' : imageOnLeft,
-});
-export const heading = (imageOnLeft: boolean) => cnb('mb-0 -mt-01em', {
-  'cc-right': imageOnLeft,
-  'cc-left -ml-8 md:-ml-20 lg:-ml-40 w-full': !imageOnLeft,
-});
 
 export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
   'lg:order-last': imageOnLeft,
   'lg:order-first': !imageOnLeft,
 });
 
-export const bodyWrapper = (imageOnLeft: boolean) => imageOnLeft ? 'cc 3xl:pr-[calc(100%-750px)] lg:rs-pl-4' : 'cc 3xl:pl-[calc(100%-750px)] lg:rs-pr-2';
+export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
+  // 'flex-row-reverse' : imageOnLeft,
+});
+export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('', {
+  '' : imageOnLeft,
+  '' : !imageOnLeft,
+});
+export const heading = (imageOnLeft: boolean) => cnb('mb-0', {
+  'border-r-[1rem] md:border-r-[2rem] lg:border-r-[3rem] xl:border-r-[4rem] pr-10 sm:pr-20 md:pr-30 lg:pr-50 xl:pr-60': imageOnLeft,
+  'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] pl-10 sm:pl-20 md:pl-30 lg:pl-50 xl:pl-60': !imageOnLeft,
+});
+
+export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc', {
+  '3xl:pr-[calc(100%-750px)] lg:pl-60': imageOnLeft,
+  '3xl:pl-[calc(100%-750px)] lg:pr-60': !imageOnLeft,
+});
 
 export const imageWrapper = (imageOnLeft: boolean) => cnb('mt-30 md:mt-50 lg:mt-0 shrink-0 cc', {
-  'lg:order-first 3xl:pl-[calc(100%-750px)]': imageOnLeft,
-  ' 3xl:pr-[calc(100%-750px)]': !imageOnLeft,
+  'lg:order-first 3xl:pl-[calc(100%-750px)] lg:pr-0': imageOnLeft,
+  ' 3xl:pr-[calc(100%-750px)] lg:pl-0': !imageOnLeft,
 });

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -9,7 +9,7 @@ export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
 });
 
 export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
-  // 'flex-row-reverse' : imageOnLeft,
+  'lg:w-[120%] lg:-ml-[20%] 3xl:w-auto 3xl:-ml-100 lg:mr-0' : imageOnLeft,
 });
 export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('', {
   '' : imageOnLeft,
@@ -17,7 +17,7 @@ export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('', {
 });
 export const heading = (imageOnLeft: boolean) => cnb('mb-0', {
   'border-r-[1rem] md:border-r-[2rem] lg:border-r-[3rem] xl:border-r-[4rem] pr-10 sm:pr-20 md:pr-30 lg:pr-50 xl:pr-60': imageOnLeft,
-  'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] pl-10 sm:pl-20 md:pl-30 lg:pl-50 xl:pl-60': !imageOnLeft,
+  'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] pl-10 pr-20 sm:pl-20 sm:pl-30 md:pl-30 md:pr-50 lg:pl-50 xl:pl-60 lg:pr-0 3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[120%]': !imageOnLeft,
 });
 
 export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc', {
@@ -25,7 +25,7 @@ export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc', {
   '3xl:pl-[calc(100%-750px)] lg:pr-60': !imageOnLeft,
 });
 
-export const imageWrapper = (imageOnLeft: boolean) => cnb('mt-30 md:mt-50 lg:mt-0 shrink-0 cc', {
+export const imageWrapper = (imageOnLeft: boolean) => cnb('w-full mt-30 md:mt-50 lg:mt-0 shrink-0 cc', {
   'lg:order-first 3xl:pl-[calc(100%-750px)] lg:pr-0': imageOnLeft,
   ' 3xl:pr-[calc(100%-750px)] lg:pl-0': !imageOnLeft,
 });

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -3,6 +3,8 @@ import { cnb } from 'cnbuilder';
 export const root = 'relative bg-no-repeat bg-cover bg-center overflow-hidden break-words';
 export const blurWrapper = 'w-full h-full backdrop-blur-md';
 
+export const grid = 'w-full rs-py-8';
+
 export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
   'lg:order-last': imageOnLeft,
   'lg:order-first': !imageOnLeft,
@@ -11,15 +13,14 @@ export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
 export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
   'lg:w-[120%] lg:-ml-[20%] 3xl:w-auto 3xl:-ml-200 lg:mr-0' : imageOnLeft,
 });
-export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('', {
-  '' : imageOnLeft,
-  '' : !imageOnLeft,
+export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('pl-10 pr-20 sm:pl-30 sm:pr-20 md:pl-30 md:pr-50', {
+  'border-l-[1rem] md:border-l-[2rem] lg:border-l-0 lg:border-r-[3rem] xl:border-r-[4rem] lg:pl-0 lg:pr-50 xl:pr-60': imageOnLeft,
+  'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] lg:pl-50 xl:pl-60 lg:pr-0 3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[120%]': !imageOnLeft,
 });
-export const heading = (imageOnLeft: boolean, isSmallHeading: boolean) => cnb('mb-0', {
-  'border-r-[1rem] md:border-r-[2rem] lg:border-r-[3rem] xl:border-r-[4rem] pr-10 sm:pr-20 md:pr-30 lg:pr-50 xl:pr-60': imageOnLeft,
-  'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] pl-10 pr-20 sm:pl-20 sm:pl-30 md:pl-30 md:pr-50 lg:pl-50 xl:pl-60 lg:pr-0 3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[120%]': !imageOnLeft,
-  'fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
-  'fluid-type-9': !isSmallHeading,
+export const heading = (imageOnLeft: boolean, isSmallHeading: boolean) => cnb('mb-0 -mt-01em fluid-type-7', {
+  '3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[130%]': !imageOnLeft,
+  'md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
+  'md:fluid-type-9': !isSmallHeading,
 });
 
 export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc w-full', {
@@ -27,7 +28,11 @@ export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc w-full', {
   '3xl:pl-[calc(100%-750px)] lg:pr-60': !imageOnLeft,
 });
 
+export const cta = 'rs-mt-4';
+
 export const imageWrapper = (imageOnLeft: boolean) => cnb('w-full mt-30 md:mt-50 lg:mt-0 shrink-0 cc', {
   'lg:order-first 3xl:pl-[calc(100%-750px)] lg:pr-0': imageOnLeft,
   ' 3xl:pr-[calc(100%-750px)] lg:pl-0': !imageOnLeft,
 });
+export const image = 'h-full w-full object-cover object-center hidden lg:block';
+export const imageMobile = 'h-full w-full object-cover object-center lg:hidden';

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -3,15 +3,22 @@ import { cnb } from 'cnbuilder';
 export const root = 'relative bg-no-repeat bg-cover bg-center overflow-hidden';
 export const blurWrapper = 'w-full h-full backdrop-blur-md';
 
-export const heading = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5 lg:w-[140%]', {
-  'lg:ml-[-40%]': imageOnLeft,
+export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
+  'flex-row-reverse' : imageOnLeft,
+});
+export const heading = (imageOnLeft: boolean) => cnb('mb-0 -mt-01em', {
+  'cc-right': imageOnLeft,
+  'cc-left -ml-8 md:-ml-20 lg:-ml-40 w-full': !imageOnLeft,
 });
 
-export const contentWrapper = (imageOnLeft: boolean) => cnb('z-10', {
+export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
   'order-last lg:rs-pl-4': imageOnLeft,
   'order-first lg:rs-pr-2': !imageOnLeft,
 });
 
+export const bodyWrapper = (imageOnLeft: boolean) => imageOnLeft ? 'cc-right' : 'cc-left';
+
 export const imageWrapper = (imageOnLeft: boolean) => cnb('', {
-  'order-first': imageOnLeft,
+  'order-first cc-left': imageOnLeft,
+  'cc-right': !imageOnLeft,
 });

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -12,13 +12,13 @@ export const heading = (imageOnLeft: boolean) => cnb('mb-0 -mt-01em', {
 });
 
 export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
-  'order-last lg:rs-pl-4': imageOnLeft,
-  'order-first lg:rs-pr-2': !imageOnLeft,
+  'order-last': imageOnLeft,
+  'order-first': !imageOnLeft,
 });
 
-export const bodyWrapper = (imageOnLeft: boolean) => imageOnLeft ? 'cc-right' : 'cc-left';
+export const bodyWrapper = (imageOnLeft: boolean) => imageOnLeft ? 'cc-right lg:rs-pl-4' : 'cc-left lg:rs-pr-2';
 
-export const imageWrapper = (imageOnLeft: boolean) => cnb('', {
+export const imageWrapper = (imageOnLeft: boolean) => cnb('shrink-0', {
   'order-first cc-left': imageOnLeft,
   'cc-right': !imageOnLeft,
 });

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -12,13 +12,13 @@ export const heading = (imageOnLeft: boolean) => cnb('mb-0 -mt-01em', {
 });
 
 export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
-  'order-last': imageOnLeft,
-  'order-first': !imageOnLeft,
+  'lg:order-last': imageOnLeft,
+  'lg:order-first': !imageOnLeft,
 });
 
-export const bodyWrapper = (imageOnLeft: boolean) => imageOnLeft ? 'cc-right lg:rs-pl-4' : 'cc-left lg:rs-pr-2';
+export const bodyWrapper = (imageOnLeft: boolean) => imageOnLeft ? 'cc 3xl:pr-[calc(100%-750px)] lg:rs-pl-4' : 'cc 3xl:pl-[calc(100%-750px)] lg:rs-pr-2';
 
-export const imageWrapper = (imageOnLeft: boolean) => cnb('shrink-0', {
-  'order-first cc-left': imageOnLeft,
-  'cc-right': !imageOnLeft,
+export const imageWrapper = (imageOnLeft: boolean) => cnb('mt-30 md:mt-50 lg:mt-0 shrink-0 cc', {
+  'lg:order-first 3xl:pl-[calc(100%-750px)]': imageOnLeft,
+  ' 3xl:pr-[calc(100%-750px)]': !imageOnLeft,
 });

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -54,17 +54,16 @@ export const BlurryPoster = ({
   return (
     <Container {...props} bgColor="black" width="full" className={styles.root} style={bgImageStyle}>
       <div className={styles.blurWrapper}>
-        <Grid lg={2} className="w-full rs-py-8">
+        <Grid lg={2} className={styles.grid}>
           <div className={styles.contentWrapper(imageOnLeft)}>
             <FlexBox className={styles.headingWrapper(imageOnLeft)}>
               {heading &&  (
-                <div className={styles.headingInnerWrapper(imageOnLeft)}>
+                <div className={cnb(styles.headingInnerWrapper(imageOnLeft), accentBorderColors[tabColor])}>
                   <Heading
-                    // size={isSmallHeading ? 'f8' : 'f9'}
                     font="druk"
                     color="white"
                     leading="none"
-                    className={cnb(styles.heading(imageOnLeft, isSmallHeading), accentBorderColors[tabColor])}
+                    className={styles.heading(imageOnLeft, isSmallHeading)}
                   >
                     {heading}
                   </Heading>
@@ -82,26 +81,28 @@ export const BlurryPoster = ({
                 <time dateTime={publishedDate}>{formattedDate}</time>
               )}
               {cta && (
-                <div className="rs-mt-4">
+                <div className={styles.cta}>
                   {cta}
                 </div>
               )}
             </div>
           </div>
-          {imageSrc && (
-            <div className={styles.imageWrapper(imageOnLeft)}>
-              <img
-                src={getProcessedImage(imageSrc, '900x1200', imageFocus)}
-                alt=""
-                className="h-full w-full object-cover object-center hidden lg:block"
-              />
-              <img
-                src={getProcessedImage(imageSrc, '800x400', imageFocus)}
-                alt=""
-                className="h-full w-full object-cover object-center lg:hidden"
-              />
-            </div>
-          )}
+          <div className={styles.imageWrapper(imageOnLeft)}>
+            {imageSrc && (
+              <>
+                <img
+                  src={getProcessedImage(imageSrc, '900x1200', imageFocus)}
+                  alt=""
+                  className={styles.image}
+                />
+                <img
+                  src={getProcessedImage(imageSrc, '800x400', imageFocus)}
+                  alt=""
+                  className={styles.imageMobile}
+                />
+              </>
+            )}
+          </div>
         </Grid>
       </div>
     </Container>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -104,7 +104,12 @@ export const BlurryPoster = ({
             <img
               src={getProcessedImage(imageSrc, '1200x1600', imageFocus)}
               alt=""
-              className="h-full w-full object-cover object-center"
+              className="h-full w-full object-cover object-center hidden lg:block"
+            />
+            <img
+              src={getProcessedImage(imageSrc, '800x400', imageFocus)}
+              alt=""
+              className="h-full w-full object-cover object-center lg:hidden"
             />
           </div>
         </Grid>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -8,7 +8,7 @@ import {
 } from '../Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import * as styles from './BlurryPoster.styles';
-import { accentBgColors, type AccentColorType } from '@/utilities/datasource';
+import { accentBorderColors, type AccentColorType } from '@/utilities/datasource';
 
 type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   bgImageSrc?: string;
@@ -59,23 +59,25 @@ export const BlurryPoster = ({
         <Grid lg={2} className="w-full rs-py-8">
           <div className={styles.contentWrapper(imageOnLeft)}>
             <FlexBox className={styles.headingWrapper(imageOnLeft)}>
-              {tabColor && (
+              {/* {tabColor && (
                 <div className={cnb(
                   'block w-8 md:w-20 lg:w-40',
                   accentBgColors[tabColor],
                   )}
                 />
-              )}
+              )} */}
               {heading &&  (
-                <Heading
-                  size={isSmallHeading ? 'f8' : 'f9'}
-                  font="druk"
-                  color="white"
-                  leading="none"
-                  className={styles.heading(imageOnLeft)}
-                >
-                  {heading}
-                </Heading>
+                <div className={styles.headingInnerWrapper(imageOnLeft)}>
+                  <Heading
+                    size={isSmallHeading ? 'f8' : 'f9'}
+                    font="druk"
+                    color="white"
+                    leading="none"
+                    className={cnb(styles.heading(imageOnLeft), accentBorderColors[tabColor])}
+                  >
+                    {heading}
+                  </Heading>
+                </div>
               )}
               {customHeading && (
                 <div className="rs-mt-7 rs-mb-5">

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -17,7 +17,6 @@ type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   headingLevel?: HeadingType;
   heading?: string;
   isSmallHeading?: boolean;
-  customHeading?: React.ReactNode;
   body?: string;
   byline?: string;
   publishedDate?: string;
@@ -34,7 +33,6 @@ export const BlurryPoster = ({
   heading,
   headingLevel = 'h2',
   isSmallHeading,
-  customHeading,
   body,
   byline,
   publishedDate,
@@ -59,29 +57,17 @@ export const BlurryPoster = ({
         <Grid lg={2} className="w-full rs-py-8">
           <div className={styles.contentWrapper(imageOnLeft)}>
             <FlexBox className={styles.headingWrapper(imageOnLeft)}>
-              {/* {tabColor && (
-                <div className={cnb(
-                  'block w-8 md:w-20 lg:w-40',
-                  accentBgColors[tabColor],
-                  )}
-                />
-              )} */}
               {heading &&  (
                 <div className={styles.headingInnerWrapper(imageOnLeft)}>
                   <Heading
-                    size={isSmallHeading ? 'f8' : 'f9'}
+                    // size={isSmallHeading ? 'f8' : 'f9'}
                     font="druk"
                     color="white"
                     leading="none"
-                    className={cnb(styles.heading(imageOnLeft), accentBorderColors[tabColor])}
+                    className={cnb(styles.heading(imageOnLeft, isSmallHeading), accentBorderColors[tabColor])}
                   >
                     {heading}
                   </Heading>
-                </div>
-              )}
-              {customHeading && (
-                <div className="rs-mt-7 rs-mb-5">
-                  {customHeading}
                 </div>
               )}
             </FlexBox>
@@ -102,18 +88,20 @@ export const BlurryPoster = ({
               )}
             </div>
           </div>
-          <div className={styles.imageWrapper(imageOnLeft)}>
-            <img
-              src={getProcessedImage(imageSrc, '1200x1600', imageFocus)}
-              alt=""
-              className="h-full w-full object-cover object-center hidden lg:block"
-            />
-            <img
-              src={getProcessedImage(imageSrc, '800x400', imageFocus)}
-              alt=""
-              className="h-full w-full object-cover object-center lg:hidden"
-            />
-          </div>
+          {imageSrc && (
+            <div className={styles.imageWrapper(imageOnLeft)}>
+              <img
+                src={getProcessedImage(imageSrc, '900x1200', imageFocus)}
+                alt=""
+                className="h-full w-full object-cover object-center hidden lg:block"
+              />
+              <img
+                src={getProcessedImage(imageSrc, '800x400', imageFocus)}
+                alt=""
+                className="h-full w-full object-cover object-center lg:hidden"
+              />
+            </div>
+          )}
         </Grid>
       </div>
     </Container>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -1,12 +1,14 @@
 import { HTMLAttributes } from 'react';
+import { cnb } from 'cnbuilder';
 import { Container } from '../Container';
 import { Grid } from '../Grid';
+import { FlexBox } from '../FlexBox';
 import {
   Heading, Paragraph, Text, type HeadingType,
 } from '../Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import * as styles from './BlurryPoster.styles';
-import { image } from '../Banner';
+import { accentBgColors, type AccentColorType } from '@/utilities/datasource';
 
 type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   bgImageSrc?: string;
@@ -21,6 +23,7 @@ type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   publishedDate?: string;
   imageSrc?: string;
   imageFocus?: string;
+  tabColor?: AccentColorType;
   cta?: React.ReactNode;
 };
 
@@ -37,6 +40,7 @@ export const BlurryPoster = ({
   publishedDate,
   imageSrc,
   imageFocus,
+  tabColor,
   cta,
   className,
   ...props
@@ -52,38 +56,49 @@ export const BlurryPoster = ({
   return (
     <Container {...props} bgColor="black" width="full" className={styles.root} style={bgImageStyle}>
       <div className={styles.blurWrapper}>
-        <Grid lg={2} className="cc rs-py-8">
+        <Grid lg={2} className="w-full rs-py-8">
           <div className={styles.contentWrapper(imageOnLeft)}>
-            {heading &&  (
-              <Heading
-                size={isSmallHeading ? 'f8' : 'f9'}
-                font="druk"
-                color="white"
-                leading="none"
-                className={styles.heading(imageOnLeft)}
-              >
-                {heading}
-              </Heading>
-            )}
-            {customHeading && (
-              <div className="rs-mt-7 rs-mb-5">
-                {customHeading}
-              </div>
-            )}
-            {body && (
-              <Paragraph size={2} color="white" leading="display">{body}</Paragraph>
-            )}
-            {byline && (
-              <Text>{byline}</Text>
-            )}
-            {date && (
-              <time dateTime={publishedDate}>{formattedDate}</time>
-            )}
-            {cta && (
-              <div className="rs-mt-4">
-                {cta}
-              </div>
-            )}
+            <FlexBox className={styles.headingWrapper(imageOnLeft)}>
+              {tabColor && (
+                <div className={cnb(
+                  'block w-8 md:w-20 lg:w-40',
+                  accentBgColors[tabColor],
+                  )}
+                />
+              )}
+              {heading &&  (
+                <Heading
+                  size={isSmallHeading ? 'f8' : 'f9'}
+                  font="druk"
+                  color="white"
+                  leading="none"
+                  className={styles.heading(imageOnLeft)}
+                >
+                  {heading}
+                </Heading>
+              )}
+              {customHeading && (
+                <div className="rs-mt-7 rs-mb-5">
+                  {customHeading}
+                </div>
+              )}
+            </FlexBox>
+            <div className={styles.bodyWrapper(imageOnLeft)}>
+              {body && (
+                <Paragraph size={2} color="white" leading="display">{body}</Paragraph>
+              )}
+              {byline && (
+                <Text>{byline}</Text>
+              )}
+              {date && (
+                <time dateTime={publishedDate}>{formattedDate}</time>
+              )}
+              {cta && (
+                <div className="rs-mt-4">
+                  {cta}
+                </div>
+              )}
+            </div>
           </div>
           <div className={styles.imageWrapper(imageOnLeft)}>
             <img

--- a/components/Homepage/HomepageSplitHero.tsx
+++ b/components/Homepage/HomepageSplitHero.tsx
@@ -94,7 +94,7 @@ export const HomepageSplitHero = () => {
               <span className="italic">We’re</span> all in this <span className="italic">together</span>.
             </Heading>
           </AnimateInView>
-          <AnimateInView delay={0.2} animation="slideUp" className="max-w-1200 rs-ml-0">
+          <AnimateInView delay={0.2} animation="slideUp" className="max-w-1200 xl:ml-08em">
             <Paragraph size={2} weight="normal" leading="snug" className="max-w-1000 ml-0 mr-auto">
               Sustaining a thriving planet. Accelerating solutions and empowering the next generation of leaders.
             </Paragraph>

--- a/components/Storyblok/SbBlurryPoster.tsx
+++ b/components/Storyblok/SbBlurryPoster.tsx
@@ -3,6 +3,7 @@ import { BlurryPoster } from '../BlurryPoster';
 import { CreateBloks } from '../CreateBloks';
 import { type HeadingType } from '../Typography';
 import { type SbImageType } from './Storyblok.types';
+import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 
 type SbBlurryPosterProps = {
   blok: {
@@ -17,6 +18,9 @@ type SbBlurryPosterProps = {
     cta?: SbBlokData[];
     image?: SbImageType;
     bgImage?: SbImageType;
+    tabColor?: {
+      value?: PaletteAccentHexColorType;
+    }
   }
 };
 
@@ -32,6 +36,7 @@ export const SbBlurryPoster = ({
     cta,
     image: { filename, focus } = {},
     bgImage: { filename: bgImageSrc, focus: bgImageFocus } = {},
+    tabColor: { value: tabColorValue } = {},
   },
   blok,
 }: SbBlurryPosterProps) => {
@@ -52,6 +57,7 @@ export const SbBlurryPoster = ({
       imageFocus={focus}
       bgImageSrc={bgImageSrc}
       bgImageFocus={bgImageFocus}
+      tabColor={paletteAccentColors[tabColorValue]}
     />
   );
 };

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -1,5 +1,5 @@
 import { cnb } from 'cnbuilder';
-import { storyblokEditable } from '@storyblok/react/rsc';
+import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '../CreateBloks';
 import { FlexBox } from '../FlexBox';
 import {
@@ -12,7 +12,7 @@ import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities
 type SbSectionProps = {
   blok: {
     _uid: string;
-    content?: any[];
+    content?: SbBlokData[];
     superhead?: string;
     heading?: string;
     headingLevel?: HeadingType;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,5 +30,6 @@ export default {
     require('@tailwindcss/container-queries'),
     require(`${dir}/base/gc-base.js`)(),
     require(`${dir}/components/gc-typography.js`)(),
+    require(`${dir}/components/layout.js`)(),
   ],
 } satisfies Config;

--- a/tailwind/plugins/components/layout.js
+++ b/tailwind/plugins/components/layout.js
@@ -1,0 +1,45 @@
+/**
+ * Half centered container.
+ */
+module.exports = function () {
+  return function ({ addComponents, theme }) {
+    // Find and set the padding based on the screen margins
+    const screens = theme('screens');
+    const paddingLeft = {};
+    const paddingRight = {};
+
+    // Create padding for each screen size which equals to the screen margin setting.
+    const keys = Object.keys(screens);
+    keys.forEach((key) => {
+      paddingLeft[`@screen ${key}`] = {
+        paddingLeft: theme(`decanter.screenMargins.${key}`),
+      };
+    });
+    keys.forEach((key) => {
+      paddingRight[`@screen ${key}`] = {
+        paddingRight: theme(`decanter.screenMargins.${key}`),
+      };
+    });
+
+    const components = {
+      '.cc-left': {
+        paddingLeft: theme('decanter.screenMargins.xs'),
+        marginLeft: 0,
+        ...paddingLeft,
+        '@media only screen and (min-width: 1700px)': {
+          paddingLeft: 'calc(100% - 750px)',
+        },
+      },
+      '.cc-right': {
+        paddingRight: theme('decanter.screenMargins.xs'),
+        marginRight: 0,
+        ...paddingRight,
+        '@media only screen and (min-width: 1700px)': {
+          paddingRight: 'calc(100% - 750px)',
+        },
+      },
+    };
+
+    addComponents(components);
+  };
+};


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Options and responsive behavior for Blurry Poster

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the homepage and see the 2 blurry posters
https://deploy-preview-124--giving-campaign.netlify.app/
![Screenshot 2023-09-29 at 5 22 13 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/972ad3f3-a9e0-458d-8400-5fcda97ac1da)
![Screenshot 2023-09-29 at 5 22 22 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e27dff0e-cd16-4ba2-a667-dc414e6ab141)

2. Check responsive behavior

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-201