### PR TITLE
GIVCAMP-253 Storyblok Text (Typography) component

### DIFF
--- a/components/FeaturedStories/FeatureMasonry.tsx
+++ b/components/FeaturedStories/FeatureMasonry.tsx
@@ -29,12 +29,11 @@ export const FeatureMasonry = ({
 }: FeatureMasonryProps) => {
   return (
     <Container {...props} width="full">
-      <Grid sm={12} gap="xs">
+      <Grid sm={12} gap="default">
         <FlexBox alignItems="center" className="md:col-span-7 bg-fog-light">
           <EmbedMedia
             mediaUrl={audioUrl}
-            className="rs-px-6"
-            aspectRatio="4x1"
+            className="lg:rs-px-6 lg:children:children:aspect-w-4 lg:children:children:aspect-h-1"
           />
         </FlexBox>
         <div className="md:col-span-5 w-full h-full">

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,10 +1,13 @@
 import React, { HTMLAttributes } from 'react';
 import { cnb } from 'cnbuilder';
 import {
+  marginTops,
+  marginBottoms,
   paddingTops,
   paddingBottoms,
   paddingVerticals,
   type PaddingType,
+  type MarginType,
 } from '@/utilities/datasource';
 import * as styles from './Grid.styles';
 import * as types from './Grid.types';
@@ -23,6 +26,8 @@ export type GridProps = HTMLAttributes<HTMLElement> & {
   justifyItems?: types.GridJustifyItemsType,
   alignContent?: types.GridAlignContentType,
   alignItems?: types.GridAlignItemsType,
+  mt?: MarginType;
+  mb?: MarginType;
   pt?: PaddingType;
   pb?: PaddingType;
   py?: PaddingType;
@@ -42,6 +47,8 @@ export const Grid = ({
   justifyItems,
   alignContent,
   alignItems,
+  mt,
+  mb,
   pt,
   pb,
   py,
@@ -68,6 +75,8 @@ export const Grid = ({
       py ? paddingVerticals[py] : '',
       pt ? paddingTops[pt] : '',
       pb ? paddingBottoms[pb] : '',
+      mt ? marginTops[mt] : '',
+      mb ? marginBottoms[mb] : '',
       className,
     )}
   >

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -3,6 +3,7 @@ import { cnb } from 'cnbuilder';
 import {
   marginTops,
   marginBottoms,
+  marginVerticals,
   paddingTops,
   paddingBottoms,
   paddingVerticals,
@@ -28,6 +29,7 @@ export type GridProps = HTMLAttributes<HTMLElement> & {
   alignItems?: types.GridAlignItemsType,
   mt?: MarginType;
   mb?: MarginType;
+  my?: MarginType;
   pt?: PaddingType;
   pb?: PaddingType;
   py?: PaddingType;
@@ -49,6 +51,7 @@ export const Grid = ({
   alignItems,
   mt,
   mb,
+  my,
   pt,
   pb,
   py,
@@ -77,6 +80,7 @@ export const Grid = ({
       pb ? paddingBottoms[pb] : '',
       mt ? marginTops[mt] : '',
       mb ? marginBottoms[mb] : '',
+      my ? marginVerticals[my] : '',
       className,
     )}
   >

--- a/components/Storyblok/SbText.tsx
+++ b/components/Storyblok/SbText.tsx
@@ -2,7 +2,7 @@ import { storyblokEditable } from '@storyblok/react/rsc';
 import { AnimateInView, type AnimationType } from '@/components/Animate';
 import { Text } from '@/components/Typography';
 import { WidthBox } from '@/components/WidthBox';
-import { type PaddingType } from '@/utilities/datasource';
+import { type MarginType, type PaddingType } from '@/utilities/datasource';
 import {
   type FontFamilyType,
   type FontSizeType,
@@ -30,8 +30,10 @@ export type SbTextProps = {
     srOnly?: boolean;
     boundingWidth?: 'site' | 'full';
     width?: '12' | '10' | '8' | '6' | '4';
-    pt?: PaddingType;
-    pb?: PaddingType;
+    marginTop?: MarginType;
+    marginBottom?: MarginType;
+    paddingTop?: PaddingType;
+    paddingBottom?: PaddingType;
     animation?: AnimationType;
     delay?: number;
   };
@@ -51,8 +53,10 @@ export const SbText = ({
     italic,
     srOnly,
     boundingWidth,
-    pt,
-    pb,
+    marginTop,
+    marginBottom,
+    paddingTop,
+    paddingBottom,
     width,
     animation,
     delay,
@@ -63,8 +67,10 @@ export const SbText = ({
     <WidthBox
       boundingWidth={boundingWidth}
       width={width}
-      pt={pt}
-      pb={pb}
+      mt={marginTop}
+      mb={marginBottom}
+      pt={paddingTop}
+      pb={paddingBottom}
     >
       <Text
         as={headingLevel || 'div'}
@@ -77,7 +83,7 @@ export const SbText = ({
         weight={weight}
         italic={italic}
         srOnly={srOnly}
-        className="whitespace-pre-line"
+        className="whitespace-pre-line mb-0"
       >
         {text}
       </Text>

--- a/components/Storyblok/SbText.tsx
+++ b/components/Storyblok/SbText.tsx
@@ -1,0 +1,86 @@
+import { storyblokEditable } from '@storyblok/react/rsc';
+import { AnimateInView, type AnimationType } from '@/components/Animate';
+import { Text } from '@/components/Typography';
+import { WidthBox } from '@/components/WidthBox';
+import { type PaddingType } from '@/utilities/datasource';
+import {
+  type FontFamilyType,
+  type FontSizeType,
+  type FontLeadingType,
+  type FontWeightType,
+  type TextVariantType,
+  type TextColorType,
+  type TextAlignType,
+  type HeadingType,
+} from '../Typography';
+
+export type SbTextProps = {
+  blok: {
+    _uid: string;
+    text: string;
+    color?: TextColorType;
+    headingLevel?: HeadingType;
+    font?: FontFamilyType;
+    size?: FontSizeType;
+    variant?: TextVariantType;
+    leading?: FontLeadingType;
+    align?: TextAlignType;
+    weight?: FontWeightType;
+    italic?: boolean;
+    srOnly?: boolean;
+    boundingWidth?: 'site' | 'full';
+    width?: '12' | '10' | '8' | '6' | '4';
+    pt?: PaddingType;
+    pb?: PaddingType;
+    animation?: AnimationType;
+    delay?: number;
+  };
+};
+
+export const SbText = ({
+  blok: {
+    text,
+    color,
+    headingLevel,
+    font,
+    size,
+    variant,
+    leading,
+    align,
+    weight,
+    italic,
+    srOnly,
+    boundingWidth,
+    pt,
+    pb,
+    width,
+    animation,
+    delay,
+  },
+  blok,
+}: SbTextProps) => (
+  <AnimateInView {...storyblokEditable(blok)} animation={animation} delay={delay}>
+    <WidthBox
+      boundingWidth={boundingWidth}
+      width={width}
+      pt={pt}
+      pb={pb}
+    >
+      <Text
+        as={headingLevel || 'div'}
+        font={font}
+        color={color}
+        size={size}
+        variant={variant}
+        leading={leading}
+        align={align}
+        weight={weight}
+        italic={italic}
+        srOnly={srOnly}
+        className="whitespace-pre-line"
+      >
+        {text}
+      </Text>
+    </WidthBox>
+  </AnimateInView>
+);

--- a/components/StoryblokProvider.tsx
+++ b/components/StoryblokProvider.tsx
@@ -24,6 +24,7 @@ import { SbStory } from './Storyblok/SbStory';
 import { SbStoryMvp } from './Storyblok/SbStoryMvp/SbStoryMvp';
 import { SbStoryCard } from './Storyblok/SbStoryCard';
 import { SbStoryImage } from './Storyblok/SbStoryImage';
+import { SbText } from './Storyblok/SbText';
 import { SbTextCard } from './Storyblok/SbTextCard';
 import { SbTexturedBar } from './Storyblok/SbTexturedBar';
 import { SbThemeCard } from './Storyblok/SbThemeCard';
@@ -56,6 +57,7 @@ const components = {
   sbStoryMvp: SbStoryMvp,
   sbStoryCard: SbStoryCard,
   sbStoryImage: SbStoryImage,
+  sbText: SbText,
   sbTextCard: SbTextCard,
   sbTexturedBar: SbTexturedBar,
   sbThemeCard: SbThemeCard,

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -170,6 +170,16 @@ export type PaddingType = keyof typeof paddingTops;
 // Add other margins as needed. Used for spacing between elements.
 export const marginVerticals = {
   none: 'my-0',
+  '01em': 'my-01em',
+  '02em': 'my-02em',
+  '03em': 'my-03em',
+  '04em': 'my-04em',
+  '05em': 'my-05em',
+  '06em': 'my-06em',
+  '07em': 'my-07em',
+  '08em': 'my-08em',
+  '09em': 'my-09em',
+  '1em': 'my-1em',
   base: 'rs-my-0',
   1: 'rs-my-1',
   2: 'rs-my-2',

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -169,7 +169,7 @@ export type PaddingType = keyof typeof paddingTops;
 
 // Add other margins as needed. Used for spacing between elements.
 export const marginVerticals = {
-  none: '',
+  none: 'my-0',
   base: 'rs-my-0',
   1: 'rs-my-1',
   2: 'rs-my-2',
@@ -184,7 +184,17 @@ export const marginVerticals = {
 };
 
 export const marginTops = {
-  none: '',
+  none: 'mt-0',
+  '01em': 'mt-01em',
+  '02em': 'mt-02em',
+  '03em': 'mt-03em',
+  '04em': 'mt-04em',
+  '05em': 'mt-05em',
+  '06em': 'mt-06em',
+  '07em': 'mt-07em',
+  '08em': 'mt-08em',
+  '09em': 'mt-09em',
+  '1em': 'mt-1em',
   base: 'rs-mt-0',
   1: 'rs-mt-1',
   2: 'rs-mt-2',
@@ -199,7 +209,17 @@ export const marginTops = {
 };
 
 export const marginBottoms = {
-  none: '',
+  none: 'mb-0',
+  '01em': 'mb-01em',
+  '02em': 'mb-02em',
+  '03em': 'mb-03em',
+  '04em': 'mb-04em',
+  '05em': 'mb-05em',
+  '06em': 'mb-06em',
+  '07em': 'mb-07em',
+  '08em': 'mb-08em',
+  '09em': 'mb-09em',
+  '1em': 'mb-1em',
   base: 'rs-mb-0',
   1: 'rs-mb-1',
   2: 'rs-mb-2',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This site is going to have a lot of custom story layouts. The regular WYSIWYG kind of limits the heading sizes based on their heading level, eg, a h2 is going to have a certain size - this isn't flexible enough for the highly customized stories. Creating this component that maps to the existing `<Text>` component that takes advantage of all the options, e.g., font modular size, variant, etc

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-160--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
2. Take a look at this h2, and this block of text - they're added on Storyblok using this new SbText component

![Screenshot 2023-11-07 at 2 11 34 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/ad649b43-6e3d-4b2e-be01-4dea553a2547)
![Screenshot 2023-11-07 at 2 11 39 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/5ff922ae-1a19-4187-b19a-5b867d84cf6c)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-253