### PR TITLE
GIVCAMP-230 | Together section animation and other misc updates

### DIFF
--- a/components/ChangemakerCard/ChangemakerCard.styles.ts
+++ b/components/ChangemakerCard/ChangemakerCard.styles.ts
@@ -1,7 +1,7 @@
-export const root = 'group relative [perspective:100rem] w-full max-w-[35rem] mx-auto break-words transition-transform focus-visible:outline-none';
+export const root = 'group relative [perspective:100rem] w-full max-w-300 lg:max-w-[35rem] mx-auto break-words transition-transform focus-visible:outline-none ';
 export const cardInner = 'relative w-full aspect-w-1 aspect-h-2 group-hocus:[transform:rotateY(180deg)] [transform-style:preserve-3d] transform-gpu duration-1000';
 export const cardFront = 'absolute w-full h-full top-0 left-0';
 export const cardBack = 'backface-hidden absolute w-full h-full top-0 left-0 rs-px-2 rs-py-3 bg-gradient-to-b from-gc-black/40 to-gc-black/90 [transform:rotateY(180deg)] gc-card';
 export const imageWrapper = 'overflow-hidden aspect-w-1 aspect-h-2';
 export const heading = 'mb-02em group-hocus:opacity-0 transition-opacity delay-100';
-export const content = 'group-hocus:opacity-0 transition-opacity delay-100 rs-pt-3 rs-px-2 rs-pb-9 absolute w-full bottom-0 left-0';
+export const content = 'group-hocus:opacity-0 transition-opacity delay-100 rs-pt-3 rs-px-2 pb-[8em] absolute w-full bottom-0 left-0';

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -38,7 +38,9 @@ export const TogetherSection = () => {
       <m.div
         aria-hidden
         className="font-druk uppercase text-center leading-none text-[28vw] -ml-[0.04em] tracking-wide z-0"
-        style={{ scale: scaleAnimation, opacity: opacityAnimation, letterSpacing: trackingAnimation, willChange }}
+        style={{
+          scale: scaleAnimation, opacity: opacityAnimation, letterSpacing: trackingAnimation, willChange,
+        }}
       >
         Together
       </m.div>

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -1,17 +1,27 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import {
   m, useScroll, useSpring, useTransform, SpringOptions, useWillChange,
 } from 'framer-motion';
 import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
-import { Heading, Text, Paragraph } from '../Typography';
+import { Heading, Paragraph } from '../Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 
 export const TogetherSection = () => {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const willChange = useWillChange();
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ['-80vh', '0'],
+  });
+  const trackingAnimation = useTransform(scrollYProgress, [0, 1], ['0.3em', '0.025em']);
+  const scaleAnimation = useTransform(scrollYProgress, [0, 1], [3, 1]);
+  const opacityAnimation = useTransform(scrollYProgress, [0, 1], [0, 1]);
+
   return (
-    <Container pb={7} width="full" bgColor="black" className="relative overflow-hidden">
+    <div ref={sectionRef} className="relative overflow-hidden rs-pb-8 w-full bg-gc-black text-white">
       <Container>
         <AnimateInView animation="slideUp">
           <Heading size="f6" align="center" leading="tight" className="mx-auto max-w-[105rem]">
@@ -25,23 +35,20 @@ export const TogetherSection = () => {
           </Paragraph>
         </AnimateInView>
       </Container>
-      <Text
-        font="druk"
-        color="white"
-        align="center"
-        leading="none"
+      <m.div
         aria-hidden
-        className="text-[28vw] -ml-[0.04em] tracking-wide"
+        className="font-druk uppercase text-center leading-none text-[28vw] -ml-[0.04em] tracking-wide z-0"
+        style={{ scale: scaleAnimation, opacity: opacityAnimation, letterSpacing: trackingAnimation, willChange }}
       >
         Together
-      </Text>
+      </m.div>
       <Container>
         <img
-          src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3014x1979/5d314e43ba/together_h412-18.jpg', '1000x0')}
+          src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3014x1979/5d314e43ba/together_h412-18.jpg', '1200x0')}
           alt=""
-          className="w-[86vw] sm:w-[60vw] xl:w-[42vw] mx-auto -mt-[13vw]"
+          className="relative w-[86vw] sm:w-[60vw] xl:w-[42vw] mx-auto -mt-[13vw] z-10"
         />
       </Container>
-    </Container>
+    </div>
   );
 };

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -2,11 +2,11 @@
 
 import { useRef } from 'react';
 import {
-  m, useScroll, useSpring, useTransform, SpringOptions, useWillChange,
+  m, useScroll, useTransform, useWillChange,
 } from 'framer-motion';
 import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
-import { Heading, Paragraph } from '../Typography';
+import { Heading, Paragraph, SrOnlyText } from '../Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 
 export const TogetherSection = () => {
@@ -16,9 +16,16 @@ export const TogetherSection = () => {
     target: sectionRef,
     offset: ['-80vh', '0'],
   });
+  const { scrollYProgress: imageScrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ['-80vh', '30vh'],
+  });
   const trackingAnimation = useTransform(scrollYProgress, [0, 1], ['0.3em', '0.025em']);
   const scaleAnimation = useTransform(scrollYProgress, [0, 1], [3, 1]);
   const opacityAnimation = useTransform(scrollYProgress, [0, 1], [0, 1]);
