### PR TITLE
GIVCAMP-251 | Add background color animation option to Storyblok Section

### DIFF
--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -87,7 +87,7 @@ export const BlurryPoster = ({
   return (
     <Container {...props} bgColor={bgColor} width="full" className={styles.root}>
       <img
-        src={getProcessedImage(bgImageSrc, '1200x1200', bgImageFocus)}
+        src={getProcessedImage(bgImageSrc, '1000x1500', bgImageFocus)}
         alt={bgImageAlt || ''}
         aria-describedby={caption ? 'story-hero-caption' : undefined}
         className={styles.bgImageMobile}

--- a/components/Homepage/HomepageSplitHero.tsx
+++ b/components/Homepage/HomepageSplitHero.tsx
@@ -76,7 +76,7 @@ export const HomepageSplitHero = () => {
               </AnimateInView>
             </Grid>
           </Container>
-          <FlexBox direction="col" justifyContent="between" className={styles.textFlexbox}>
+          <FlexBox direction="col" justifyContent="between" className={styles.textFlexbox} aria-hidden>
             <AnimateInView
               animation="slideInFromLeft"
               delay={0.6}

--- a/components/Quote/Quote.styles.ts
+++ b/components/Quote/Quote.styles.ts
@@ -7,7 +7,7 @@ export const root = (
   hasBar?: boolean,
 ) => cnb('relative break-words flex flex-col lg:max-w-prose ml-0', {
   'max-w-[90%] sm:max-w-[80%] mx-auto md:max-w-full': isMinimal && !addDarkOverlay,
-  'bg-gc-black/50 backdrop-blur-sm h-full children:mt-auto children:mb-0': addDarkOverlay && !isMinimal,
+  'bg-gc-black/50 backdrop-blur-sm h-full children:mt-auto children:mb-0 text-white': addDarkOverlay && !isMinimal,
   'rs-pl-4': !quoteOnRight && (!isMinimal || addDarkOverlay),
   'rs-pr-4': quoteOnRight && (!isMinimal || addDarkOverlay),
   'rs-px-4': addDarkOverlay && !hasBar,

--- a/components/Quote/Quote.styles.ts
+++ b/components/Quote/Quote.styles.ts
@@ -5,7 +5,7 @@ export const root = (
   addDarkOverlay?: boolean,
   quoteOnRight?: boolean,
   hasBar?: boolean,
-) => cnb('relative break-words flex flex-col lg:max-w-prose ml-0', {
+) => cnb('relative break-words flex flex-col lg:max-w-prose lg:ml-0', {
   'max-w-[90%] sm:max-w-[80%] mx-auto md:max-w-full': isMinimal && !addDarkOverlay,
   'bg-gc-black/50 backdrop-blur-sm h-full children:mt-auto children:mb-0 text-white': addDarkOverlay && !isMinimal,
   'rs-pl-4': !quoteOnRight && (!isMinimal || addDarkOverlay),
@@ -22,6 +22,6 @@ export const quoteMark = (isLargeTeaser?: boolean) => cnb('shrink-0 leading-[0]'
   'text-[clamp(16rem,7.46vw+13.31rem,26rem)] mt-[clamp(5.7rem,2.61vw+4.76rem,9.2rem)]': !isLargeTeaser,
   'text-[clamp(17rem,11.19vw+12.97rem,32rem)] mt-[clamp(6rem,4.03vw+4.55rem,11.4rem)]': isLargeTeaser,
 });
-export const teaser = 'rs-mb-0 grow-0 w-fit max-w-[20ch]';
+export const teaser = 'rs-mb-0 grow-0 w-fit';
 export const body = 'mt-02em first:mt-0 whitespace-pre-line';
 export const source = 'rs-mt-1 whitespace-pre-line';

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -60,7 +60,13 @@ export const Quote = ({
             >
               {quoteOnRight ? '”' : '“'}
             </Text>
-            <Text size={isLargeTeaser ? 'f5' : 'f4'} leading="none" font="druk" className={styles.teaser}>
+            <Text
+              size={isLargeTeaser ? 'f5' : 'f4'}
+              leading="none"
+              font="druk"
+              color={addDarkOverlay ? 'white' : 'black'}
+              className={styles.teaser}
+            >
               {teaser}
             </Text>
           </FlexBox>
@@ -72,13 +78,14 @@ export const Quote = ({
             leading="display"
             size={isLargeBody ? 2 : undefined}
             font="serif"
+            color={addDarkOverlay ? 'white' : 'black'}
             className={styles.body}
           >
             {body}
           </Text>
         )}
         {source && (
-          <Text variant="card" className={styles.source}>{source}</Text>
+          <Text variant="card" color={addDarkOverlay ? 'white' : 'black'} className={styles.source}>{source}</Text>
         )}
       </blockquote>
     </Container>

--- a/components/Quote/Quote.tsx
+++ b/components/Quote/Quote.tsx
@@ -64,7 +64,6 @@ export const Quote = ({
               size={isLargeTeaser ? 'f5' : 'f4'}
               leading="none"
               font="druk"
-              color={addDarkOverlay ? 'white' : 'black'}
               className={styles.teaser}
             >
               {teaser}
@@ -78,14 +77,13 @@ export const Quote = ({
             leading="display"
             size={isLargeBody ? 2 : undefined}
             font="serif"
-            color={addDarkOverlay ? 'white' : 'black'}
             className={styles.body}
           >
             {body}
           </Text>
         )}
         {source && (
-          <Text variant="card" color={addDarkOverlay ? 'white' : 'black'} className={styles.source}>{source}</Text>
+          <Text variant="card" className={styles.source}>{source}</Text>
         )}
       </blockquote>
     </Container>

--- a/components/Storyblok/SbGrid.tsx
+++ b/components/Storyblok/SbGrid.tsx
@@ -1,7 +1,8 @@
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
-import { Grid, type GridGapType, type GridNumColsType } from '../Grid';
-import { WidthBox, type WidthType } from '../WidthBox';
-import { CreateBloks } from '../CreateBloks';
+import { Grid, type GridGapType, type GridNumColsType } from '@/components/Grid';
+import { WidthBox, type WidthType } from '@/components/WidthBox';
+import { CreateBloks } from '@/components/CreateBloks';
+import { type PaddingType, type MarginType } from '@/utilities/datasource';
 
 type SbGridProps = {
   blok: {
@@ -22,6 +23,10 @@ type SbGridProps = {
     lg?: GridNumColsType
     xl?: GridNumColsType
     xxl?: GridNumColsType
+    paddingTop?: PaddingType;
+    paddingBottom?: PaddingType;
+    marginTop?: MarginType;
+    marginBottom?: MarginType;
   };
 };
 
@@ -39,6 +44,10 @@ export const SbGrid = ({
     lg,
     xl,
     xxl,
+    paddingTop,
+    paddingBottom,
+    marginTop,
+    marginBottom,
   },
   blok,
 }: SbGridProps) => (
@@ -47,6 +56,10 @@ export const SbGrid = ({
     boundingWidth={boundingWidth}
     width={width}
     align={align}
+    mt={marginTop}
+    mb={marginBottom}
+    pt={paddingTop}
+    pb={paddingBottom}
   >
     <Grid
       xs={xs}

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -74,17 +74,22 @@ export const SbSection = ({
   const ref = useRef<HTMLDivElement>(null);
   const hasHeader = heading || superhead || subheading;
 
-  const stops: number[] = [];
-  const bgColors: string[] = [];
-  for (const element of bgColorStops) {
-    stops.push(parseFloat(element.stop));
-    bgColors.push(element.hexColor);
-  }
-
+  const stops = [];
+  const bgColors = [];
   const { scrollYProgress } = useScroll({
     target: ref,
     offset: ['start start', 'end start'],
   });
+
+  if (!!bgColorStops?.length) {
+    for (const element of bgColorStops) {
+      stops.push(parseFloat(element.stop));
+      bgColors.push(element.hexColor);
+    }
+  } else {
+    stops.push(0);
+    bgColors.push('transparent');
+  }
   const animatedBgColor = useTransform(scrollYProgress, stops, bgColors);
 
   return (
@@ -95,7 +100,7 @@ export const SbSection = ({
       className="relative overflow-hidden"
       {...storyblokEditable(blok)}
     >
-      <m.div ref={ref} style={{ backgroundColor: animatedBgColor }}>
+      <m.div ref={ref} style={{ backgroundColor: bgColorStops?.length > 1 ? animatedBgColor : undefined }}>
         <Container
           width="full"
           bgColor={bgColor}

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -1,4 +1,8 @@
+'use client';
+
+import { useRef } from 'react';
 import { cnb } from 'cnbuilder';
+import { useScroll, m, useTransform } from 'framer-motion';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { CreateBloks } from '../CreateBloks';
@@ -16,7 +20,7 @@ import { RichText } from '../RichText';
 import { WidthBox } from '../WidthBox';
 import { accentBgColors, type PaddingType, type MarginType } from '@/utilities/datasource';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
-import { type SbImageType } from './Storyblok.types';
+import { type SbImageType, type SbColorStopProps } from './Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { hasRichText } from '@/utilities/hasRichText';
 
@@ -37,6 +41,7 @@ type SbSectionProps = {
     }
     bgColor?: BgColorType;
     bgImage?: SbImageType;
+    bgColorStops?: SbColorStopProps[];
     paddingTop?: PaddingType;
     paddingBottom?: PaddingType;
     marginTop?: MarginType;
@@ -58,6 +63,7 @@ export const SbSection = ({
     barColor: { value: barColorValue } = {},
     bgColor,
     bgImage: { filename, focus } = {},
+    bgColorStops,
     paddingTop,
     paddingBottom,
     marginTop,
@@ -65,7 +71,21 @@ export const SbSection = ({
   },
   blok,
 }: SbSectionProps) => {
+  const ref = useRef<HTMLDivElement>(null);
   const hasHeader = heading || superhead || subheading;
+
+  const stops: number[] = [];
+  const bgColors: string[] = [];
+  for (const element of bgColorStops) {
+    stops.push(parseFloat(element.stop));
+    bgColors.push(element.hexColor);
+  }
+
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ['start start', 'end start'],
+  });
+  const animatedBgColor = useTransform(scrollYProgress, stops, bgColors);
 
   return (
     <Container
@@ -75,74 +95,76 @@ export const SbSection = ({
       className="relative overflow-hidden"
       {...storyblokEditable(blok)}
     >
-      <Container
-        width="full"
-        bgColor={bgColor}
-        pt={paddingTop}
-        pb={paddingBottom}
-        className="relative overflow-hidden"
-      >
-        {filename && (
-          <ImageOverlay imageSrc={getProcessedImage(filename, '2000x1600', focus)} overlay={bgColor === 'black' ? 'black-60' : 'white-90'} />
-        )}
-        {(heading || superhead) && (
-          <FlexBox className={cnb('relative z-10', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}>
-            {barColorValue && (
+      <m.div ref={ref} style={{ backgroundColor: animatedBgColor }}>
+        <Container
+          width="full"
+          bgColor={bgColor}
+          pt={paddingTop}
+          pb={paddingBottom}
+          className="relative overflow-hidden"
+        >
+          {filename && (
+            <ImageOverlay imageSrc={getProcessedImage(filename, '2000x1600', focus)} overlay={bgColor === 'black' ? 'black-60' : 'white-90'} />
+          )}
+          {(heading || superhead) && (
+            <FlexBox className={cnb('relative z-10', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}>
+              {barColorValue && (
+                <div className={cnb(
+                  'block w-10 sm:w-14 md:w-20 lg:w-30 xl:w-40',
+                  rightAlignHeader ? 'order-last' : 'order-first',
+                  accentBgColors[paletteAccentColors[barColorValue]],
+                )}
+                />
+              )}
               <div className={cnb(
-                'block w-10 sm:w-14 md:w-20 lg:w-30 xl:w-40',
-                rightAlignHeader ? 'order-last' : 'order-first',
-                accentBgColors[paletteAccentColors[barColorValue]],
+                'cc whitespace-pre-line w-full 3xl:max-w-[90%]',
+                barColorValue && !rightAlignHeader ? '-ml-10 sm:-ml-14 md:-ml-20 lg:-ml-30 xl:-ml-40' : '',
+                barColorValue && rightAlignHeader ? '-mr-10 sm:-mr-14 md:-mr-20 lg:-mr-30 xl:-mr-40' : '',
+                !barColorValue && !rightAlignHeader ? 'ml-0' : '',
+                !barColorValue && rightAlignHeader ? 'mr-0' : '',
+                superhead ? '' : '-mt-05em',
               )}
-              />
-            )}
-            <div className={cnb(
-              'cc whitespace-pre-line w-full 3xl:max-w-[90%]',
-              barColorValue && !rightAlignHeader ? '-ml-10 sm:-ml-14 md:-ml-20 lg:-ml-30 xl:-ml-40' : '',
-              barColorValue && rightAlignHeader ? '-mr-10 sm:-mr-14 md:-mr-20 lg:-mr-30 xl:-mr-40' : '',
-              !barColorValue && !rightAlignHeader ? 'ml-0' : '',
-              !barColorValue && rightAlignHeader ? 'mr-0' : '',
-              superhead ? '' : '-mt-05em',
-            )}
-            >
-              {superhead && (
-                <Text size={2} leading="tight" font="serif" weight="semibold" align={rightAlignHeader ? 'right' : 'left'} aria-hidden>
-                  {superhead}
-                </Text>
-              )}
-              {heading && (
-                <Heading
-                  as={headingLevel}
-                  size={isSmallHeading ? 'f8' : 'splash'}
-                  leading="none"
-                  uppercase
-                  font="druk"
-                  align={rightAlignHeader ? 'right' : 'left'}
-                  className="mb-0"
-                >
-                  {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
-                </Heading>
-              )}
-            </div>
-          </FlexBox>
-        )}
-        {subheading && (
-          <Container>
-            <Paragraph
-              variant="overview"
-              weight="normal"
-              align={rightAlignHeader ? 'right' : 'left'}
-              color={bgColor === 'black' ? 'black-20' : 'black-80'}
-              noMargin
-              className={cnb('relative z-10 max-w-prose ml-0 rs-mt-3', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}
-            >
-              {subheading}
-            </Paragraph>
+              >
+                {superhead && (
+                  <Text size={2} leading="tight" font="serif" weight="semibold" align={rightAlignHeader ? 'right' : 'left'} aria-hidden>
+                    {superhead}
+                  </Text>
+                )}
+                {heading && (
+                  <Heading
+                    as={headingLevel}
+                    size={isSmallHeading ? 'f8' : 'splash'}
+                    leading="none"
+                    uppercase
+                    font="druk"
+                    align={rightAlignHeader ? 'right' : 'left'}
+                    className="mb-0"
+                  >
+                    {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
+                  </Heading>
+                )}
+              </div>
+            </FlexBox>
+          )}
+          {subheading && (
+            <Container>
+              <Paragraph
+                variant="overview"
+                weight="normal"
+                align={rightAlignHeader ? 'right' : 'left'}
+                color={bgColor === 'black' ? 'black-20' : 'black-80'}
+                noMargin
+                className={cnb('relative z-10 max-w-prose ml-0 rs-mt-3', rightAlignHeader ? 'mr-0 ml-auto' : 'ml-0')}
+              >
+                {subheading}
+              </Paragraph>
+            </Container>
+          )}
+          <Container pt={hasHeader ? 8 : undefined} width="full" className="relative z-10">
+            <CreateBloks blokSection={content} isDarkTheme={bgColor === 'black'} />
           </Container>
-        )}
-        <Container pt={hasHeader ? 8 : undefined} width="full" className="relative z-10">
-          <CreateBloks blokSection={content} isDarkTheme={bgColor === 'black'} />
         </Container>
-      </Container>
+      </m.div>
       {hasRichText(caption) && (
         <WidthBox boundingWidth="site" width={captionColumnWidth}>
           <RichText

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -71,9 +71,9 @@ export const SbSection = ({
   },
   blok,
 }: SbSectionProps) => {
-  const ref = useRef<HTMLDivElement>(null);
   const hasHeader = heading || superhead || subheading;
 
+  const ref = useRef<HTMLDivElement>(null);
   const stops = [];
   const bgColors = [];
   const { scrollYProgress } = useScroll({
@@ -81,12 +81,22 @@ export const SbSection = ({
     offset: ['start start', 'end start'],
   });
 
-  if (!!bgColorStops?.length) {
+  // bgColorStops is an array of objects with the shape {stop, hexColor}
+  if (bgColorStops?.length >= 2) {
+    /**
+     * If bgColorStops has at least 2 stops, we add background color animation
+     * This loop splits the array into two separate arrays, one for the stops and one for the colors
+     */
     for (const element of bgColorStops) {
       stops.push(parseFloat(element.stop));
       bgColors.push(element.hexColor);
     }
   } else {
+    /**
+     * If there is less than 2 stops, we push a single stop and color to the arrays
+     * We can't use the below Framer Motion useTransform hook conditionally,
+     * so we need to push a single stop and color for it to not throw an error
+     */
     stops.push(0);
     bgColors.push('transparent');
   }
@@ -100,7 +110,8 @@ export const SbSection = ({
       className="relative overflow-hidden"
       {...storyblokEditable(blok)}
     >
-      <m.div ref={ref} style={{ backgroundColor: bgColorStops?.length > 1 ? animatedBgColor : undefined }}>
+      {/* Add background color animation if there are at least 2 color stops */}
+      <m.div ref={ref} style={{ backgroundColor: bgColorStops?.length >= 2 ? animatedBgColor : undefined }}>
         <Container
           width="full"
           bgColor={bgColor}

--- a/components/Storyblok/SbSidebarCard.tsx
+++ b/components/Storyblok/SbSidebarCard.tsx
@@ -57,6 +57,8 @@ export const SbSidebarCard = ({
       barOnRight={barOnRight}
       bgColor={paletteAccentColors[bgColorValue]}
       cta={Cta}
+      animation={animation}
+      delay={delay}
     >
       {Content}
     </SidebarCard>

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -23,6 +23,7 @@ type SbStoryImageProps = {
     spacingTop?: PaddingType;
     spacingBottom?: PaddingType;
     isCaptionInset?: boolean;
+    isCaptionLight?: boolean;
     animation?: AnimationType;
     delay?: number;
   };
@@ -41,12 +42,13 @@ export const SbStoryImage = ({
     spacingTop,
     spacingBottom,
     isCaptionInset,
+    isCaptionLight,
     animation = 'none',
     delay,
   },
   blok,
 }: SbStoryImageProps) => {
-  const Caption = hasRichText(caption) ? <RichText textColor="black-70" wysiwyg={caption} /> : undefined;
+  const Caption = hasRichText(caption) ? <RichText textColor={isCaptionLight ? 'white' : 'black-70'} wysiwyg={caption} /> : undefined;
 
   return (
     <StoryImage

--- a/components/Storyblok/Storyblok.types.ts
+++ b/components/Storyblok/Storyblok.types.ts
@@ -44,3 +44,8 @@ export type SbTypographyProps = {
   font?: 'druk' | 'serif';
   italic?: boolean;
 };
+
+export type SbColorStopProps = {
+  stop: string;
+  hexColor: string;
+};

--- a/components/Storyblok/Storyblok.types.ts
+++ b/components/Storyblok/Storyblok.types.ts
@@ -45,6 +45,7 @@ export type SbTypographyProps = {
   italic?: boolean;
 };
 
+// Used for SbSection background color animation
 export type SbColorStopProps = {
   stop: string;
   hexColor: string;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add options to add background color stops to Storyblok Section wrapper component for background color animation with Framer Motion
- Misc other updates including adding spacing options to Storyblok Grid

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Scroll through this story to see the background color change (starting beneath the larger video in the story) from white to light blue back to white at the end
https://deploy-preview-170--giving-campaign.netlify.app/stories/the-most-wicked-problems
2. Make sure it works on mobile Safari as well
3. Go to https://deploy-preview-170--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
4. See that there's added spacing below the "Sign up with TypeForm" button


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-251
