### PR TITLE
GIVCAMP-223 | Story image; layout component options; packages updates

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -13,7 +13,7 @@ export const blurWrapper = (
 ) => cnb(
   'relative w-full h-full z-10', {
     'backdrop-blur-md' : addBgBlur,
-    'bg-black-true/50 md:bg-black-true/30': type === 'hero' && addDarkOverlay && bgColor === 'black',
+    'bg-black-true/50 md:bg-black-true/40': type === 'hero' && addDarkOverlay && bgColor === 'black',
     'bg-gradient-to-b from-black-true/50': type === 'poster' && bgColor === 'black',
     'lg:from-black-true/20 lg:to-black-true/70': type === 'poster' && addDarkOverlay && bgColor === 'black',
     'lg:bg-none': type === 'poster' && bgColor === 'black' && !addDarkOverlay,

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -123,7 +123,7 @@ export const BlurryPoster = ({
                   <Heading
                     as={headingLevel}
                     font={headingFont}
-                    leading={headingFont === 'druk' ? 'none' : 'display'}
+                    leading={headingFont === 'druk' ? 'none' : 'tight'}
                     className={styles.heading(imageOnLeft, isSmallHeading, headingFont, isTwoCol)}
                   >
                     {heading}

--- a/components/Container/Container.tsx
+++ b/components/Container/Container.tsx
@@ -4,6 +4,10 @@ import {
   paddingTops,
   paddingBottoms,
   paddingVerticals,
+  marginTops,
+  marginBottoms,
+  marginVerticals,
+  type MarginType,
   type PaddingType,
 } from '@/utilities/datasource';
 import * as styles from './Container.styles';
@@ -15,6 +19,9 @@ export type ContainerProps = HTMLAttributes<HTMLElement> & {
   pt?: PaddingType;
   pb?: PaddingType;
   py?: PaddingType;
+  mt?: MarginType;
+  mb?: MarginType;
+  my?: MarginType;
   bgColor?: types.BgColorType;
   style?: React.CSSProperties;
 };
@@ -25,6 +32,9 @@ export const Container = ({
   py,
   pt,
   pb,
+  mt,
+  mb,
+  my,
   bgColor,
   style,
   className,
@@ -39,6 +49,9 @@ export const Container = ({
       py ? paddingVerticals[py] : '',
       pt ? paddingTops[pt] : '',
       pb ? paddingBottoms[pb] : '',
+      my ? marginVerticals[my] : '',
+      mt ? marginTops[mt] : '',
+      mb ? marginBottoms[mb] : '',
       width ? styles.widths[width] : '',
       className,
     )}

--- a/components/EmbedMedia/EmbedMedia.styles.ts
+++ b/components/EmbedMedia/EmbedMedia.styles.ts
@@ -1,2 +1,2 @@
 export const mediaWrapper = 'children:!w-full children:!h-full';
-export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-08em max-w-prose-wide';
+export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-1em max-w-prose-wide';

--- a/components/Hero/StoryHeroMvp.styles.ts
+++ b/components/Hero/StoryHeroMvp.styles.ts
@@ -26,5 +26,5 @@ export const image = (renderTwoImages: boolean) => cnb(
   renderTwoImages ? 'hidden lg:block' : '',
 );
 export const mobileImage = 'w-full h-full lg:hidden';
-export const captionWrapper = 'mt-08em';
+export const captionWrapper = 'mt-06em';
 export const caption = 'max-w-prose-wide text-black-70';

--- a/components/Quote/Quote.styles.ts
+++ b/components/Quote/Quote.styles.ts
@@ -5,9 +5,9 @@ export const root = (
   addDarkOverlay?: boolean,
   quoteOnRight?: boolean,
   hasBar?: boolean,
-) => cnb('relative break-words', {
+) => cnb('relative break-words flex flex-col', {
   'max-w-[90%] sm:max-w-[80%] mx-auto md:max-w-full': isMinimal && !addDarkOverlay,
-  'bg-gc-black/50 backdrop-blur-sm': addDarkOverlay && !isMinimal,
+  'bg-gc-black/50 backdrop-blur-sm h-full children:mt-auto children:mb-0': addDarkOverlay && !isMinimal,
   'rs-pl-4': !quoteOnRight && (!isMinimal || addDarkOverlay),
   'rs-pr-4': quoteOnRight && (!isMinimal || addDarkOverlay),
   'rs-px-4': addDarkOverlay && !hasBar,

--- a/components/Quote/Quote.styles.ts
+++ b/components/Quote/Quote.styles.ts
@@ -22,9 +22,9 @@ export const quoteMark = (isLargeTeaser?: boolean) => cnb('shrink-0 leading-[0]'
   'text-[clamp(16rem,7.46vw+13.31rem,26rem)] mt-[clamp(5.7rem,2.61vw+4.76rem,9.2rem)]': !isLargeTeaser,
   'text-[clamp(17rem,11.19vw+12.97rem,32rem)] mt-[clamp(6rem,4.03vw+4.55rem,11.4rem)]': isLargeTeaser,
 });
-export const teaser = 'rs-mb-0 grow-0 w-fit max-w-[25ch]';
+export const teaser = 'rs-mb-0 grow-0 w-fit max-w-[20ch]';
 export const body = (isLargeBody?: boolean) => cnb('mt-02em first:mt-0', {
   'max-w-[55ch]': !isLargeBody,
-  'max-w-[40ch]': isLargeBody,
+  'max-w-[35ch]': isLargeBody,
 });
 export const source = 'rs-mt-1 whitespace-pre-line';

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -48,7 +48,8 @@ export const Quote = ({
     <Container
       as="article"
       width="full"
-      py={addDarkOverlay && !isMinimal ? 4 : undefined}
+      pt={addDarkOverlay && !isMinimal ? 6 : undefined}
+      pb={addDarkOverlay && !isMinimal ? 4 : undefined}
       className={cnb(styles.root(isMinimal, addDarkOverlay, quoteOnRight, !!barColor), className)}
       {...props}
     >

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -1,3 +1,5 @@
+import { cnb } from 'cnbuilder';
+
 export const imageCrops = {
   '1x1': '1400x1400',
   '1x2': '1000x2000',
@@ -14,5 +16,9 @@ export const imageCrops = {
 };
 export type ImageCropType = keyof typeof imageCrops;
 
+export const root = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
+export const animateWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
+export const figure = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
+export const imageWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const image = 'w-full h-full object-cover';
 export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-1em max-w-prose-wide';

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -1,0 +1,2 @@
+export const mediaWrapper = 'children:!w-full children:!h-full';
+export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-08em max-w-prose-wide';

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -15,4 +15,4 @@ export const imageCrops = {
 export type ImageCropType = keyof typeof imageCrops;
 
 export const image = 'w-full h-full object-cover';
-export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-08em max-w-prose-wide';
+export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-1em max-w-prose-wide';

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -1,2 +1,18 @@
+export const imageCrops = {
+  '1x1': '1400x1400',
+  '1x2': '1000x2000',
+  '2x1': '2000x1000',
+  '2x3': '1200x1800',
+  '3x2': '2100x1400',
+  '3x4': '1500x2000',
+  '4x3': '2000x1500',
+  '5x8': '1000x1600',
+  '8x5': '2000x1250',
+  '9x16': '900x1600',
+  '16x9': '2000x1125',
+  'free': '2000x0',
+};
+export type ImageCropType = keyof typeof imageCrops;
+
 export const image = 'w-full h-full object-cover';
 export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-08em max-w-prose-wide';

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -1,2 +1,2 @@
-export const mediaWrapper = 'children:!w-full children:!h-full';
+export const image = 'w-full h-full object-cover';
 export const caption = 'children:children:text-black-70 children:children:leading-display caption mt-08em max-w-prose-wide';

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -9,6 +9,7 @@ import * as styles from './StoryImage.styles';
 type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   imageSrc: string;
   imageFocus?: string;
+  alt?: string;
   caption?: React.ReactNode;
   aspectRatio?: ImageAspectRatioType;
   boundingWidth?: 'site' | 'full';
@@ -21,6 +22,7 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
 export const StoryImage = ({
   imageSrc,
   imageFocus,
+  alt,
   caption,
   aspectRatio,
   boundingWidth = 'full',
@@ -42,8 +44,8 @@ export const StoryImage = ({
       className={className}
     >
       <figure>
-        <div className={cnb(imageAspectRatios[aspectRatio], styles.mediaWrapper)}>
-          <img src={getProcessedImage(imageSrc)} alt="" className="object-cover" />
+        <div className={imageAspectRatios[aspectRatio]}>
+          <img src={getProcessedImage(imageSrc, '2000x0', imageFocus)} alt={alt || ''} className={styles.image} />
         </div>
         {caption && (
           <Container as="figcaption" width={isCaptionInset ? 'site' : 'full'}>

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -1,3 +1,4 @@
+import { cnb } from 'cnbuilder';
 import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
 import { WidthBox, type WidthType } from '../WidthBox';
@@ -15,6 +16,7 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   alt?: string;
   caption?: React.ReactNode;
   aspectRatio?: ImageAspectRatioType;
+  isFullHeight?: boolean;
   boundingWidth?: 'site' | 'full';
   width?: WidthType;
   spacingTop?: PaddingType;
@@ -31,6 +33,7 @@ export const StoryImage = ({
   alt,
   caption,
   aspectRatio,
+  isFullHeight,
   boundingWidth = 'full',
   width,
   spacingTop,
@@ -59,11 +62,11 @@ export const StoryImage = ({
       width={width}
       pt={spacingTop}
       pb={spacingBottom}
-      className={className}
+      className={cnb(className, styles.root(isFullHeight))}
     >
-      <AnimateInView animation={animation} delay={delay}>
-        <figure>
-          <div className={imageAspectRatios[aspectRatio]}>
+      <AnimateInView animation={animation} delay={delay} className={styles.animateWrapper(isFullHeight)}>
+        <figure className={styles.figure(isFullHeight)}>
+          <div className={cnb(imageAspectRatios[aspectRatio], styles.imageWrapper(isFullHeight))}>
             <img
               src={getProcessedImage(imageSrc, cropSize, imageFocus)}
               loading={isLoadingEager ? 'eager' : 'lazy'}

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -1,4 +1,3 @@
-import { cnb } from 'cnbuilder';
 import { Container } from '../Container';
 import { WidthBox, type WidthType } from '../WidthBox';
 import { type PaddingType } from '@/utilities/datasource';

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -4,6 +4,7 @@ import { WidthBox, type WidthType } from '../WidthBox';
 import { type PaddingType } from '@/utilities/datasource';
 import { imageAspectRatios, type ImageAspectRatioType } from '@/utilities/datasource';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
+import { getSbImageSize } from '@/utilities/getSbImageSize';
 import { type AnimationType } from '../Animate';
 import * as styles from './StoryImage.styles';
 
@@ -40,9 +41,16 @@ export const StoryImage = ({
   className,
   ...props
 }: StoryImageProps) => {
+  const { width: originalWidth, height: originalHeight } = getSbImageSize(imageSrc);
   const cropSize = styles.imageCrops[aspectRatio];
+  /**
+   * Crop width and height are used for width and height attributes on the img element.
+   * They don't need to be exact as long as the aspect ratio is correct.
+   */
   const cropWidth = parseInt(cropSize?.split('x')[0], 10);
-  const cropHeight = parseInt(cropSize?.split('x')[1], 10);
+  const cropHeight = aspectRatio === 'free'
+    ? Math.round(originalHeight * 2000 / originalWidth)
+    : parseInt(cropSize?.split('x')[1], 10);
 
   return (
     <WidthBox

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -9,6 +9,7 @@ import * as styles from './StoryImage.styles';
 type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   imageSrc: string;
   imageFocus?: string;
+  isLoadingEager?: boolean;
   alt?: string;
   caption?: React.ReactNode;
   aspectRatio?: ImageAspectRatioType;
@@ -22,6 +23,7 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
 export const StoryImage = ({
   imageSrc,
   imageFocus,
+  isLoadingEager,
   alt,
   caption,
   aspectRatio,
@@ -33,6 +35,9 @@ export const StoryImage = ({
   className,
   ...props
 }: StoryImageProps) => {
+  const cropSize = styles.imageCrops[aspectRatio];
+  const cropWidth = parseInt(cropSize?.split('x')[0], 10);
+  const cropHeight = parseInt(cropSize?.split('x')[1], 10);
 
   return (
     <WidthBox
@@ -45,7 +50,14 @@ export const StoryImage = ({
     >
       <figure>
         <div className={imageAspectRatios[aspectRatio]}>
-          <img src={getProcessedImage(imageSrc, '2000x0', imageFocus)} alt={alt || ''} className={styles.image} />
+          <img
+            src={getProcessedImage(imageSrc, cropSize, imageFocus)}
+            loading={isLoadingEager ? 'eager' : 'lazy'}
+            width={cropWidth}
+            height={cropHeight}
+            alt={alt || ''}
+            className={styles.image}
+          />
         </div>
         {caption && (
           <Container as="figcaption" width={isCaptionInset ? 'site' : 'full'}>

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -1,8 +1,10 @@
+import { AnimateInView } from '../Animate';
 import { Container } from '../Container';
 import { WidthBox, type WidthType } from '../WidthBox';
 import { type PaddingType } from '@/utilities/datasource';
 import { imageAspectRatios, type ImageAspectRatioType } from '@/utilities/datasource';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
+import { type AnimationType } from '../Animate';
 import * as styles from './StoryImage.styles';
 
 type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -17,6 +19,8 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   spacingTop?: PaddingType;
   spacingBottom?: PaddingType;
   isCaptionInset?: boolean;
+  animation?: AnimationType;
+  delay?: number;
 };
 
 export const StoryImage = ({
@@ -31,6 +35,8 @@ export const StoryImage = ({
   spacingTop,
   spacingBottom,
   isCaptionInset,
+  animation = 'none',
+  delay,
   className,
   ...props
 }: StoryImageProps) => {
@@ -47,25 +53,27 @@ export const StoryImage = ({
       pb={spacingBottom}
       className={className}
     >
-      <figure>
-        <div className={imageAspectRatios[aspectRatio]}>
-          <img
-            src={getProcessedImage(imageSrc, cropSize, imageFocus)}
-            loading={isLoadingEager ? 'eager' : 'lazy'}
-            width={cropWidth}
-            height={cropHeight}
-            alt={alt || ''}
-            className={styles.image}
-          />
-        </div>
-        {caption && (
-          <Container as="figcaption" width={isCaptionInset ? 'site' : 'full'}>
-            <div className={styles.caption}>
-              {caption}
-            </div>
-          </Container>
-        )}
-      </figure>
+      <AnimateInView animation={animation} delay={delay}>
+        <figure>
+          <div className={imageAspectRatios[aspectRatio]}>
+            <img
+              src={getProcessedImage(imageSrc, cropSize, imageFocus)}
+              loading={isLoadingEager ? 'eager' : 'lazy'}
+              width={cropWidth}
+              height={cropHeight}
+              alt={alt || ''}
+              className={styles.image}
+            />
+          </div>
+          {caption && (
+            <Container as="figcaption" width={isCaptionInset ? 'site' : 'full'}>
+              <div className={styles.caption}>
+                {caption}
+              </div>
+            </Container>
+          )}
+        </figure>
+      </AnimateInView>
     </WidthBox>
   );
 };

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -1,0 +1,58 @@
+import { cnb } from 'cnbuilder';
+import { Container } from '../Container';
+import { WidthBox, type WidthType } from '../WidthBox';
+import { type PaddingType } from '@/utilities/datasource';
+import { imageAspectRatios, type ImageAspectRatioType } from '@/utilities/datasource';
+import { getProcessedImage } from '@/utilities/getProcessedImage';
+import * as styles from './StoryImage.styles';
+
+type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
+  imageSrc: string;
+  imageFocus?: string;
+  caption?: React.ReactNode;
+  aspectRatio?: ImageAspectRatioType;
+  boundingWidth?: 'site' | 'full';
+  width?: WidthType;
+  spacingTop?: PaddingType;
+  spacingBottom?: PaddingType;
+  isCaptionInset?: boolean;
+};
+
+export const StoryImage = ({
+  imageSrc,
+  imageFocus,
+  caption,
+  aspectRatio,
+  boundingWidth = 'full',
+  width,
+  spacingTop,
+  spacingBottom,
+  isCaptionInset,
+  className,
+  ...props
+}: StoryImageProps) => {
+
+  return (
+    <WidthBox
+      {...props}
+      boundingWidth={boundingWidth}
+      width={width}
+      pt={spacingTop}
+      pb={spacingBottom}
+      className={className}
+    >
+      <figure>
+        <div className={cnb(imageAspectRatios[aspectRatio], styles.mediaWrapper)}>
+          <img src={getProcessedImage(imageSrc)} alt="" className="object-cover" />
+        </div>
+        {caption && (
+          <Container as="figcaption" width={isCaptionInset ? 'site' : 'full'}>
+            <div className={styles.caption}>
+              {caption}
+            </div>
+          </Container>
+        )}
+      </figure>
+    </WidthBox>
+  );
+};

--- a/components/StoryImage/index.ts
+++ b/components/StoryImage/index.ts
@@ -1,0 +1,1 @@
+export * from './StoryImage';

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -1,5 +1,6 @@
 import { cnb } from 'cnbuilder';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
+import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { CreateBloks } from '../CreateBloks';
 import { FlexBox } from '../FlexBox';
 import {
@@ -11,10 +12,13 @@ import {
 } from '../Typography';
 import { Container, type BgColorType } from '../Container';
 import { ImageOverlay } from '../ImageOverlay';
+import { RichText } from '../RichText';
+import { WidthBox } from '../WidthBox';
 import { accentBgColors, type PaddingType, type MarginType } from '@/utilities/datasource';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 import { type SbImageType } from './Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
+import { hasRichText } from '@/utilities/hasRichText';
 
 type SbSectionProps = {
   blok: {
@@ -25,6 +29,8 @@ type SbSectionProps = {
     isSmallHeading?: boolean;
     headingLevel?: HeadingType;
     subheading?: string;
+    caption?: StoryblokRichtext;
+    captionColumnWidth?: '12' | '10' | '8' | '6' | '4';
     rightAlignHeader?: boolean;
     barColor?: {
       value?: PaletteAccentHexColorType;
@@ -46,6 +52,8 @@ export const SbSection = ({
     isSmallHeading,
     headingLevel,
     subheading,
+    caption,
+    captionColumnWidth,
     rightAlignHeader,
     barColor: { value: barColorValue } = {},
     bgColor,
@@ -61,75 +69,88 @@ export const SbSection = ({
 
   return (
     <Container
-      {...storyblokEditable(blok)}
       width="full"
-      bgColor={bgColor}
-      pt={paddingTop}
-      pb={paddingBottom}
       mt={marginTop}
       mb={marginBottom}
       className="relative overflow-hidden"
+      {...storyblokEditable(blok)}
     >
-      {filename && (
-        <ImageOverlay imageSrc={getProcessedImage(filename, '2000x1600', focus)} overlay={bgColor === 'black' ? 'black-60' : 'white-90'} />
-      )}
-      {(heading || superhead) && (
-        <FlexBox className={cnb('relative z-10', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}>
-          {barColorValue && (
+      <Container
+        width="full"
+        bgColor={bgColor}
+        pt={paddingTop}
+        pb={paddingBottom}
+        className="relative overflow-hidden"
+      >
+        {filename && (
+          <ImageOverlay imageSrc={getProcessedImage(filename, '2000x1600', focus)} overlay={bgColor === 'black' ? 'black-60' : 'white-90'} />
+        )}
+        {(heading || superhead) && (
+          <FlexBox className={cnb('relative z-10', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}>
+            {barColorValue && (
+              <div className={cnb(
+                'block w-10 sm:w-14 md:w-20 lg:w-30 xl:w-40',
+                rightAlignHeader ? 'order-last' : 'order-first',
+                accentBgColors[paletteAccentColors[barColorValue]],
+              )}
+              />
+            )}
             <div className={cnb(
-              'block w-10 sm:w-14 md:w-20 lg:w-30 xl:w-40',
-              rightAlignHeader ? 'order-last' : 'order-first',
-              accentBgColors[paletteAccentColors[barColorValue]],
+              'cc whitespace-pre-line w-full 3xl:max-w-[90%]',
+              barColorValue && !rightAlignHeader ? '-ml-10 sm:-ml-14 md:-ml-20 lg:-ml-30 xl:-ml-40' : '',
+              barColorValue && rightAlignHeader ? '-mr-10 sm:-mr-14 md:-mr-20 lg:-mr-30 xl:-mr-40' : '',
+              !barColorValue && !rightAlignHeader ? 'ml-0' : '',
+              !barColorValue && rightAlignHeader ? 'mr-0' : '',
+              superhead ? '' : '-mt-05em',
             )}
-            />
-          )}
-          <div className={cnb(
-            'cc whitespace-pre-line w-full 3xl:max-w-[90%]',
-            barColorValue && !rightAlignHeader ? '-ml-10 sm:-ml-14 md:-ml-20 lg:-ml-30 xl:-ml-40' : '',
-            barColorValue && rightAlignHeader ? '-mr-10 sm:-mr-14 md:-mr-20 lg:-mr-30 xl:-mr-40' : '',
-            !barColorValue && !rightAlignHeader ? 'ml-0' : '',
-            !barColorValue && rightAlignHeader ? 'mr-0' : '',
-            superhead ? '' : '-mt-05em',
-          )}
-          >
-            {superhead && (
-              <Text size={2} leading="tight" font="serif" weight="semibold" align={rightAlignHeader ? 'right' : 'left'} aria-hidden>
-                {superhead}
-              </Text>
-            )}
-            {heading && (
-              <Heading
-                as={headingLevel}
-                size={isSmallHeading ? 'f8' : 'splash'}
-                leading="none"
-                uppercase
-                font="druk"
-                align={rightAlignHeader ? 'right' : 'left'}
-                className="mb-0"
-              >
-                {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
-              </Heading>
-            )}
-          </div>
-        </FlexBox>
-      )}
-      {subheading && (
-        <Container>
-          <Paragraph
-            variant="overview"
-            weight="normal"
-            align={rightAlignHeader ? 'right' : 'left'}
-            color={bgColor === 'black' ? 'black-20' : 'black-80'}
-            noMargin
-            className={cnb('relative z-10 max-w-prose ml-0 rs-mt-3', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}
-          >
-            {subheading}
-          </Paragraph>
+            >
+              {superhead && (
+                <Text size={2} leading="tight" font="serif" weight="semibold" align={rightAlignHeader ? 'right' : 'left'} aria-hidden>
+                  {superhead}
+                </Text>
+              )}
+              {heading && (
+                <Heading
+                  as={headingLevel}
+                  size={isSmallHeading ? 'f8' : 'splash'}
+                  leading="none"
+                  uppercase
+                  font="druk"
+                  align={rightAlignHeader ? 'right' : 'left'}
+                  className="mb-0"
+                >
+                  {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
+                </Heading>
+              )}
+            </div>
+          </FlexBox>
+        )}
+        {subheading && (
+          <Container>
+            <Paragraph
+              variant="overview"
+              weight="normal"
+              align={rightAlignHeader ? 'right' : 'left'}
+              color={bgColor === 'black' ? 'black-20' : 'black-80'}
+              noMargin
+              className={cnb('relative z-10 max-w-prose ml-0 rs-mt-3', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}
+            >
+              {subheading}
+            </Paragraph>
+          </Container>
+        )}
+        <Container pt={hasHeader ? 8 : undefined} width="full" className="relative z-10">
+          <CreateBloks blokSection={content} isDarkTheme={bgColor === 'black'} />
         </Container>
-      )}
-      <Container pt={hasHeader ? 8 : undefined} width="full" className="relative z-10">
-        <CreateBloks blokSection={content} isDarkTheme={bgColor === 'black'} />
       </Container>
+      {hasRichText(caption) && (
+        <WidthBox boundingWidth="site" width={captionColumnWidth}>
+          <RichText
+            wysiwyg={caption}
+            className="children:text-black-70 children:leading-display caption mt-1em max-w-prose-wide"
+          />
+        </WidthBox>
+      )}
     </Container>
   );
 };

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -3,11 +3,15 @@ import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '../CreateBloks';
 import { FlexBox } from '../FlexBox';
 import {
-  Heading, type HeadingType, SrOnlyText, Text, Paragraph,
+  Heading,
+  type HeadingType,
+  SrOnlyText,
+  Text,
+  Paragraph,
 } from '../Typography';
 import { Container, type BgColorType } from '../Container';
 import { ImageOverlay } from '../ImageOverlay';
-import { accentBgColors, type PaddingType } from '@/utilities/datasource';
+import { accentBgColors, type PaddingType, type MarginType } from '@/utilities/datasource';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 import { type SbImageType } from './Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
@@ -29,6 +33,8 @@ type SbSectionProps = {
     bgImage?: SbImageType;
     paddingTop?: PaddingType;
     paddingBottom?: PaddingType;
+    marginTop?: MarginType;
+    marginBottom?: MarginType;
   };
 };
 
@@ -46,6 +52,8 @@ export const SbSection = ({
     bgImage: { filename, focus } = {},
     paddingTop,
     paddingBottom,
+    marginTop,
+    marginBottom,
   },
   blok,
 }: SbSectionProps) => {
@@ -58,10 +66,12 @@ export const SbSection = ({
       bgColor={bgColor}
       pt={paddingTop}
       pb={paddingBottom}
+      mt={marginTop}
+      mb={marginBottom}
       className="relative overflow-hidden"
     >
       {filename && (
-        <ImageOverlay imageSrc={getProcessedImage(filename, '2000x1600', focus)} overlay={bgColor === 'black' ? 'black-70' : 'white-90'} />
+        <ImageOverlay imageSrc={getProcessedImage(filename, '2000x1600', focus)} overlay={bgColor === 'black' ? 'black-60' : 'white-90'} />
       )}
       {(heading || superhead) && (
         <FlexBox className={cnb('relative z-10', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}>

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -1,0 +1,54 @@
+import { storyblokEditable } from '@storyblok/react/rsc';
+import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
+import { type ImageAspectRatioType } from '@/utilities/datasource';
+import { type WidthType } from '../WidthBox';
+import { type PaddingType } from '@/utilities/datasource';
+import { hasRichText } from '@/utilities/hasRichText';
+import { StoryImage } from '../StoryImage';
+import { RichText } from '../RichText';
+import { type SbImageType } from './Storyblok.types';
+
+type SbStoryImageProps = {
+  blok: {
+    _uid: string;
+    image: SbImageType;
+    caption?: StoryblokRichtext;
+    aspectRatio?: ImageAspectRatioType;
+    boundingWidth?: 'site' | 'full';
+    width?: WidthType;
+    spacingTop?: PaddingType;
+    spacingBottom?: PaddingType;
+    isCaptionInset?: boolean;
+  };
+};
+
+export const SbStoryImage = ({
+  blok: {
+    image: { filename, focus } = {},
+    caption,
+    aspectRatio,
+    boundingWidth = 'full',
+    width,
+    spacingTop,
+    spacingBottom,
+    isCaptionInset,
+  },
+  blok,
+}: SbStoryImageProps) => {
+  const Caption = hasRichText(caption) ? <RichText wysiwyg={caption} /> : undefined;
+
+  return (
+    <StoryImage
+      {...storyblokEditable(blok)}
+      imageSrc={filename}
+      imageFocus={focus}
+      caption={Caption}
+      aspectRatio={aspectRatio}
+      boundingWidth={boundingWidth}
+      width={width}
+      spacingTop={spacingTop}
+      spacingBottom={spacingBottom}
+      isCaptionInset={isCaptionInset}
+    />
+  );
+};

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -6,6 +6,7 @@ import { type PaddingType } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
 import { StoryImage } from '../StoryImage';
 import { RichText } from '../RichText';
+import { type AnimationType } from '../Animate';
 import { type SbImageType } from './Storyblok.types';
 
 type SbStoryImageProps = {
@@ -20,6 +21,8 @@ type SbStoryImageProps = {
     spacingTop?: PaddingType;
     spacingBottom?: PaddingType;
     isCaptionInset?: boolean;
+    animation?: AnimationType;
+    delay?: number;
   };
 };
 
@@ -34,6 +37,8 @@ export const SbStoryImage = ({
     spacingTop,
     spacingBottom,
     isCaptionInset,
+    animation = 'none',
+    delay,
   },
   blok,
 }: SbStoryImageProps) => {
@@ -52,6 +57,8 @@ export const SbStoryImage = ({
       spacingTop={spacingTop}
       spacingBottom={spacingBottom}
       isCaptionInset={isCaptionInset}
+      animation={animation}
+      delay={delay}
     />
   );
 };

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -12,6 +12,7 @@ type SbStoryImageProps = {
   blok: {
     _uid: string;
     image: SbImageType;
+    isLoadingEager?: boolean;
     caption?: StoryblokRichtext;
     aspectRatio?: ImageAspectRatioType;
     boundingWidth?: 'site' | 'full';
@@ -25,6 +26,7 @@ type SbStoryImageProps = {
 export const SbStoryImage = ({
   blok: {
     image: { filename, focus } = {},
+    isLoadingEager,
     caption,
     aspectRatio,
     boundingWidth = 'full',
@@ -42,6 +44,7 @@ export const SbStoryImage = ({
       {...storyblokEditable(blok)}
       imageSrc={filename}
       imageFocus={focus}
+      isLoadingEager={isLoadingEager}
       caption={Caption}
       aspectRatio={aspectRatio}
       boundingWidth={boundingWidth}

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -17,6 +17,7 @@ type SbStoryImageProps = {
     isLoadingEager?: boolean;
     caption?: StoryblokRichtext;
     aspectRatio?: ImageAspectRatioType;
+    isFullHeight?: boolean;
     boundingWidth?: 'site' | 'full';
     width?: WidthType;
     spacingTop?: PaddingType;
@@ -34,6 +35,7 @@ export const SbStoryImage = ({
     isLoadingEager,
     caption,
     aspectRatio,
+    isFullHeight,
     boundingWidth = 'full',
     width,
     spacingTop,
@@ -55,6 +57,7 @@ export const SbStoryImage = ({
       isLoadingEager={isLoadingEager}
       caption={Caption}
       aspectRatio={aspectRatio}
+      isFullHeight={isFullHeight}
       boundingWidth={boundingWidth}
       width={width}
       spacingTop={spacingTop}

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -13,6 +13,7 @@ type SbStoryImageProps = {
   blok: {
     _uid: string;
     image: SbImageType;
+    alt?: string;
     isLoadingEager?: boolean;
     caption?: StoryblokRichtext;
     aspectRatio?: ImageAspectRatioType;
@@ -29,6 +30,7 @@ type SbStoryImageProps = {
 export const SbStoryImage = ({
   blok: {
     image: { filename, focus } = {},
+    alt,
     isLoadingEager,
     caption,
     aspectRatio,
@@ -49,6 +51,7 @@ export const SbStoryImage = ({
       {...storyblokEditable(blok)}
       imageSrc={filename}
       imageFocus={focus}
+      alt={alt}
       isLoadingEager={isLoadingEager}
       caption={Caption}
       aspectRatio={aspectRatio}

--- a/components/Storyblok/SbStoryMvp/SbAboveContent.tsx
+++ b/components/Storyblok/SbStoryMvp/SbAboveContent.tsx
@@ -21,7 +21,7 @@ export const SbAboveContent = ({
         <CreateBloks blokSection={intro} />
       </div>
       {sidebar && (
-        <aside className="md:col-span-10 md:col-start-2 lg:col-span-5 lg:col-start-8 xl:col-span-4 xl:col-start-9 2xl:col-span-4 2xl:col-start-9">
+        <aside className="md:col-span-8 md:col-start-3 lg:col-span-5 lg:col-start-8 xl:col-span-4 xl:col-start-9 2xl:col-span-4 2xl:col-start-9">
           <div className="2xl:max-w-[90%] mr-0 ml-auto">
             <CreateBloks blokSection={sidebar} />
           </div>

--- a/components/StoryblokProvider.tsx
+++ b/components/StoryblokProvider.tsx
@@ -23,6 +23,7 @@ import { SbSplitPoster } from './Storyblok/SbSplitPoster';
 import { SbStory } from './Storyblok/SbStory';
 import { SbStoryMvp } from './Storyblok/SbStoryMvp/SbStoryMvp';
 import { SbStoryCard } from './Storyblok/SbStoryCard';
+import { SbStoryImage } from './Storyblok/SbStoryImage';
 import { SbTextCard } from './Storyblok/SbTextCard';
 import { SbTexturedBar } from './Storyblok/SbTexturedBar';
 import { SbThemeCard } from './Storyblok/SbThemeCard';
@@ -52,11 +53,12 @@ const components = {
   sbSplitPoster: SbSplitPoster,
   sbStory: SbStory,
   sbStoryMvp: SbStoryMvp,
+  sbStoryCard: SbStoryCard,
+  sbStoryImage: SbStoryImage,
   sbTextCard: SbTextCard,
   sbTexturedBar: SbTexturedBar,
   sbThemeCard: SbThemeCard,
   sbTriangle: SbTriangle,
-  sbStoryCard: SbStoryCard,
   sbVerticalPoster: SbVerticalPoster,
   sbWysiwyg: SbWysiwyg,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,12 +23,12 @@
         "@types/node": "^20.4.7",
         "@types/react": "^18.2",
         "@types/react-dom": "^18.2",
-        "autoprefixer": "^10.4.14",
-        "decanter": "^7.1.1",
+        "autoprefixer": "^10.4.16",
+        "decanter": "^7.1.2",
         "eslint": "^8.50.0",
         "eslint-config-next": "^13.4.13",
         "netlify-plugin-vault-variables": "^1.0.7",
-        "postcss": "^8.4.27",
+        "postcss": "^8.4.31",
         "typescript": "^5.1"
       },
       "engines": {
@@ -483,15 +483,6 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
-      }
-    },
-    "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
-      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
-      "dev": true,
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@typeform/embed": {
@@ -1351,15 +1342,14 @@
       }
     },
     "node_modules/decanter": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/decanter/-/decanter-7.1.1.tgz",
-      "integrity": "sha512-rmR8+OgjkLM8ondaBG8L/+zZVhJBcmavu3y/OxAt/vy0eKc1ICPK+QVcC+C52q0ltS4Jt9yfWDq50+J2xMzK3w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/decanter/-/decanter-7.1.2.tgz",
+      "integrity": "sha512-TxhNhB2PtcT4V2SveCjAMhCpIP6XfmYwaNROG1kRZqeHgHarktXI/Clk6sEiY8MQ5/t0pDL+I8dFhAMAQmLI1g==",
       "dev": true,
       "dependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.3",
-        "@tailwindcss/line-clamp": "^0.4.4",
-        "tailwindcss": "^3.3.2"
+        "tailwindcss": "^3.3.5"
       }
     },
     "node_modules/deep-is": {
@@ -4629,9 +4619,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
-      "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
+      "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
       "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -4639,10 +4629,10 @@
         "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
+        "jiti": "^1.19.1",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.2",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
-        "@storyblok/react": "^2.4.0",
+        "@storyblok/react": "^2.4.7",
         "cnbuilder": "^3.1.0",
-        "framer-motion": "^10.15.0",
+        "framer-motion": "^10.16.4",
         "next": "13.4.9",
         "react-player": "^2.13.0",
         "storyblok-rich-text-react-renderer-ts": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "@types/node": "^20.4.7",
     "@types/react": "^18.2",
     "@types/react-dom": "^18.2",
-    "autoprefixer": "^10.4.14",
-    "decanter": "^7.1.1",
+    "autoprefixer": "^10.4.16",
+    "decanter": "^7.1.2",
     "eslint": "^8.50.0",
     "eslint-config-next": "^13.4.13",
     "netlify-plugin-vault-variables": "^1.0.7",
-    "postcss": "^8.4.27",
+    "postcss": "^8.4.31",
     "typescript": "^5.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
-    "@storyblok/react": "^2.4.0",
+    "@storyblok/react": "^2.4.7",
     "cnbuilder": "^3.1.0",
-    "framer-motion": "^10.15.0",
+    "framer-motion": "^10.16.4",
     "next": "13.4.9",
     "react-player": "^2.13.0",
     "storyblok-rich-text-react-renderer-ts": "^3.2.0",

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -167,6 +167,36 @@ export const paddingVerticals = {
 export type PaddingType = keyof typeof paddingTops;
 
 // Add other margins as needed. Used for spacing between elements.
+export const marginVerticals = {
+  none: '',
+  base: 'rs-my-0',
+  1: 'rs-my-1',
+  2: 'rs-my-2',
+  3: 'rs-my-3',
+  4: 'rs-my-4',
+  5: 'rs-my-5',
+  6: 'rs-my-6',
+  7: 'rs-my-7',
+  8: 'rs-my-8',
+  9: 'rs-my-9',
+  10: 'rs-my-10',
+};
+
+export const marginTops = {
+  none: '',
+  base: 'rs-mt-0',
+  1: 'rs-mt-1',
+  2: 'rs-mt-2',
+  3: 'rs-mt-3',
+  4: 'rs-mt-4',
+  5: 'rs-mt-5',
+  6: 'rs-mt-6',
+  7: 'rs-mt-7',
+  8: 'rs-mt-8',
+  9: 'rs-mt-9',
+  10: 'rs-mt-10',
+};
+
 export const marginBottoms = {
   none: '',
   base: 'rs-mb-0',

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -67,6 +67,7 @@ export const imageAspectRatios = {
   '8x5': 'aspect-w-8 aspect-h-5',
   '9x16': 'aspect-w-9 aspect-h-16',
   '16x9': 'aspect-w-16 aspect-h-9',
+  free: '',
 }
 export type ImageAspectRatioType = keyof typeof imageAspectRatios;
 

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -55,6 +55,21 @@ export const accentTextColors = {
 };
 export type AccentTextColorType = keyof typeof accentTextColors;
 
+export const imageAspectRatios = {
+  '1x1': 'aspect-w-1 aspect-h-1',
+  '1x2': 'aspect-w-1 aspect-h-2',
+  '2x1': 'aspect-w-2 aspect-h-1',
+  '2x3': 'aspect-w-2 aspect-h-3',
+  '3x2': 'aspect-w-3 aspect-h-2',
+  '3x4': 'aspect-w-3 aspect-h-4',
+  '4x3': 'aspect-w-4 aspect-h-3',
+  '5x8': 'aspect-w-5 aspect-h-8',
+  '8x5': 'aspect-w-8 aspect-h-5',
+  '9x16': 'aspect-w-9 aspect-h-16',
+  '16x9': 'aspect-w-16 aspect-h-9',
+}
+export type ImageAspectRatioType = keyof typeof imageAspectRatios;
+
 // TODO: We might be not need this
 export const storyHeroAspectRatios = {
   '1x1': 'aspect-w-1 aspect-h-1',

--- a/utilities/getSbImageSize.ts
+++ b/utilities/getSbImageSize.ts
@@ -3,11 +3,11 @@
  * @param imageSrc The URL of the Storyblok image.
  * @returns An object containing the width and height of the image, or null if the URL is invalid.
  */
-export const getSbImageSize = (imageSrc: string): { width: string, height: string } | null => {
+export const getSbImageSize = (imageSrc: string): { width: number, height: number } | null => {
   if (imageSrc.startsWith('http')) {
     const imageSize = {
-      width: imageSrc.split('/')[5].split('x')[0],
-      height: imageSrc.split('/')[5].split('x')[1],
+      width: parseInt(imageSrc.split('/')[5].split('x')[0], 10),
+      height: parseInt(imageSrc.split('/')[5].split('x')[1], 10),
     };
 
     return imageSize;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- image component + various updates in other components
- Update Decanter and other packages

# Review By (Date)
- Retro
# Review Tasks

## Setup tasks and/or behavior to test

1. https://deploy-preview-158--giving-campaign.netlify.app/stories/charging-ahead-batteries-of-the-future
2. https://deploy-preview-158--giving-campaign.netlify.app/stories/the-second-envelope

Look at the two previews, and see all the image component options, plus layouts such as these 50/50 splits

![Screenshot 2023-11-06 at 6 26 25 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/07219662-ee2a-412a-ae13-cf33a9e5d1bd)

Check responsive and make sure that the image fills the grid cell when the quote side is longer
![Screenshot 2023-11-06 at 6 26 11 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/2dc59b2e-6923-426a-a98c-fe5ac74b48a3)


![Screenshot 2023-11-06 at 6 58 47 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/54603393-770d-41d9-9a6a-c771f8502120)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-223
