### PR TITLE
GIVCAMP-107 | Textured bar component

### DIFF
--- a/components/FeaturedStories/FeatureMasonry.tsx
+++ b/components/FeaturedStories/FeatureMasonry.tsx
@@ -29,7 +29,7 @@ export const FeatureMasonry = ({
 }: FeatureMasonryProps) => {
   return (
     <Container {...props} width="full">
-      <Grid sm={12} gap="default">
+      <Grid sm={12} gap="xs">
         <FlexBox alignItems="center" className="md:col-span-7 bg-fog-light">
           <EmbedMedia
             mediaUrl={audioUrl}

--- a/components/Hero/StoryHeroMvp.tsx
+++ b/components/Hero/StoryHeroMvp.tsx
@@ -1,8 +1,11 @@
 import { Container } from '../Container';
 import { BlurryPoster } from '../BlurryPoster';
+import { CreateBloks } from '../CreateBloks';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
+import { getNumBloks } from '@/utilities/getNumBloks';
 import { type SbImageType, type SbTypographyProps } from '../Storyblok/Storyblok.types';
+import { type SbBlokData } from '@storyblok/react/rsc';
 import * as styles from './StoryHeroMvp.styles';
 
 export type StoryHeroMvpProps = {
@@ -31,6 +34,7 @@ export type StoryHeroMvpProps = {
     value?: PaletteAccentHexColorType;
   }
   topics?: string[];
+  heroTexturedBar?: SbBlokData[];
 };
 
 export const StoryHeroMvp = ({
@@ -55,6 +59,7 @@ export const StoryHeroMvp = ({
   aspectRatio = isVerticalHero ? '5x8' : '2x1',
   mobileAspectRatio = '1x1',
   tabColor: { value: tabColorValue } = {},
+  heroTexturedBar,
 }: StoryHeroMvpProps) => {
   const useTwoColLayout = isVerticalHero;
   const date = publishedDate && new Date(publishedDate);
@@ -136,6 +141,9 @@ export const StoryHeroMvp = ({
         imageOnLeft={isLeftImage}
         tabColor={paletteAccentColors[tabColorValue]}
       />
+      {!!getNumBloks(heroTexturedBar) && (
+        <CreateBloks blokSection={heroTexturedBar} />
+      )}
     </Container>
   );
 };

--- a/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
+++ b/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
@@ -45,6 +45,7 @@ export const SbStoryMvp = ({
     isLightHero,
     tabColor,
     topics,
+    heroTexturedBar,
     // page regions
     hideTopSocial,
     aboveSidebar,
@@ -87,6 +88,7 @@ export const SbStoryMvp = ({
             isVerticalHero={isVerticalHero}
             tabColor={tabColor}
             topics={topics}
+            heroTexturedBar={heroTexturedBar}
           />
           {!hideTopSocial && !!slug && <SocialSharing title={title} slug={slug} isTop />}
           {showAboveContent && (

--- a/components/Storyblok/SbTexturedBar.tsx
+++ b/components/Storyblok/SbTexturedBar.tsx
@@ -1,0 +1,22 @@
+import { storyblokEditable } from '@storyblok/react/rsc';
+import { TexturedBar } from '@/components/TexturedBar';
+import { type SbImageType } from './Storyblok.types';
+
+type SbTexturedBarProps = {
+  blok: {
+    _uid: string;
+    image?: SbImageType;
+  };
+};
+
+export const SbTexturedBar = ({
+  blok: {
+    image: { filename } = {},
+  },
+  blok,
+}: SbTexturedBarProps) => (
+  <TexturedBar
+    {...storyblokEditable(blok)}
+    imageSrc={filename}
+  />
+);

--- a/components/StoryblokProvider.tsx
+++ b/components/StoryblokProvider.tsx
@@ -24,6 +24,7 @@ import { SbStory } from './Storyblok/SbStory';
 import { SbStoryMvp } from './Storyblok/SbStoryMvp/SbStoryMvp';
 import { SbStoryCard } from './Storyblok/SbStoryCard';
 import { SbTextCard } from './Storyblok/SbTextCard';
+import { SbTexturedBar } from './Storyblok/SbTexturedBar';
 import { SbThemeCard } from './Storyblok/SbThemeCard';
 import { SbTriangle } from './Storyblok/SbTriangle';
 import { SbVerticalPoster } from './Storyblok/SbVerticalPoster';
@@ -52,6 +53,7 @@ const components = {
   sbStory: SbStory,
   sbStoryMvp: SbStoryMvp,
   sbTextCard: SbTextCard,
+  sbTexturedBar: SbTexturedBar,
   sbThemeCard: SbThemeCard,
   sbTriangle: SbTriangle,
   sbStoryCard: SbStoryCard,

--- a/components/TexturedBar/TexturedBar.tsx
+++ b/components/TexturedBar/TexturedBar.tsx
@@ -1,0 +1,20 @@
+import { getProcessedImage } from '@/utilities/getProcessedImage';
+
+type TexturedBarProps = {
+  imageSrc: string;
+}
+
+export const TexturedBar= ({
+  imageSrc,
+}: TexturedBarProps) => (
+  <div className="relative w-full h-20 md:h-30 lg:h-40">
+    <img
+      src={getProcessedImage(imageSrc, '3000x60')}
+      loading="lazy"
+      alt=""
+      width={3000}
+      height={60}
+      className="w-full h-full object-cover"
+    />
+  </div>
+);

--- a/components/TexturedBar/index.ts
+++ b/components/TexturedBar/index.ts
@@ -1,0 +1,1 @@
+export * from './TexturedBar';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Create a Textured Bar component in Storyblok where the content author can pick from images in a specific folder in Storyblok.
- It should be available below story hero (optional), and anywhere inside page content. 

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to this page
https://deploy-preview-151--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose

2. See the textured bar below the hero, and there are 2 more in the ankle
3. Check responsive behavior

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-107
