### PR TITLE
GIVCAMP-233 | Add dark overlay for blurry poster; minor updates

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -3,7 +3,7 @@ import { cnb } from 'cnbuilder';
 export const root = 'relative bg-no-repeat bg-cover bg-center overflow-hidden break-words';
 export const blurWrapper = (addDarkOverlay: boolean) => cnb(
   'w-full h-full backdrop-blur-md bg-gradient-to-b from-black-true/40',
-  addDarkOverlay ? 'lg:from-black-true/30' : 'lg:bg-none'
+  addDarkOverlay ? 'lg:from-black-true/30' : 'lg:bg-none',
 );
 
 export const grid = 'w-full rs-py-8';

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -1,7 +1,10 @@
 import { cnb } from 'cnbuilder';
 
 export const root = 'relative bg-no-repeat bg-cover bg-center overflow-hidden break-words';
-export const blurWrapper = 'w-full h-full backdrop-blur-md';
+export const blurWrapper = (addDarkOverlay: boolean) => cnb(
+  'w-full h-full backdrop-blur-md bg-gradient-to-b from-black-true/40',
+  addDarkOverlay ? 'lg:from-black-true/30' : 'lg:bg-none'
+);
 
 export const grid = 'w-full rs-py-8';
 

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -22,8 +22,8 @@ export const headingInnerWrapper = (imageOnLeft: boolean) => cnb('w-full border-
 });
 export const heading = (imageOnLeft: boolean, isSmallHeading: boolean) => cnb('mb-0 -mt-01em fluid-type-7', {
   '3xl:pl-[calc(100%-750px-40px)] lg:w-[140%] xl:w-[130%]': !imageOnLeft,
-  'mt-01em md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
-  'mt-01em md:fluid-type-9': !isSmallHeading,
+  'md:fluid-type-8 lg:fluid-type-7 3xl:fluid-type-8 4xl:text-[17.1rem]': isSmallHeading,
+  'md:fluid-type-9': !isSmallHeading,
 });
 
 export const customHeading = (imageOnLeft: boolean) => cnb('flex flex-wrap gap-x-[1em] items-center mb-0 -mt-05em lg:-mt-08em children:inline-block', {

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -20,6 +20,7 @@ type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;
   customHeading?: SbTypographyProps[];
   isSmallHeading?: boolean;
+  addDarkOverlay?: boolean;
   body?: string;
   byline?: string;
   publishedDate?: string;
@@ -37,6 +38,7 @@ export const BlurryPoster = ({
   customHeading,
   headingLevel = 'h2',
   isSmallHeading,
+  addDarkOverlay,
   body,
   byline,
   publishedDate,
@@ -57,7 +59,7 @@ export const BlurryPoster = ({
 
   return (
     <Container {...props} bgColor="black" width="full" className={styles.root} style={bgImageStyle}>
-      <div className={styles.blurWrapper}>
+      <div className={styles.blurWrapper(addDarkOverlay)}>
         <Grid lg={2} className={styles.grid}>
           <div className={styles.contentWrapper(imageOnLeft)}>
             <FlexBox className={styles.headingWrapper(imageOnLeft)}>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -68,7 +68,7 @@ export const BlurryPoster = ({
                 className={cnb(styles.headingInnerWrapper(imageOnLeft), accentBorderColors[tabColor])}
               >
                 {/* Render all Druk font heading if custom heading is not entered */}
-                {heading && !customHeading && (
+                {heading && !customHeading?.length && (
                   <Heading
                     font="druk"
                     color="white"
@@ -79,7 +79,7 @@ export const BlurryPoster = ({
                   </Heading>
                 )}
                 {/* Render custom mixed typography heading if entered */}
-                {customHeading && (
+                {!!customHeading?.length && (
                   <Heading size="base" leading="none" className={styles.customHeading(imageOnLeft)}>
                     {customHeading.map(({text, font, italic}) => (
                       <Text

--- a/components/Storyblok/SbBlurryPoster.tsx
+++ b/components/Storyblok/SbBlurryPoster.tsx
@@ -13,6 +13,7 @@ type SbBlurryPosterProps = {
     headingLevel?: HeadingType;
     isSmallHeading?: boolean;
     imageOnLeft?: boolean;
+    addDarkOverlay?: boolean;
     body: string;
     byline?: string;
     publishedDate?: string;
@@ -32,6 +33,7 @@ export const SbBlurryPoster = ({
     headingLevel,
     isSmallHeading,
     imageOnLeft,
+    addDarkOverlay,
     body,
     byline,
     publishedDate,
@@ -52,6 +54,7 @@ export const SbBlurryPoster = ({
       headingLevel={headingLevel}
       isSmallHeading={isSmallHeading}
       imageOnLeft={imageOnLeft}
+      addDarkOverlay={addDarkOverlay}
       body={body}
       byline={byline}
       publishedDate={publishedDate}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add dark overlay for blurry poster (mandatory for mobile, optional Storyblok toggle for desktop)
- Minor fixups

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview and look at the blurry posters on mobile, check that they both have a dark overlay

Before:
![Screenshot 2023-10-05 at 2 40 11 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/3a1e4941-4aa4-40db-b707-ce9be30a6a31)


This PR:
![Screenshot 2023-10-05 at 2 38 55 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e450b065-6b0f-47cb-bbd1-ede9e5f59d97)
![Screenshot 2023-10-05 at 2 39 11 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/65d5ab02-2fd8-4a6b-b45a-70818dbcee20)

2. Look at this poster on desktop breakpoint, check that it has a dark overlay

Before:
![Screenshot 2023-10-05 at 2 39 24 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/c0b2158d-4072-482b-8720-e53694195e4a)

This PR:
![Screenshot 2023-10-05 at 2 44 10 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/59812acd-7d45-4a1a-8e0a-01a3a94e9079)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-233