### PR TITLE
GIVCAMP-243 | Add support for superhead field in Story Heroes (MVP)

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -32,9 +32,9 @@ export const contentWrapper = (
   'lg:order-first': !imageOnLeft && isTwoCol,
 });
 
-export const superhead = (imageOnLeft?: boolean) => cnb('cc rs-mb-1 w-full', {
-  'lg:pl-40 2xl:pl-60 3xl:pr-[calc(100%-750px)]': imageOnLeft,
-  'lg:pr-40 2xl:pr-60 3xl:pl-[calc(100%-750px)]': !imageOnLeft,
+export const superhead = (imageOnLeft?: boolean, isTwoCol?: boolean) => cnb('cc rs-mb-1 w-full', {
+  'lg:pl-40 2xl:pl-60 3xl:pr-[calc(100%-750px)]': imageOnLeft && isTwoCol,
+  'lg:pr-40 2xl:pr-60 3xl:pl-[calc(100%-750px)]': !imageOnLeft && isTwoCol,
 });
 
 export const headingWrapper = (

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -68,7 +68,7 @@ export const BlurryPoster = ({
   className,
   ...props
 }: BlurryPosterProps) => {
-  const bgImageStyle = bgImageSrc ? { backgroundImage: `url('${getProcessedImage(bgImageSrc, '1800x1200', bgImageFocus)}')` } : undefined;
+  const bgImageStyle = bgImageSrc ? { backgroundImage: `url('${getProcessedImage(bgImageSrc, '2100x1400', bgImageFocus)}')` } : undefined;
   const date = publishedDate && new Date(publishedDate);
   const formattedDate = date && date.toLocaleDateString('en-US', {
     month: 'long',
@@ -82,12 +82,21 @@ export const BlurryPoster = ({
         <Grid lg={isTwoCol ? 2 : 1} pt={type === 'hero' ? 9 : 8} pb={8} className={styles.grid}>
           <div className={styles.contentWrapper(type, !!imageSrc, imageOnLeft, isTwoCol)}>
             {superhead && (
-              <Text size={1} aria-hidden={!!heading} className={styles.superhead(imageOnLeft)}>{superhead}</Text>
+              <Text
+                size={1}
+                aria-hidden={!!heading}
+                className={styles.superhead(imageOnLeft, isTwoCol)}
+              >
+                {superhead}
+              </Text>
             )}
             <FlexBox className={styles.headingWrapper(imageOnLeft, headingFont, isTwoCol)}>
               <AnimateInView
                 animation={imageOnLeft ? 'slideInFromRight' : 'slideInFromLeft'}
-                className={cnb(styles.headingInnerWrapper(imageOnLeft, headingFont, isTwoCol), accentBorderColors[tabColor])}
+                className={cnb(
+                  styles.headingInnerWrapper(imageOnLeft, headingFont, isTwoCol),
+                  accentBorderColors[tabColor],
+                )}
               >
                 {/* Render all Druk font heading if custom heading is not entered */}
                 {heading && !customHeading?.length && (

--- a/components/Hero/StoryHeroMvp.tsx
+++ b/components/Hero/StoryHeroMvp.tsx
@@ -7,6 +7,7 @@ import * as styles from './StoryHeroMvp.styles';
 
 export type StoryHeroMvpProps = {
   title: string;
+  superhead?: string;
   customHeading?: SbTypographyProps[];
   headingFont?: 'serif' | 'druk';
   isSmallHeading?: boolean;
@@ -33,6 +34,7 @@ export type StoryHeroMvpProps = {
 
 export const StoryHeroMvp = ({
   title,
+  superhead,
   customHeading,
   headingFont,
   isSmallHeading,
@@ -114,6 +116,7 @@ export const StoryHeroMvp = ({
         type="hero"
         isTwoCol={useTwoColLayout}
         heading={title}
+        superhead={superhead}
         customHeading={customHeading}
         headingLevel="h1"
         headingFont={headingFont === 'druk' ? 'druk' : 'serif'}

--- a/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
+++ b/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
@@ -32,6 +32,7 @@ type SbStoryMvpProps = {
 export const SbStoryMvp = ({
   blok: {
     title,
+    superhead,
     customHeading,
     headingFont,
     isSmallHeading,
@@ -72,6 +73,7 @@ export const SbStoryMvp = ({
           {!(title?.includes('Whereas') || title?.includes('Progress') || title?.includes('Video') || title?.includes('Solve')) && (
             <StoryHeroMvp
               title={title}
+              superhead={superhead}
               customHeading={customHeading}
               headingFont={headingFont}
               isSmallHeading={isSmallHeading}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add an optional superhead field for Story heroes

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to stories like
https://deploy-preview-146--giving-campaign.netlify.app/stories/the-most-wicked-problems
https://deploy-preview-146--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose

and verify that you can see the superhead above the large story title

![Screenshot 2023-10-24 at 4 54 45 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/82d87223-a395-4546-9428-9a09a7ccc711)

2. Check that responsive looks good

![Screenshot 2023-10-24 at 4 56 58 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/0539ccbc-57b8-4087-bb15-889cf9c63eb3)

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-243
