### PR TITLE
Fix | Margin fix when no bar color is selected for Sections

### DIFF
--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -74,6 +74,8 @@ export const SbSection = ({
           'cc whitespace-pre-line w-full 3xl:max-w-[90%]',
           barColorValue && !rightAlignHeader ? '-ml-10 sm:-ml-14 md:-ml-20 lg:-ml-30 xl:-ml-40' : '',
           barColorValue && rightAlignHeader ? '-mr-10 sm:-mr-14 md:-mr-20 lg:-mr-30 xl:-mr-40' : '',
+          !barColorValue && !rightAlignHeader ? 'ml-0' : '',
+          !barColorValue && rightAlignHeader ? 'mr-0' : '',
           superhead ? '' : '-mt-05em',
         )}
         >


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixup for Sections with no bar color options selected

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the preview and look at all the Sections now with no color bars selected and check that they're align to the edge of the centered container (left or right side depending on whether the section header is left or right aligned)
![Screenshot 2023-10-09 at 11 54 12 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/c55ea5b9-fa4f-4d41-a089-bb046181e05f)
![Screenshot 2023-10-09 at 11 54 02 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/1062614d-0db9-4a91-aa80-5a6b8519196d)

