### PR TITLE
GIVCAMP-237 | Story Hero caption

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -13,7 +13,7 @@ export const blurWrapper = (
 ) => cnb(
   'relative w-full h-full z-10', {
     'backdrop-blur-md' : addBgBlur,
-    'bg-black-true/60 md:bg-black-true/40': type === 'hero' && addDarkOverlay && bgColor === 'black',
+    'bg-black-true/50 md:bg-black-true/30': type === 'hero' && addDarkOverlay && bgColor === 'black',
     'bg-gradient-to-b from-black-true/50': type === 'poster' && bgColor === 'black',
     'lg:from-black-true/20 lg:to-black-true/70': type === 'poster' && addDarkOverlay && bgColor === 'black',
     'lg:bg-none': type === 'poster' && bgColor === 'black' && !addDarkOverlay,

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -43,6 +43,10 @@ type BlurryPosterProps = HTMLAttributes<HTMLDivElement> & {
   alt?: string;
   tabColor?: AccentColorType;
   cta?: React.ReactNode;
+  /**
+   * This isn't displayed in the component, aria-describedby will be added to the images if a caption exists
+   */
+  caption?: string;
 };
 
 export const BlurryPoster = ({
@@ -69,6 +73,7 @@ export const BlurryPoster = ({
   alt,
   tabColor,
   cta,
+  caption,
   className,
   ...props
 }: BlurryPosterProps) => {
@@ -84,11 +89,13 @@ export const BlurryPoster = ({
       <img
         src={getProcessedImage(bgImageSrc, '1200x1200', bgImageFocus)}
         alt={bgImageAlt || ''}
+        aria-describedby={caption ? 'story-hero-caption' : undefined}
         className={styles.bgImageMobile}
       />
       <img
         src={getProcessedImage(bgImageSrc, '2000x1200', bgImageFocus)}
         alt={bgImageAlt || ''}
+        aria-describedby={caption ? 'story-hero-caption' : undefined}
         className={styles.bgImage}
       />
       <div className={styles.blurWrapper(addBgBlur, addDarkOverlay, type, bgColor)}>
@@ -176,11 +183,13 @@ export const BlurryPoster = ({
                 <img
                   src={getProcessedImage(imageSrc, type === 'hero' && !isTwoCol ? '1800x900' : '900x1200', imageFocus)}
                   alt={alt || ''}
+                  aria-describedby={caption ? 'story-hero-caption' : undefined}
                   className={styles.image}
                 />
                 <img
                   src={getProcessedImage(imageSrc, type === 'hero' ? '1000x1000' : '1000x500', imageFocus)}
                   alt={alt || ''}
+                  aria-describedby={caption ? 'story-hero-caption' : undefined}
                   className={styles.imageMobile}
                 />
               </AnimateInView>

--- a/components/EmbedMedia/EmbedMedia.styles.ts
+++ b/components/EmbedMedia/EmbedMedia.styles.ts
@@ -1,2 +1,2 @@
 export const mediaWrapper = 'children:!w-full children:!h-full';
-export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-09em max-w-prose-wide';
+export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-08em max-w-prose-wide';

--- a/components/Hero/StoryHeroMvp.styles.ts
+++ b/components/Hero/StoryHeroMvp.styles.ts
@@ -26,3 +26,5 @@ export const image = (renderTwoImages: boolean) => cnb(
   renderTwoImages ? 'hidden lg:block' : '',
 );
 export const mobileImage = 'w-full h-full lg:hidden';
+export const captionWrapper = 'mt-08em';
+export const caption = 'max-w-prose-wide text-black-70';

--- a/components/Hero/StoryHeroMvp.tsx
+++ b/components/Hero/StoryHeroMvp.tsx
@@ -147,12 +147,13 @@ export const StoryHeroMvp = ({
         <CreateBloks blokSection={heroTexturedBar} />
       )}
       {caption && (
-        <Container bgColor="white" className="mt-06em">
+        <Container bgColor="white" className={styles.captionWrapper}>
           <Text
+            // id is for aria-describedby in the images since we can't use figcaption here
             id="story-hero-caption"
             variant="caption"
             leading="display"
-            className="max-w-prose-wide text-black-70"
+            className={styles.caption}
           >
             {caption}
           </Text>

--- a/components/Hero/StoryHeroMvp.tsx
+++ b/components/Hero/StoryHeroMvp.tsx
@@ -150,7 +150,6 @@ export const StoryHeroMvp = ({
         <Container bgColor="white" className="mt-06em">
           <Text
             id="story-hero-caption"
-            color="black-80"
             variant="caption"
             leading="display"
             className="max-w-prose-wide text-black-70"

--- a/components/Hero/StoryHeroMvp.tsx
+++ b/components/Hero/StoryHeroMvp.tsx
@@ -1,11 +1,12 @@
-import { Container } from '../Container';
-import { BlurryPoster } from '../BlurryPoster';
-import { CreateBloks } from '../CreateBloks';
+import { Container } from '@/components/Container';
+import { BlurryPoster } from '@/components/BlurryPoster';
+import { CreateBloks } from '@/components/CreateBloks';
+import { Text } from '@/components/Typography';
+import { type SbImageType, type SbTypographyProps } from '@/components/Storyblok/Storyblok.types';
+import { type SbBlokData } from '@storyblok/react/rsc';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { getNumBloks } from '@/utilities/getNumBloks';
-import { type SbImageType, type SbTypographyProps } from '../Storyblok/Storyblok.types';
-import { type SbBlokData } from '@storyblok/react/rsc';
 import * as styles from './StoryHeroMvp.styles';
 
 export type StoryHeroMvpProps = {
@@ -53,6 +54,7 @@ export const StoryHeroMvp = ({
   addBgBlur,
   addDarkOverlay,
   alt,
+  caption,
   isVerticalHero = false,
   isLeftImage = false,
   isLightHero = false,
@@ -114,7 +116,6 @@ export const StoryHeroMvp = ({
     <Container
       as="header"
       width="full"
-      bgColor={isLightHero ? 'white' : 'black'}
       className={styles.root}
     >
       <BlurryPoster
@@ -140,9 +141,23 @@ export const StoryHeroMvp = ({
         addDarkOverlay={addDarkOverlay}
         imageOnLeft={isLeftImage}
         tabColor={paletteAccentColors[tabColorValue]}
+        caption={caption}
       />
       {!!getNumBloks(heroTexturedBar) && (
         <CreateBloks blokSection={heroTexturedBar} />
+      )}
+      {caption && (
+        <Container bgColor="white" className="mt-06em">
+          <Text
+            id="story-hero-caption"
+            color="black-80"
+            variant="caption"
+            leading="display"
+            className="max-w-prose-wide text-black-70"
+          >
+            {caption}
+          </Text>
+        </Container>
       )}
     </Container>
   );

--- a/components/TexturedBar/TexturedBar.tsx
+++ b/components/TexturedBar/TexturedBar.tsx
@@ -1,19 +1,28 @@
+import { HTMLAttributes } from 'react';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 
-type TexturedBarProps = {
+type TexturedBarProps = HTMLAttributes<HTMLDivElement> & {
   imageSrc: string;
 }
 
-export const TexturedBar= ({
+export const TexturedBar = ({
   imageSrc,
+  ...props
 }: TexturedBarProps) => (
-  <div className="relative w-full h-20 md:h-30 lg:h-40">
+  <div {...props} className="relative w-full h-20 md:h-30 lg:h-40">
     <img
       src={getProcessedImage(imageSrc, '3000x60')}
+      srcSet={`
+        ${getProcessedImage(imageSrc, '800x20')} 800w,
+        ${getProcessedImage(imageSrc, '1200x30')} 1200w,
+        ${getProcessedImage(imageSrc, '2000x40')} 2000w,
+        ${getProcessedImage(imageSrc, '3000x60')} 3000w
+      `}
       loading="lazy"
       alt=""
       width={3000}
       height={60}
+      sizes="100vw"
       className="w-full h-full object-cover"
     />
   </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Support for caption for hero image(s)

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-153--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
2. See the caption appear below the hero, in this case, below the textured bar that is below the hero
![Screenshot 2023-11-01 at 10 58 02 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/0296e5a5-abb2-49c0-95d1-0999386fa345)
3. Go to this story
https://deploy-preview-153--giving-campaign.netlify.app/stories/the-most-wicked-problems
4. See that there's a caption there below the hero too (this time no textured bar)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-237