### PR TITLE
GIVCAMP-252 | Remove sticky header behavior on scrolling back up

### DIFF
--- a/components/Masthead/Masthead.styles.ts
+++ b/components/Masthead/Masthead.styles.ts
@@ -1,18 +1,9 @@
-import { cnb } from 'cnbuilder';
-
-export const root = (isAtTop?: boolean, isScrollingBack?: boolean) => cnb(
-  'w-full fixed top-0 z-50 transition-colors will-change-transform',
-  !isAtTop && isScrollingBack ?
-  'bg-gc-black border-b border-b-black-80 h-60 lg:h-[6.8rem]'
-  : 'bg-transparent border-b-transparent h-[7.6rem]',
-);
+export const root = 'w-full absolute top-0 z-50 transition-colors h-[7.6rem]';
 
 // Use a wider centered container (1800px wide at 4XL (2000px) breakpoint)
-export const wrapper = (isAtTop?: boolean) => cnb(
-  'cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)] py-12 transition',
-  isAtTop ? 'sm:py-13 lg:py-20' : 'lg:py-11',
-);
+export const wrapper = 'cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)] py-12 sm:py-13 lg:py-20 transition';
 
 // Pass in a root style for the lock up to scale everything within proportionally
 export const lockup = 'sm:-mt-02em shrink-0 sm:text-17 md:text-22 lg:text-28';
+
 export const ctaWrapper = 'gap-12 xl:gap-20';

--- a/components/Masthead/Masthead.tsx
+++ b/components/Masthead/Masthead.tsx
@@ -1,13 +1,8 @@
-'use client';
-
-import { useEffect, useState, HTMLAttributes } from 'react';
-import {
-  m, useMotionValueEvent, useScroll, useVelocity,
-} from 'framer-motion';
+import { HTMLAttributes } from 'react';
 import { cnb } from 'cnbuilder';
 import { FlexBox } from '../FlexBox';
 import { LogoLockup } from '@/components/Logo/LogoLockup';
-import { CtaLink, type CtaVariantType } from '../Cta';
+import { CtaLink } from '../Cta';
 import { Skiplink } from '../SkipLink';
 import { ood } from '@/utilities/externalLinks';
 import * as styles from './Masthead.styles';
@@ -16,85 +11,38 @@ type MastheadProps = HTMLAttributes<HTMLDivElement> & {
   isLight?: boolean;
 };
 
-export const Masthead = ({ isLight, className }: MastheadProps) => {
-  const slideDistance = 76;
-  const threshold = 200;
-
-  const { scrollY } = useScroll();
-  const scrollVelocity = useVelocity(scrollY);
-
-  const [isScrollingBack, setIsScrollingBack] = useState(false);
-  const [isAtTop, setIsAtTop] = useState(true);
-  const [isVisible, setIsVisible] = useState(true);
-
-  useMotionValueEvent(scrollVelocity, 'change', (latest) => {
-    if (latest > 0) {
-      setIsScrollingBack(false);
-      return;
-    }
-    if (latest < -threshold) {
-      setIsScrollingBack(true);
-    }
-  });
-
-  useMotionValueEvent(scrollY, 'change', (latest) => {
-    setIsAtTop(latest <= 40);
-  });
-
-  useEffect(() => setIsVisible(isScrollingBack || isAtTop), [
-    isScrollingBack,
-    isAtTop,
-  ]);
-
-  let ctaVariant: CtaVariantType = 'mainNav';
-  let givingLinkVariant: CtaVariantType = 'mastheadGiving';
-
-  if (!isAtTop && isScrollingBack) {
-    ctaVariant = 'mainNavUp';
-    givingLinkVariant = 'mastheadGiving';
-  }
-  if (isLight && isAtTop) {
-    ctaVariant = 'mainNavBlack';
-    givingLinkVariant = 'mastheadGivingBlack';
-  }
-
-  return (
-    <m.header
-      className={cnb(styles.root(isAtTop, isScrollingBack), className)}
-      animate={{ y: isVisible ? 0 : -slideDistance, opacity: isVisible ? 1 : 0 }}
-      transition={{ duration: 0.2, delay: !isAtTop && isScrollingBack ? 0.4 : 0, ease: 'easeInOut' }}
+export const Masthead = ({ isLight, className }: MastheadProps) => (
+  <header className={cnb(styles.root, className)}>
+    <Skiplink />
+    <FlexBox
+      justifyContent="between"
+      alignItems="center"
+      className={styles.wrapper}
     >
-      <Skiplink />
-      <FlexBox
-        justifyContent="between"
-        alignItems="center"
-        className={styles.wrapper(isAtTop)}
-      >
-        <LogoLockup
-          isLink
-          color={isLight && isAtTop ? 'default' : 'white'}
-          text="Impact Stories"
-          className={styles.lockup}
-        />
-        <FlexBox alignItems="center" className={styles.ctaWrapper}>
-          <CtaLink
-            href={ood.giving}
-            variant={givingLinkVariant}
-            icon="external"
-            color="current"
-            animate="top-right"
-          >
-            Giving to Stanford
-          </CtaLink>
-          <CtaLink
-            href={ood.give}
-            variant={ctaVariant}
-            color="current"
-          >
-            Make a gift
-          </CtaLink>
-        </FlexBox>
+      <LogoLockup
+        isLink
+        color={isLight ? 'default' : 'white'}
+        text="Impact Stories"
+        className={styles.lockup}
+      />
+      <FlexBox alignItems="center" className={styles.ctaWrapper}>
+        <CtaLink
+          href={ood.giving}
+          variant={isLight ? 'mastheadGivingBlack' : 'mastheadGiving'}
+          icon="external"
+          color="current"
+          animate="top-right"
+        >
+          Giving to Stanford
+        </CtaLink>
+        <CtaLink
+          href={ood.give}
+          variant={isLight ? 'mainNavBlack' : 'mainNav'}
+          color="current"
+        >
+          Make a gift
+        </CtaLink>
       </FlexBox>
-    </m.header>
-  );
-};
+    </FlexBox>
+  </header>
+);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the sticky header on scrolling up behavior (not great for accessibility)

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-154--giving-campaign.netlify.app/
2. Check that the masthead looks just as before
![Screenshot 2023-11-01 at 2 42 19 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/aaae9b6e-b5ac-492c-a683-606acd0eb990)

3. Scroll down and back up, check that you don't see the masthead coming back in view as sticky at the top
4. Check a light mode page and see that the masthead also looks ok and also no sticky header coming in on scrolling back up
https://deploy-preview-154--giving-campaign.netlify.app/stories/test-story-hero-white-background-vertical
![Screenshot 2023-11-01 at 2 46 46 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/46e9283b-afec-497c-9b23-d752c4aa4484)



# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)
