### PR TITLE
GIVCAMP-192: Add basic auth plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,13 @@
     secretId = 'VAULT_SECRET_ID'
     roleId = 'VAULT_ROLE_ID'
 
+[[plugins]]
+  package = '/plugins/netlify-plugin-contextual-auth'
+  [plugins.inputs]
+    username = ''
+    password = '0nPurrpose'
+    context = ['branch-deploy', 'deploy-preview', 'production']
+
 # HEADERS
 # ##############################################################################
 [[headers]]

--- a/plugins/netlify-plugin-contextual-auth/index.js
+++ b/plugins/netlify-plugin-contextual-auth/index.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+
+module.exports = {
+  async onPostBuild({ inputs, utils: { build, status } }) {
+    const contextMatch = inputs.context.includes(process.env.CONTEXT);
+    const branchMatch = inputs.branch
+      ? inputs.branch === process.env.BRANCH
+      : true;
+
+    // Correct build context?
+    if (contextMatch && branchMatch) {
+      try {
+        // Add basic auth headers
+        fs.appendFileSync(
+          inputs.file,
+          `\n${inputs.path}\n  Basic-Auth: ${inputs.username}:${inputs.password}`
+        );
+      } catch (error) {
+        // Report a user error
+        build.failBuild('Error message', { error });
+      }
+
+      // Display success information
+      console.log(
+        `Added basic auth "${inputs.username}:${inputs.password} for path "${inputs.path}""`
+      );
+      status.show({ summary: 'Success!' });
+    }
+  },
+};

--- a/plugins/netlify-plugin-contextual-auth/manifest.yml
+++ b/plugins/netlify-plugin-contextual-auth/manifest.yml
@@ -1,0 +1,19 @@
+name: netlify-plugin-contextual-basic-auth
+inputs:
+  - name: username
+    description: Username for http basic auth
+    required: true
+  - name: password
+    description: Password for http basic auth
+    required: true
+  - name: context
+    description: An array of which contexts should have auth [production, deploy-preview, branch-deploy]
+    required: true
+  - name: branch
+    description: Optional branch name to match against
+  - name: path
+    description: Header path match string for basic auth
+    default: /*
+  - name: file
+    description: path to `_headers` file
+    default: 'public/_headers'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds (browser based) basic auth to all contexts

# Review By (Date)
- Whenever

# Criticality
- 🤷 

# Review Tasks

1. Navigate to the [build preview](deploy-preview-144--giving-campaign.netlify.app)
2. Do not enter anything for username
3. Enter `0nPurrpose` for password