### PR TITLE
GIVCAMP-235 | Add superhead for blurry poster; dark overlay for mobile

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -10,28 +10,38 @@ export const blurWrapper = (
   'w-full h-full', {
     'backdrop-blur-md' : addBgBlur,
     'bg-black-true/40': type === 'hero' && addDarkOverlay && bgColor === 'black',
-    'bg-gradient-to-b from-black-true/40 lg:from-black-true/30': type === 'poster' && addDarkOverlay && bgColor === 'black',
+    'bg-gradient-to-b from-black-true/40': type === 'poster' && bgColor === 'black',
+    'lg:from-black-true/30': type === 'poster' && addDarkOverlay && bgColor === 'black',
+    'lg:bg-none': type === 'poster' && bgColor === 'black' && !addDarkOverlay,
     'bg-white/80' : type === 'hero' && bgColor === 'white',
   },
 );
 
 export const grid = 'w-full';
 
-export const contentWrapper = (imageOnLeft?: boolean, isTwoCol?: boolean) => cnb('relative z-10', {
+export const contentWrapper = (
+  type?: 'hero' | 'poster',
+  hasHeroImage?: boolean, // Hero image is the foreground image
+  imageOnLeft?: boolean,
+  isTwoCol?: boolean,
+) => cnb('relative z-10', {
+  'rs-mt-10': !hasHeroImage && !isTwoCol && type === 'hero',
+  'rs-mt-7': hasHeroImage && type === 'hero',
+  'lg:rs-mt-6': type === 'poster',
   'lg:order-last': imageOnLeft && isTwoCol,
   'lg:order-first': !imageOnLeft && isTwoCol,
 });
 
+export const superhead = (imageOnLeft?: boolean) => cnb('cc rs-mb-1 w-full', {
+  'lg:pl-40 2xl:pl-60 3xl:pr-[calc(100%-750px)]': imageOnLeft,
+  '3xl:pl-[calc(100%-750px)]': !imageOnLeft,
+});
+
 export const headingWrapper = (
-  type?: 'hero' | 'poster',
-  hasHeroImage?: boolean, // Hero image is the foreground image
   imageOnLeft?: boolean,
   headingFont?: 'druk' | 'serif',
   isTwoCol?: boolean,
 ) => cnb('rs-mb-5', {
-  'rs-mt-10': !hasHeroImage && !isTwoCol && type === 'hero',
-  'rs-mt-7': hasHeroImage && type === 'hero',
-  'lg:rs-mt-7': type === 'poster',
   'lg:mr-0 lg:w-[120%] lg:-ml-[20%] 3xl:w-auto 3xl:-ml-200': imageOnLeft && headingFont === 'druk' && isTwoCol,
 });
 export const headingInnerWrapper = (

--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -10,7 +10,7 @@ export const blurWrapper = (
   'w-full h-full', {
     'backdrop-blur-md' : addBgBlur,
     'bg-black-true/40': type === 'hero' && addDarkOverlay && bgColor === 'black',
-    'bg-gradient-to-b from-black-true/40': type === 'poster' && bgColor === 'black',
+    'bg-gradient-to-b from-black-true/50': type === 'poster' && bgColor === 'black',
     'lg:from-black-true/30': type === 'poster' && addDarkOverlay && bgColor === 'black',
     'lg:bg-none': type === 'poster' && bgColor === 'black' && !addDarkOverlay,
     'bg-white/80' : type === 'hero' && bgColor === 'white',
@@ -34,7 +34,7 @@ export const contentWrapper = (
 
 export const superhead = (imageOnLeft?: boolean) => cnb('cc rs-mb-1 w-full', {
   'lg:pl-40 2xl:pl-60 3xl:pr-[calc(100%-750px)]': imageOnLeft,
-  '3xl:pl-[calc(100%-750px)]': !imageOnLeft,
+  'lg:pr-40 2xl:pr-60 3xl:pl-[calc(100%-750px)]': !imageOnLeft,
 });
 
 export const headingWrapper = (

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -26,6 +26,7 @@ type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   bgImageFocus?: string;
   bgColor?: 'black' | 'white';
   imageOnLeft?: boolean;
+  superhead?: string;
   headingLevel?: HeadingType;
   heading?: string;
   headingFont?: 'serif' | 'druk';
@@ -49,6 +50,7 @@ export const BlurryPoster = ({
   bgImageFocus,
   bgColor = 'black',
   imageOnLeft,
+  superhead,
   heading,
   headingFont = 'druk',
   customHeading,
@@ -78,8 +80,11 @@ export const BlurryPoster = ({
     <Container {...props} bgColor={bgColor} width="full" className={styles.root} style={bgImageStyle}>
       <div className={styles.blurWrapper(addBgBlur, addDarkOverlay, type, bgColor)}>
         <Grid lg={isTwoCol ? 2 : 1} pt={type === 'hero' ? 9 : 8} pb={8} className={styles.grid}>
-          <div className={styles.contentWrapper(imageOnLeft, isTwoCol)}>
-            <FlexBox className={styles.headingWrapper(type, !!imageSrc, imageOnLeft, headingFont, isTwoCol)}>
+          <div className={styles.contentWrapper(type, !!imageSrc, imageOnLeft, isTwoCol)}>
+            {superhead && (
+              <Text size={1} aria-hidden={!!heading} className={styles.superhead(imageOnLeft)}>{superhead}</Text>
+            )}
+            <FlexBox className={styles.headingWrapper(imageOnLeft, headingFont, isTwoCol)}>
               <AnimateInView
                 animation={imageOnLeft ? 'slideInFromRight' : 'slideInFromLeft'}
                 className={cnb(styles.headingInnerWrapper(imageOnLeft, headingFont, isTwoCol), accentBorderColors[tabColor])}

--- a/components/Storyblok/SbBlurryPoster.tsx
+++ b/components/Storyblok/SbBlurryPoster.tsx
@@ -8,6 +8,7 @@ import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities
 type SbBlurryPosterProps = {
   blok: {
     _uid: string;
+    superhead?: string;
     heading?: string;
     customHeading?: SbTypographyProps[];
     headingLevel?: HeadingType;
@@ -28,6 +29,7 @@ type SbBlurryPosterProps = {
 
 export const SbBlurryPoster = ({
   blok: {
+    superhead,
     heading,
     customHeading,
     headingLevel,
@@ -50,6 +52,7 @@ export const SbBlurryPoster = ({
     <BlurryPoster
       {...storyblokEditable(blok)}
       type="poster"
+      superhead={superhead}
       heading={heading}
       customHeading={customHeading}
       headingLevel={headingLevel}

--- a/components/Storyblok/SbHomepageMvp.tsx
+++ b/components/Storyblok/SbHomepageMvp.tsx
@@ -4,7 +4,6 @@ import { Heading } from '../Typography';
 import { HomepageSplitHero } from '../Homepage/HomepageSplitHero';
 import { Masthead } from '../Masthead';
 import { Changemaker } from '../Homepage/Changemaker';
-import { IdealFellow } from '../Homepage/IdealFellow';
 
 type SbHomepageMvpProps = {
   blok: {
@@ -31,7 +30,6 @@ export const SbHomepageMvp = ({
       <div>
         <Heading as="h1" srOnly>{title || 'Homepage'}</Heading>
         <HomepageSplitHero />
-        <IdealFellow />
         <CreateBloks blokSection={content} />
         <Changemaker />
         <CreateBloks blokSection={ankle} />


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Add superhead for blurry poster
- Add dark overlay for mobile poster for a11y whether dark overlay is turn on or off
Note: client has already approved of the look of the superhead

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the homepage
https://deploy-preview-137--giving-campaign.netlify.app/

2. Look at the superhead on both variants (image on left or right) of the blurry posters and check all the responsive.
![Screenshot 2023-10-13 at 9 42 35 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/a7cc31f6-6fbc-4802-8e0a-c545712e38fa)

![Screenshot 2023-10-13 at 9 42 49 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e3c8abb5-1b5a-41d0-9110-caad7fb7ab3d)

3. Check that for this poster, it has a dark overlay in the background on mobile (XS-MD)
![Screenshot 2023-10-13 at 9 54 15 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/5e716f6f-7b92-4de3-80b4-ab2a1826e52f)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-235