### PR TITLE
GIVCAMP-258 | Homepage hero, logo, local footer, quote updates

### DIFF
--- a/components/Homepage/Changemaker.tsx
+++ b/components/Homepage/Changemaker.tsx
@@ -30,16 +30,15 @@ export const Changemaker = () => {
             </Text>
           </AnimateInView>
           <AnimateInView animation="slideInFromRight" delay={0.4}>
-            <Text as="span" font="serif" className="block" italic>
+            <Text as="span" font="serif" className="block">
               Risk-takers.
             </Text>
           </AnimateInView>
         </Heading>
         <AnimateInView animation="slideUp" delay={0.5}>
-          <Paragraph size={2} weight="semibold" noMargin font="serif" align="center" className="max-w-900 mx-auto rs-my-4" leading="display">
+          <Paragraph size={2} weight="semibold" noMargin font="serif" align="center" className="max-w-700 mx-auto rs-my-4" leading="display">
             The Stanford community overflows with curious people unafraid to try,
-            change, and try again.<br />
-            Meet some of them.
+            change, and try again. Meet some of them.
           </Paragraph>
         </AnimateInView>
         <Grid md={2} xxl={4} pt={7} gap="default">

--- a/components/Homepage/HomepageSplitHero.styles.ts
+++ b/components/Homepage/HomepageSplitHero.styles.ts
@@ -17,5 +17,4 @@ export const textWrapperBottom = 'relative top-[12%]';
 export const serifText = 'text-[clamp(2.5rem,2.74vw+1.51rem,7rem)]';
 
 export const introWrapper = 'relative z-10 bg-gradient-to-t from-gc-black to-[#020002]';
-export const introBodyWrapper = 'md:ml-06em';
 export const introParagraph = 'max-w-[50ch] ml-0 mr-auto';

--- a/components/Homepage/HomepageSplitHero.styles.ts
+++ b/components/Homepage/HomepageSplitHero.styles.ts
@@ -12,7 +12,7 @@ export const imageTopLayerCommon = 'absolute top-0 right-0 w-full h-full object-
 export const imageBottomLayerCommon = 'w-full h-full object-cover';
 
 export const textFlexbox = 'absolute w-full h-full top-0 left-0 cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)]';
-export const textWrapperTop = 'relative -top-65 sm:-top-[10vw] xl:-top-[8vw] 4xl:-top-[15rem] right-0';
+export const textWrapperTop = 'relative -top-60 sm:-top-[10vw] xl:-top-[8vw] 4xl:-top-[15rem] right-0';
 export const textWrapperBottom = 'relative top-[12%]';
 export const serifText = 'text-[clamp(2.5rem,2.74vw+1.51rem,7rem)]';
 

--- a/components/Homepage/HomepageSplitHero.tsx
+++ b/components/Homepage/HomepageSplitHero.tsx
@@ -84,10 +84,10 @@ export const HomepageSplitHero = () => {
               className={styles.textWrapperTop}
             >
               <Text font="serif" weight="semibold" leading="none" italic className={styles.serifText}>
-                How will we
+                Our challenges
               </Text>
               <Text font="druk" size="hero" leading="none">
-                come together
+                are urgent
               </Text>
             </AnimateInView>
             <AnimateInView
@@ -97,10 +97,10 @@ export const HomepageSplitHero = () => {
               className={styles.textWrapperBottom}
             >
               <Text font="serif" weight="semibold" leading="none" align="right" italic className={styles.serifText}>
-                all in service of
+                Let’s face them
               </Text>
               <Text font="druk" size="hero" leading="none" align="right">
-                Tomorrow?
+                together
               </Text>
             </AnimateInView>
           </FlexBox>
@@ -109,15 +109,18 @@ export const HomepageSplitHero = () => {
       <Container bgColor="black" pt={2} pb={7} className={styles.introWrapper}>
         <AnimateInView animation="slideUp">
           <Heading size="f5" leading="tight">
-            We’re all in this together.
+            This is the moment.
           </Heading>
         </AnimateInView>
-        <AnimateInView delay={0.2} animation="slideUp" className={styles.introBodyWrapper}>
+        <AnimateInView delay={0.2} animation="slideUp">
           <Paragraph size={1} weight="normal" leading="snug" className={styles.introParagraph}>
-            Sustaining a thriving planet. Accelerating solutions and empowering the next generation of leaders.
+            For combating the climate crisis. For reducing inequality. For embedding ethics in all we do.
           </Paragraph>
           <Paragraph size={1} weight="normal" leading="snug" className={styles.introParagraph}>
-            Meet your community of changemakers, explore what you’re passionate about, and join the conversation.
+            Welcome to <em>Momentum</em>, telling the stories of Stanford’s impact.
+          </Paragraph>
+          <Paragraph size={1} weight="normal" leading="snug" className={styles.introParagraph}>
+            Come discover the work underway in four key thematic areas.
           </Paragraph>
         </AnimateInView>
       </Container>

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -33,13 +33,13 @@ export const TogetherSection = () => {
     <div ref={sectionRef} className="relative overflow-hidden rs-pb-8 w-full bg-gc-black text-white">
       <Container>
         <AnimateInView animation="slideUp">
-          <Heading size="f6" align="center" leading="tight" className="mx-auto max-w-[105rem]">
+          <Heading size="f5" align="center" leading="tight" className="mx-auto max-w-1000">
             True change will require all of us.
           </Heading>
         </AnimateInView>
         <AnimateInView animation="slideUp" delay={0.2}>
-          <Paragraph leading="display" align="center" size={2} className="max-w-900 mx-auto">
-            One changemaker is admirable. A community of changemakers is unstoppable.
+          <Paragraph leading="display" align="center" size={1} className="max-w-700 mx-auto">
+            One game changer is admirable. A community of game changers is unstoppable.
             There is nothing we can do that we cannot do better...
           </Paragraph>
           <SrOnlyText>together</SrOnlyText>

--- a/components/LocalFooter/LocalFooterMvp.styles.tsx
+++ b/components/LocalFooter/LocalFooterMvp.styles.tsx
@@ -1,7 +1,7 @@
 export const root = 'relative overflow-hidden bg-no-repeat bg-bottom bg-cover md:bg-contain';
 export const overlay = 'absolute top-0 left-0 w-full h-full bg-gradient-to-b from-gc-black via-gc-black/80 to-gc-black/40';
 export const flexWrapper = 'items-start lg:items-center relative z-10 w-full';
-export const logo = 'scale-125 origin-left sm:scale-100 text-[1.67em] md:text-[1.72em] lg:text-[1.9em] lg:ml-[5.4rem] 2xl:ml-60';
+export const logo = 'scale-125 origin-left sm:scale-100 text-[1.67em] md:text-[1.72em] lg:text-[1.9em]';
 export const ul = 'list-unstyled divide-x divide-white children:inline-block children:mb-0 children:px-16 md:children:px-30 xl:children:px-48 children:leading-display first:children:pl-0 last:children:pr-0 lg:mx-auto w-fit rs-mt-2 gap-y-10';
 export const grid = 'w-full lg:gap-x-[7vw] 3xl:gap-x-300';
 export const column2 = 'rs-mt-3 lg:mt-0';

--- a/components/LocalFooter/LocalFooterMvp.tsx
+++ b/components/LocalFooter/LocalFooterMvp.tsx
@@ -19,11 +19,10 @@ export const LocalFooterMvp = () => (
   >
     <div className={styles.overlay} />
     <FlexBox direction="col" className={styles.flexWrapper}>
-      <LogoLockup text="Impact Stories" color="white" isLink className={styles.logo} />
+      <LogoLockup text="Momentum" color="white" isLink className={styles.logo} />
       <FlexBox as="ul" wrap="wrap" className={styles.ul}>
         <li><CtaLink color="white" href={links.ood.giving} size="large">Giving to Stanford</CtaLink></li>
         <li><CtaLink color="white" href={links.ood.contact} size="large">Contact us</CtaLink></li>
-        <li><CtaLink color="white" href={links.ood.leadership} size="large">Leadership</CtaLink></li>
         <li><CtaLink color="white" href={links.ood.waysToGive} size="large">How to make a gift</CtaLink></li>
       </FlexBox>
       <Grid lg={2} pt={8} gap="default" className={styles.grid}>
@@ -32,7 +31,7 @@ export const LocalFooterMvp = () => (
             Get the latest in your inbox
           </Heading>
           <Paragraph variant="big" leading="display">
-            Sign up to receive Stanford’s storytelling newsletter.
+            Sign up to receive <em>The Moment</em> newsletter, telling the stories of Stanford’s impact.
           </Paragraph>
           <CtaLink
             href={links.ood.newsletterSignUp}

--- a/components/Masthead/Masthead.tsx
+++ b/components/Masthead/Masthead.tsx
@@ -22,7 +22,7 @@ export const Masthead = ({ isLight, className }: MastheadProps) => (
       <LogoLockup
         isLink
         color={isLight ? 'default' : 'white'}
-        text="Impact Stories"
+        text="Momentum"
         className={styles.lockup}
       />
       <FlexBox alignItems="center" className={styles.ctaWrapper}>

--- a/utilities/config.ts
+++ b/utilities/config.ts
@@ -2,8 +2,8 @@
  * Global variables for this project.
  */
 export const config = {
-  siteUrlProd: 'https://impactstories.stanford.edu',
-  siteTitle: 'Stanford Impact Stories',
+  siteUrlProd: 'https://momentum.stanford.edu',
+  siteTitle: 'Stanford Momentum',
   siteDescription: 'TBD', // TODO: Add generic site description as fallback for search engine if Storyblok SEO description is not provided
   assetCdn: 'https://assets.stanford.edu/',
   imageService: 'https://a-us.storyblok.com/',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Misc updates for:
- homepage hero
- logo lockup/domain
- local footer
- quote


# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-165--giving-campaign.netlify.app/
2. Compare to the latest Figma mock
https://www.figma.com/file/4OP7wBaUzeNRwAhVy4fTQU/Campaign-story-page-layouts?type=design&node-id=570%3A3846&mode=dev&t=NMy167cSV7o0ql31-1
3. Check that the logo in the masthead has been updated to Momentum
3. See that the hero text has been updated
![Screenshot 2023-11-28 at 5 37 42 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/d0b6a42d-6533-4344-8f38-93ec8e1e0993)

4. Check that the intro text has been updated (checking with design whether we want normal or semibold body copy)


![Screenshot 2023-11-28 at 5 38 26 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/6dcaf896-a53b-476c-b590-88b382f23ad8)

5. Scroll further down to see that the posters and section titles have updated copy and images (except for the square small story cards and the flipping cards - those will be updated later.
6. Scroll to the local footer and check that it has been updated.
7. Go to this story
https://deploy-preview-165--giving-campaign.netlify.app/stories/the-second-envelope
 and see that it more or less matches the below mock (I need to update the quote component some more). The final copy might be different since it's in Google doc
 https://www.figma.com/file/4OP7wBaUzeNRwAhVy4fTQU/Campaign-story-page-layouts?type=design&node-id=406%3A8191&mode=dev&t=KpOKoxdVyhuVUQD2-1


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-258