### PR TITLE
GIVCAMP-234 | Alt layout idea for above content section in stories

### DIFF
--- a/components/Sidebar/SidebarCard.styles.ts
+++ b/components/Sidebar/SidebarCard.styles.ts
@@ -11,11 +11,11 @@ export const content = (
   'rs-py-2': !hasBgColor,
   'pr-0': !hasBgColor && hasBarColor && !barOnRight,
   'pl-0': !hasBgColor && hasBarColor && barOnRight,
-  'rs-pl-3 @2xl:pl-95': hasBgColor && hasBarColor && barOnRight,
-  'rs-pr-3 @2xl:pr-95': hasBgColor && hasBarColor && !barOnRight,
-  'border-l-[1.4rem] xl:border-l-[2rem] rs-pl-2 @2xl:pl-75': hasBarColor && !barOnRight,
-  'border-r-[1.4rem] xl:border-r-[2rem] rs-pr-2 @2xl:pr-75': hasBarColor && barOnRight,
-  'rs-px-3': !hasBarColor && hasBgColor,
+  'rs-pl-2 @2xl:pl-95': hasBgColor && hasBarColor && barOnRight,
+  'rs-pr-2 @2xl:pr-95': hasBgColor && hasBarColor && !barOnRight,
+  'border-l-[1.4rem] 2xl:border-l-[2rem] rs-pl-1 @2xl:pl-75': hasBarColor && !barOnRight,
+  'border-r-[1.4rem] 2xl:border-r-[2rem] rs-pr-1 @2xl:pr-75': hasBarColor && barOnRight,
+  'rs-px-2': !hasBarColor && hasBgColor,
   'px-0': !hasBarColor && !hasBgColor,
 });
 

--- a/components/Sidebar/SidebarCard.styles.ts
+++ b/components/Sidebar/SidebarCard.styles.ts
@@ -11,11 +11,11 @@ export const content = (
   'rs-py-2': !hasBgColor,
   'pr-0': !hasBgColor && hasBarColor && !barOnRight,
   'pl-0': !hasBgColor && hasBarColor && barOnRight,
-  'rs-pl-2 @2xl:pl-95': hasBgColor && hasBarColor && barOnRight,
-  'rs-pr-2 @2xl:pr-95': hasBgColor && hasBarColor && !barOnRight,
+  'rs-pl-2 @sm:pl-48 @2xl:pl-95': hasBgColor && hasBarColor && barOnRight,
+  'rs-pr-2 @sm:pr-48 @2xl:pr-95': hasBgColor && hasBarColor && !barOnRight,
   'border-l-[1.4rem] 2xl:border-l-[2rem] rs-pl-1 @2xl:pl-75': hasBarColor && !barOnRight,
   'border-r-[1.4rem] 2xl:border-r-[2rem] rs-pr-1 @2xl:pr-75': hasBarColor && barOnRight,
-  'rs-px-2': !hasBarColor && hasBgColor,
+  'rs-px-2 @sm:px-48': !hasBarColor && hasBgColor,
   'px-0': !hasBarColor && !hasBgColor,
 });
 

--- a/components/Storyblok/SbStoryMvp/SbAboveContent.tsx
+++ b/components/Storyblok/SbStoryMvp/SbAboveContent.tsx
@@ -17,11 +17,11 @@ export const SbAboveContent = ({
   <Container pt={9} className="relative overflow-hidden">
     <CreateBloks blokSection={aboveSidebar} />
     <Grid md={12} gap="default">
-      <div className="rs-mb-3 lg:mb-0 md:col-span-10 md:col-start-2 lg:col-span-7 xl:col-span-6 2xl:col-span-5 2xl:col-start-4">
+      <div className="rs-mb-3 lg:mb-0 md:col-span-10 md:col-start-2 lg:col-span-7 xl:col-span-5 xl:col-start-4 2xl:col-span-5 2xl:col-start-4">
         <CreateBloks blokSection={intro} />
       </div>
       {sidebar && (
-        <aside className="md:col-span-10 md:col-start-2 lg:col-span-5 lg:col-start-8 xl:col-span-5 xl:col-start-8 2xl:col-span-4 2xl:col-start-9">
+        <aside className="md:col-span-10 md:col-start-2 lg:col-span-5 lg:col-start-8 xl:col-span-4 xl:col-start-9 2xl:col-span-4 2xl:col-start-9">
           <div className="2xl:max-w-[90%] 3xl:max-w-[88%] mr-0 ml-auto">
             <CreateBloks blokSection={sidebar} />
           </div>

--- a/components/Storyblok/SbStoryMvp/SbAboveContent.tsx
+++ b/components/Storyblok/SbStoryMvp/SbAboveContent.tsx
@@ -17,12 +17,14 @@ export const SbAboveContent = ({
   <Container pt={9} className="relative overflow-hidden">
     <CreateBloks blokSection={aboveSidebar} />
     <Grid md={12} gap="default">
-      <div className="rs-mb-3 lg:mb-0 md:col-span-10 md:col-start-2 lg:col-span-7 xl:col-span-6 2xl:col-span-5 2xl:col-start-2">
+      <div className="rs-mb-3 lg:mb-0 md:col-span-10 md:col-start-2 lg:col-span-7 xl:col-span-6 2xl:col-span-5 2xl:col-start-4">
         <CreateBloks blokSection={intro} />
       </div>
       {sidebar && (
-        <aside className="md:col-span-10 md:col-start-2 lg:col-span-5 lg:col-start-8 xl:col-span-5 xl:col-start-8 2xl:col-span-4 2xl:col-start-8">
-          <CreateBloks blokSection={sidebar} />
+        <aside className="md:col-span-10 md:col-start-2 lg:col-span-5 lg:col-start-8 xl:col-span-5 xl:col-start-8 2xl:col-span-4 2xl:col-start-9">
+          <div className="2xl:max-w-[90%] 3xl:max-w-[88%] mr-0 ml-auto">
+            <CreateBloks blokSection={sidebar} />
+          </div>
         </aside>
       )}
     </Grid>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change layout of the sidebar/intro story area from XL to infinity
- NOTE: Kerri and Ali have approved this

# Review By (Date)
- Retro

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to a story
https://deploy-preview-136--giving-campaign.netlify.app/stories/test-story-hero-mixed-font-horizontal
2. Look at the sidebar/intro area

New (this PR)

![Screenshot 2023-10-13 at 1 20 48 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/5725ea6e-7d82-4329-8025-7dd019dd95de)

Old
![Screenshot 2023-10-13 at 1 22 31 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/f08b7dcd-9b0f-4129-ad06-efdf0e14fcbc)

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-234