### PR TITLE
GIVCAMP-205 | Allow for mixed typography for blurry poster and add animation

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -13,9 +13,9 @@ export const contentWrapper = (imageOnLeft: boolean) => cnb('relative z-10', {
 export const headingWrapper = (imageOnLeft: boolean) => cnb('lg:rs-mt-7 rs-mb-5', {
   'lg:w-[120%] lg:-ml-[20%] 3xl:w-auto 3xl:-ml-200 lg:mr-0' : imageOnLeft,
 });
-export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('pl-10 pr-20 sm:pl-30 sm:pr-20 md:pl-30 md:pr-50', {
-  'border-l-[1rem] md:border-l-[2rem] lg:border-l-0 lg:border-r-[3rem] xl:border-r-[4rem] lg:pl-0 lg:pr-50 xl:pr-60': imageOnLeft,
-  'border-l-[1rem] md:border-l-[2rem] lg:border-l-[3rem] xl:border-l-[4rem] lg:pl-50 xl:pl-60 lg:pr-0 3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[120%]': !imageOnLeft,
+export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('border-l-[1rem] sm:border-l-[1.4rem] md:border-l-[2rem] pl-10 pr-20 sm:pl-16 sm:pr-30 md:pl-30 md:pr-50', {
+  'lg:border-l-0 lg:border-r-[3rem] xl:border-r-[4rem] lg:pl-0 lg:pr-50 xl:pr-60': imageOnLeft,
+  'lg:border-l-[3rem] xl:border-l-[4rem] lg:pl-50 xl:pl-60 lg:pr-0 3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[120%]': !imageOnLeft,
 });
 export const heading = (imageOnLeft: boolean, isSmallHeading: boolean) => cnb('mb-0 -mt-01em fluid-type-7', {
   '3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[130%]': !imageOnLeft,
@@ -30,7 +30,7 @@ export const customHeadingText = (font: 'druk' | 'serif', isSmallHeading: boolea
   'fluid-type-7': font === 'druk',
   'md:fluid-type-9' : font === 'druk' && !isSmallHeading,
   'md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]' : font === 'druk' && isSmallHeading,
-  'mx-03em mt-01em fluid-type-5': font === 'serif',
+  'mx-01em md:mx-03em mt-01em fluid-type-4 md:fluid-type-5 font-semibold md:font-normal': font === 'serif',
   'md:type-4 3xl:fluid-type-5' : font === 'serif' && isSmallHeading,
 });
 

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -19,8 +19,19 @@ export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('pl-10 pr-20 sm
 });
 export const heading = (imageOnLeft: boolean, isSmallHeading: boolean) => cnb('mb-0 -mt-01em fluid-type-7', {
   '3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[130%]': !imageOnLeft,
-  'md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
-  'md:fluid-type-9': !isSmallHeading,
+  'mt-01em md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
+  'mt-01em md:fluid-type-9': !isSmallHeading,
+});
+
+export const customHeading = (imageOnLeft: boolean) => cnb('flex flex-wrap gap-x-[1em] items-center mb-0 -mt-05em lg:-mt-08em children:inline-block', {
+  '3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[130%]': !imageOnLeft,
+});
+export const customHeadingText = (font: 'druk' | 'serif', isSmallHeading: boolean) => cnb('first:ml-0 last:mr-0', {
+  'fluid-type-7': font === 'druk',
+  'md:fluid-type-9' : font === 'druk' && !isSmallHeading,
+  'md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]' : font === 'druk' && isSmallHeading,
+  'mx-03em mt-01em fluid-type-5': font === 'serif',
+  'md:type-4 3xl:fluid-type-5' : font === 'serif' && isSmallHeading,
 });
 
 export const bodyWrapper = (imageOnLeft: boolean) => cnb('cc w-full', {

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -7,8 +7,9 @@ import {
   Heading, Paragraph, Text, type HeadingType,
 } from '../Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
-import * as styles from './BlurryPoster.styles';
 import { accentBorderColors, type AccentColorType } from '@/utilities/datasource';
+import { type SbTypographyProps } from '../Storyblok/Storyblok.types';
+import * as styles from './BlurryPoster.styles';
 
 type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   bgImageSrc?: string;
@@ -16,6 +17,7 @@ type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   imageOnLeft?: boolean;
   headingLevel?: HeadingType;
   heading?: string;
+  customHeading?: SbTypographyProps[];
   isSmallHeading?: boolean;
   body?: string;
   byline?: string;
@@ -31,6 +33,7 @@ export const BlurryPoster = ({
   bgImageFocus,
   imageOnLeft,
   heading,
+  customHeading,
   headingLevel = 'h2',
   isSmallHeading,
   body,
@@ -57,8 +60,9 @@ export const BlurryPoster = ({
         <Grid lg={2} className={styles.grid}>
           <div className={styles.contentWrapper(imageOnLeft)}>
             <FlexBox className={styles.headingWrapper(imageOnLeft)}>
-              {heading &&  (
-                <div className={cnb(styles.headingInnerWrapper(imageOnLeft), accentBorderColors[tabColor])}>
+              <div className={cnb(styles.headingInnerWrapper(imageOnLeft), accentBorderColors[tabColor])}>
+                {/* Render all Druk font heading if custom heading is not entered */}
+                {heading && !customHeading && (
                   <Heading
                     font="druk"
                     color="white"
@@ -67,12 +71,30 @@ export const BlurryPoster = ({
                   >
                     {heading}
                   </Heading>
-                </div>
-              )}
+                )}
+                {/* Render custom mixed typography heading if entered */}
+                {customHeading && (
+                  <Heading size="base" leading="none" className={styles.customHeading(imageOnLeft)}>
+                    {customHeading.map(({text, font, italic}) => (
+                      <Text
+                        as="span"
+                        key={text}
+                        font={font}
+                        leading="none"
+                        weight={font === 'druk' ? 'black' : 'normal'}
+                        italic={italic}
+                        className={styles.customHeadingText(font, isSmallHeading)}
+                      >
+                        {text}
+                      </Text>
+                    ))}
+                  </Heading>
+                )}
+              </div>
             </FlexBox>
             <div className={styles.bodyWrapper(imageOnLeft)}>
               {body && (
-                <Paragraph size={2} color="white" leading="display">{body}</Paragraph>
+                <Paragraph variant="overview" weight="normal" color="white" leading="display">{body}</Paragraph>
               )}
               {byline && (
                 <Text>{byline}</Text>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -1,5 +1,6 @@
 import { HTMLAttributes } from 'react';
 import { cnb } from 'cnbuilder';
+import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
 import { Grid } from '../Grid';
 import { FlexBox } from '../FlexBox';
@@ -60,7 +61,10 @@ export const BlurryPoster = ({
         <Grid lg={2} className={styles.grid}>
           <div className={styles.contentWrapper(imageOnLeft)}>
             <FlexBox className={styles.headingWrapper(imageOnLeft)}>
-              <div className={cnb(styles.headingInnerWrapper(imageOnLeft), accentBorderColors[tabColor])}>
+              <AnimateInView
+                animation={imageOnLeft ? 'slideInFromRight' : 'slideInFromLeft'}
+                className={cnb(styles.headingInnerWrapper(imageOnLeft), accentBorderColors[tabColor])}
+              >
                 {/* Render all Druk font heading if custom heading is not entered */}
                 {heading && !customHeading && (
                   <Heading
@@ -90,7 +94,7 @@ export const BlurryPoster = ({
                     ))}
                   </Heading>
                 )}
-              </div>
+              </AnimateInView>
             </FlexBox>
             <div className={styles.bodyWrapper(imageOnLeft)}>
               {body && (
@@ -111,7 +115,7 @@ export const BlurryPoster = ({
           </div>
           <div className={styles.imageWrapper(imageOnLeft)}>
             {imageSrc && (
-              <>
+              <AnimateInView animation="zoomSharpen" duration={1}>
                 <img
                   src={getProcessedImage(imageSrc, '900x1200', imageFocus)}
                   alt=""
@@ -122,7 +126,7 @@ export const BlurryPoster = ({
                   alt=""
                   className={styles.imageMobile}
                 />
-              </>
+              </AnimateInView>
             )}
           </div>
         </Grid>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import React, { HTMLAttributes } from 'react';
 import { cnb } from 'cnbuilder';
 import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
@@ -115,7 +115,7 @@ export const BlurryPoster = ({
           </div>
           <div className={styles.imageWrapper(imageOnLeft)}>
             {imageSrc && (
-              <AnimateInView animation="zoomSharpen" duration={1}>
+              <AnimateInView animation="zoomSharpen" duration={1} className="h-full w-full">
                 <img
                   src={getProcessedImage(imageSrc, '900x1200', imageFocus)}
                   alt=""

--- a/components/Storyblok/SbBlurryPoster.tsx
+++ b/components/Storyblok/SbBlurryPoster.tsx
@@ -2,13 +2,14 @@ import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { BlurryPoster } from '../BlurryPoster';
 import { CreateBloks } from '../CreateBloks';
 import { type HeadingType } from '../Typography';
-import { type SbImageType } from './Storyblok.types';
+import { type SbImageType, type SbTypographyProps } from './Storyblok.types';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 
 type SbBlurryPosterProps = {
   blok: {
     _uid: string;
     heading?: string;
+    customHeading?: SbTypographyProps[];
     headingLevel?: HeadingType;
     isSmallHeading?: boolean;
     imageOnLeft?: boolean;
@@ -27,6 +28,7 @@ type SbBlurryPosterProps = {
 export const SbBlurryPoster = ({
   blok: {
     heading,
+    customHeading,
     headingLevel,
     isSmallHeading,
     imageOnLeft,
@@ -46,6 +48,7 @@ export const SbBlurryPoster = ({
     <BlurryPoster
       {...storyblokEditable(blok)}
       heading={heading}
+      customHeading={customHeading}
       headingLevel={headingLevel}
       isSmallHeading={isSmallHeading}
       imageOnLeft={imageOnLeft}

--- a/components/Storyblok/Storyblok.types.ts
+++ b/components/Storyblok/Storyblok.types.ts
@@ -35,3 +35,12 @@ export type SbLinkType =
     linktype?: 'email';
     [k: string]: any;
   };
+
+/**
+ * Reusable types for custom Storyblok components
+ */
+export type SbTypographyProps = {
+  text?: string;
+  font?: 'druk' | 'serif';
+  italic?: boolean;
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add a way for the content author to add mixed typography into the Blurry Poster headline (mixed serif and Druk fonts)

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Look at the preview and scroll to the 2 blurry posters and see the animation when they're in view
  https://deploy-preview-125--giving-campaign.netlify.app/


2. Check that the mixed typography works for all breakpoints, and for both regular heading size, and for small heading size (small heading only for certain breakpoints, on mobile and largest desktop resolution, they have the same font size)
  
![Screenshot 2023-10-02 at 10 00 34 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/c8af2fbd-7c3f-4044-81d9-d86157d953df)

  
![Screenshot 2023-10-02 at 10 00 40 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/a2c098c5-457c-43fd-b7f8-c8eb4a49941c)

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-205