### PR TITLE
GIVCAMP-230 | Homepage "brand video" section

### DIFF
--- a/components/ChangemakerCard/ChangemakerCard.styles.ts
+++ b/components/ChangemakerCard/ChangemakerCard.styles.ts
@@ -1,7 +1,7 @@
 export const root = 'group relative [perspective:100rem] w-full max-w-[35rem] mx-auto break-words transition-transform focus-visible:outline-none';
 export const cardInner = 'relative w-full aspect-w-1 aspect-h-2 group-hocus:[transform:rotateY(180deg)] [transform-style:preserve-3d] transform-gpu duration-1000';
 export const cardFront = 'absolute w-full h-full top-0 left-0';
-export const cardBack = 'backface-hidden absolute w-full h-full top-0 left-0 rs-px-2 rs-py-3 bg-cardinal-red/80 [transform:rotateY(180deg)]';
+export const cardBack = 'backface-hidden absolute w-full h-full top-0 left-0 rs-px-2 rs-py-3 bg-gradient-to-b from-gc-black/40 to-gc-black/90 [transform:rotateY(180deg)] gc-card';
 export const imageWrapper = 'overflow-hidden aspect-w-1 aspect-h-2';
-export const heading = 'mb-02em group-hocus:opacity-50 transition-opacity delay-100';
-export const content = 'group-hocus:opacity-50 transition-opacity delay-100 rs-pt-3 rs-px-2 rs-pb-9 absolute w-full bottom-0 left-0';
+export const heading = 'mb-02em group-hocus:opacity-0 transition-opacity delay-100';
+export const content = 'group-hocus:opacity-0 transition-opacity delay-100 rs-pt-3 rs-px-2 rs-pb-9 absolute w-full bottom-0 left-0';

--- a/components/ChangemakerCard/ChangemakerCard.tsx
+++ b/components/ChangemakerCard/ChangemakerCard.tsx
@@ -74,7 +74,7 @@ export const ChangemakerCard = ({
             <FlexBox direction="col" alignItems="center" className="absolute bottom-50 right-36 text-white">
               <HeroIcon
                 noBaseStyle
-                icon='cursor'
+                icon='plus'
                 className="w-65 h-65 border-2 border-white rounded-full p-16"
               />
               <Text as="span" font="serif" color="white" variant="caption">

--- a/components/Homepage/Changemaker.tsx
+++ b/components/Homepage/Changemaker.tsx
@@ -11,12 +11,13 @@ export const Changemaker = () => {
   return (
     <Container
       width="full"
-      className="relative overflow-hidden bg-fixed bg-no-repeat bg-top bg-cover"
+      className="relative overflow-hidden lg:bg-fixed bg-no-repeat bg-top bg-cover"
       bgColor="black"
       style={{ backgroundImage: `url('${bgImage}')` }}
       py={10}
     >
-      <Container>
+      <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-t from-gc-black via-sapphire/60" />
+      <Container className="relative z-10">
         <Heading size="f7" font="serif" leading="tight" align="center" className="max-w-[110rem] mx-auto rs-mb-4">
           <AnimateInView animation="slideInFromRight">
             <Text as="span" font="serif" className="block">
@@ -29,7 +30,7 @@ export const Changemaker = () => {
             </Text>
           </AnimateInView>
           <AnimateInView animation="slideInFromRight" delay={0.4}>
-            <Text as="span" font="serif" className="block">
+            <Text as="span" font="serif" className="block" italic>
               Risk-takers.
             </Text>
           </AnimateInView>

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import {
+  m, useScroll, useSpring, useTransform, SpringOptions, useWillChange,
+} from 'framer-motion';
+import { AnimateInView } from '../Animate';
+import { Container } from '../Container';
+import { Heading, Text, Paragraph } from '../Typography';
+import { getProcessedImage } from '@/utilities/getProcessedImage';
+
+export const TogetherSection = () => {
+  return (
+    <Container pb={7} width="full" bgColor="black" className="relative overflow-hidden">
+      <Container>
+        <AnimateInView animation="slideUp">
+          <Heading size="f6" align="center" leading="tight" className="max-w-1200 mx-auto">
+            True change happens when we come together.
+          </Heading>
+        </AnimateInView>
+        <AnimateInView animation="slideUp" delay={0.2}>
+          <Paragraph leading="display" align="center" size={2} className="max-w-900 mx-auto">
+            One changemaker is admirable. A community of changemakers is unstoppable.
+          </Paragraph>
+        </AnimateInView>
+      </Container>
+      <Text
+        font="druk"
+        color="white"
+        align="center"
+        leading="none"
+        aria-hidden
+        className="text-[28vw] -ml-[0.04em]"
+      >
+        Together
+      </Text>
+      <Container>
+        <img
+          src={getProcessedImage('https://a-us.storyblok.com/f/1005200/1280x720/87e6131789/campusscene.gif')}
+          alt="Animated view of the Stanford Dish"
+          className="w-[86vw] sm:w-[60vw] xl:w-[42vw] mx-auto -mt-[13vw]"
+        />
+        <Paragraph
+          font="serif"
+          italic
+          leading="display"
+          align="center"
+          size={2}
+          className="max-w-1000 mx-auto rs-mt-5"
+        >
+          There is nothing we can do that we cannot do better, together.
+        </Paragraph>
+      </Container>
+    </Container>
+  );
+};

--- a/components/Storyblok/SbHomepageMvp.tsx
+++ b/components/Storyblok/SbHomepageMvp.tsx
@@ -2,6 +2,7 @@ import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '../CreateBloks';
 import { Heading } from '../Typography';
 import { HomepageSplitHero } from '../Homepage/HomepageSplitHero';
+import { TogetherSection } from '../Homepage/TogetherSection';
 import { Masthead } from '../Masthead';
 import { Changemaker } from '../Homepage/Changemaker';
 
@@ -32,6 +33,7 @@ export const SbHomepageMvp = ({
         <HomepageSplitHero />
         <CreateBloks blokSection={content} />
         <Changemaker />
+        <TogetherSection />
         <CreateBloks blokSection={ankle} />
       </div>
     </main>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- The "Brand video" section near the bottom of the page
- Using animated GIF for MVP (or static image TBD)
- Style update to the Changemaker section

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to homepage https://deploy-preview-155--giving-campaign.netlify.app/
2. Scroll down to see this section
![Screenshot 2023-11-02 at 12 42 00 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/bb6d439b-1ff7-41ae-b96b-4619f172a703)
NOTE: I'll add more custom animation once I put the new local footer in

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-230