+  const marginTopAnimation = useTransform(imageScrollYProgress, [0, 1], ['20vw', '-13vw']);
+  const imageScaleAnimation = useTransform(imageScrollYProgress, [0, 1], [3, 1]);
+  const imageOpacityAnimation = useTransform(imageScrollYProgress, [0, 0.5, 0.8, 1], [0, 0, 0.3, 1]);
 
   return (
     <div ref={sectionRef} className="relative overflow-hidden rs-pb-8 w-full bg-gc-black text-white">
@@ -33,24 +40,32 @@ export const TogetherSection = () => {
             One changemaker is admirable. A community of changemakers is unstoppable.
             There is nothing we can do that we cannot do better...
           </Paragraph>
+          <SrOnlyText>together</SrOnlyText>
         </AnimateInView>
       </Container>
       <m.div
         aria-hidden
         className="font-druk uppercase text-center leading-none text-[28vw] -ml-[0.04em] tracking-wide z-0"
         style={{
-          scale: scaleAnimation, opacity: opacityAnimation, letterSpacing: trackingAnimation, willChange,
+          scale: scaleAnimation,
+          opacity: opacityAnimation,
+          letterSpacing: trackingAnimation,
+          willChange,
         }}
       >
         Together
       </m.div>
-      <Container>
-        <img
-          src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3014x1979/5d314e43ba/together_h412-18.jpg', '1200x0')}
-          alt=""
-          className="relative w-[86vw] sm:w-[60vw] xl:w-[42vw] mx-auto -mt-[13vw] z-10"
-        />
-      </Container>
+      <m.img
+        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3014x1979/5d314e43ba/together_h412-18.jpg', '1200x0')}
+        alt=""
+        className="relative w-[90vw] sm:w-[60vw] xl:w-[42vw] mx-auto z-10"
+        style={{
+          marginTop: marginTopAnimation,
+          scale: imageScaleAnimation,
+          opacity: imageOpacityAnimation,
+          willChange,
+        }}
+      />
     </div>
   );
 };

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -31,7 +31,7 @@ export const TogetherSection = () => {
         align="center"
         leading="none"
         aria-hidden
-        className="text-[28vw] -ml-[0.04em]"
+        className="text-[28vw] -ml-[0.04em] tracking-wide"
       >
         Together
       </Text>

--- a/components/LocalFooter/LocalFooterMvp.styles.tsx
+++ b/components/LocalFooter/LocalFooterMvp.styles.tsx
@@ -1,7 +1,7 @@
 export const root = 'relative overflow-hidden bg-no-repeat bg-bottom bg-cover md:bg-contain';
-export const overlay = 'absolute top-0 left-0 w-full h-full bg-gradient-to-b from-black-true via-black-true/80 to-black-true/40';
+export const overlay = 'absolute top-0 left-0 w-full h-full bg-gradient-to-b from-gc-black via-gc-black/80 to-gc-black/40';
 export const flexWrapper = 'items-start lg:items-center relative z-10 w-full';
-export const logo = 'scale-125 origin-left sm:scale-100 text-[1.6em]';
+export const logo = 'scale-125 origin-left sm:scale-100 text-[1.67em] md:text-[1.72em] lg:text-[1.9em] lg:ml-[5.4rem] 2xl:ml-60';
 export const ul = 'list-unstyled divide-x divide-white children:inline-block children:mb-0 children:px-16 md:children:px-30 xl:children:px-48 children:leading-display first:children:pl-0 last:children:pr-0 lg:mx-auto w-fit rs-mt-2 gap-y-10';
 export const grid = 'w-full lg:gap-x-[7vw] 3xl:gap-x-300';
 export const column2 = 'rs-mt-3 lg:mt-0';

--- a/components/LocalFooter/LocalFooterMvp.tsx
+++ b/components/LocalFooter/LocalFooterMvp.tsx
@@ -28,14 +28,13 @@ export const LocalFooterMvp = () => (
       </FlexBox>
       <Grid lg={2} pt={8} gap="default" className={styles.grid}>
         <div>
-          <Heading as="h3" size={3}>
+          <Heading as="h3" size={3} leading="tight">
             Get the latest in your inbox
           </Heading>
           <Paragraph variant="big" leading="display">
             Sign up to receive Stanford’s storytelling newsletter.
           </Paragraph>
           <CtaLink
-            // This might become a button to activate a Typeform widget in-situ
             href={links.ood.newsletterSignUp}
             variant="solid"
             icon="arrow-right"
@@ -44,7 +43,7 @@ export const LocalFooterMvp = () => (
           </CtaLink>
         </div>
         <div className={styles.column2}>
-          <Heading as="h3" size={3}>
+          <Heading as="h3" size={3} leading="tight">
             We can do this, together
           </Heading>
           <Paragraph variant="big" leading="display">


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add animation to the "Together" section
- Local footer and changemaker cards style updates

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. https://deploy-preview-157--giving-campaign.netlify.app/
2. Scroll all the way down to the "Together" section and check out the animation that respond to scroll position
![Screenshot 2023-11-03 at 1 32 58 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/03536f76-c3d7-4eb4-a80d-f400b5336b17)
3. In local footer, check that the vertical line in the logo lock up aligns with one of the dividers of the nav below it
![Screenshot 2023-11-03 at 1 35 19 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/c3837e46-15c7-4ba7-9edf-557704ee1c1b)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-230