### PR TITLE
GIVCAMP-268 | Add support for card image and teaser field for MVP Stories; clean up

### DIFF
--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -56,6 +56,8 @@ export const Banner = ({
               alt=""
               src={getProcessedImage(imageSrc, '360x360', imageFocus)}
               className={styles.image}
+              width={360}
+              height={360}
             />
           </AnimateInView>
         </div>

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -93,12 +93,16 @@ export const BlurryPoster = ({
         alt={bgImageAlt || ''}
         aria-describedby={caption ? 'story-hero-caption' : undefined}
         className={styles.bgImageMobile}
+        width={1000}
+        height={1500}
       />
       <img
         src={getProcessedImage(bgImageSrc, '2000x1200', bgImageFocus)}
         alt={bgImageAlt || ''}
         aria-describedby={caption ? 'story-hero-caption' : undefined}
         className={styles.bgImage}
+        width={2000}
+        height={1200}
       />
       <div className={styles.blurWrapper(addBgBlur, addDarkOverlay, type, bgColor)}>
         <Grid lg={isTwoCol ? 2 : 1} pt={type === 'hero' ? 9 : 8} pb={8} className={styles.grid}>
@@ -186,12 +190,16 @@ export const BlurryPoster = ({
                 <img
                   src={getProcessedImage(imageSrc, type === 'hero' && !isTwoCol ? '1800x900' : '900x1200', imageFocus)}
                   alt={alt || ''}
+                  width={type === 'hero' && !isTwoCol ? 1800 : 900}
+                  height={type === 'hero' && !isTwoCol ? 900 : 1200}
                   aria-describedby={caption ? 'story-hero-caption' : undefined}
                   className={styles.image}
                 />
                 <img
                   src={getProcessedImage(imageSrc, '1000x1000', imageFocus)}
                   alt={alt || ''}
+                  width={1000}
+                  height={1000}
                   aria-describedby={caption ? 'story-hero-caption' : undefined}
                   className={styles.imageMobile}
                 />

--- a/components/ChangemakerCard/ChangemakerCard.tsx
+++ b/components/ChangemakerCard/ChangemakerCard.tsx
@@ -72,6 +72,9 @@ export const ChangemakerCard = ({
                 <ImageOverlay
                   imageSrc={getProcessedImage(imageSrc, '500x1000', imageFocus)}
                   overlay="gradient-changemaker"
+                  loading="eager"
+                  width={339}
+                  height={678}
                 />
               </div>
             )}

--- a/components/Hero/StoryHeroMvp.tsx
+++ b/components/Hero/StoryHeroMvp.tsx
@@ -5,7 +5,6 @@ import { Text } from '@/components/Typography';
 import { type SbImageType, type SbTypographyProps } from '@/components/Storyblok/Storyblok.types';
 import { type SbBlokData } from '@storyblok/react/rsc';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
-import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { getNumBloks } from '@/utilities/getNumBloks';
 import * as styles from './StoryHeroMvp.styles';
 
@@ -23,9 +22,6 @@ export type StoryHeroMvpProps = {
   bgImageAlt?: string;
   addBgBlur?: boolean;
   addDarkOverlay?: boolean;
-  aspectRatio?: styles.ImageCropType;
-  mobileImage?: SbImageType;
-  mobileAspectRatio?: styles.ImageCropType;
   alt?: string;
   caption?: string;
   isVerticalHero?: boolean;
@@ -48,7 +44,6 @@ export const StoryHeroMvp = ({
   dek,
   publishedDate,
   heroImage: { filename, focus } = {},
-  mobileImage: { filename: mobileFilename, focus: mobileFocus } = {},
   bgImage: { filename: bgImageSrc, focus: bgImageFocus } = {},
   bgImageAlt,
   addBgBlur,
@@ -58,8 +53,6 @@ export const StoryHeroMvp = ({
   isVerticalHero = false,
   isLeftImage = false,
   isLightHero = false,
-  aspectRatio = isVerticalHero ? '5x8' : '2x1',
-  mobileAspectRatio = '1x1',
   tabColor: { value: tabColorValue } = {},
   heroTexturedBar,
 }: StoryHeroMvpProps) => {
@@ -71,46 +64,6 @@ export const StoryHeroMvp = ({
     day: 'numeric',
     year: 'numeric',
   });
-
-  const cropSize = styles.imageCrops[aspectRatio];
-  const cropWidth = parseInt(cropSize?.split('x')[0], 10);
-  const cropHeight = parseInt(cropSize?.split('x')[1], 10);
-  const mobileCropSize = styles.mobileImageCrops[mobileAspectRatio];
-  const mobileCropWidth = parseInt(mobileCropSize?.split('x')[0], 10);
-  const mobileCropHeight = parseInt(mobileCropSize?.split('x')[1], 10);
-
-  const renderOneImage = !!filename && !mobileFilename && mobileAspectRatio === aspectRatio;
-  // Render 2 different images if there is both a hero image or a mobile image
-  // Or when there is no mobile image, but the mobile aspect ratio is different from the desktop aspect ratio
-  const renderTwoImages = (!!filename && !!mobileFilename) ||
-    (!!filename && !mobileFilename && mobileAspectRatio !== aspectRatio);
-
-  // TODO: add srcset later in GIVCAMP-71
-  // This one will always be rendered when there's a hero image
-  const RenderedDesktopImage = (
-    <img
-      alt={alt || ''}
-      loading="eager"
-      width={cropWidth}
-      height={cropHeight}
-      src={getProcessedImage(filename, cropSize, focus)}
-      sizes={isVerticalHero ? `${renderOneImage ? '(max-width: 991px) 100vw, 50vw}' : '50vw'}` : '100vw'}
-      className={styles.image(renderTwoImages)}
-    />
-  );
-
-  // This one will only be rendered when the conditions in renderTwoImages are met
-  const RenderedMobileImage = renderTwoImages && (
-    <img
-      alt={alt || ''}
-      loading="eager"
-      width={mobileCropWidth}
-      height={mobileCropHeight}
-      src={getProcessedImage(mobileFilename || filename, mobileCropSize, mobileFocus || focus)}
-      sizes="100vw"
-      className={styles.mobileImage}
-    />
-  );
 
   return (
     <Container

--- a/components/Homepage/HomepageSplitHero.tsx
+++ b/components/Homepage/HomepageSplitHero.tsx
@@ -63,6 +63,8 @@ export const HomepageSplitHero = () => {
                   alt=""
                   loading="eager"
                   className={cnb(styles.imageBottomLayerCommon, 'object-left')}
+                  width={700}
+                  height={700}
                 />
                 <m.img
                   src={getProcessedImage('https://a-us.storyblok.com/f/1005200/1390x1390/cb35b9488b/frame-96.jpg', '700x700')}
@@ -72,6 +74,8 @@ export const HomepageSplitHero = () => {
                   animate={{ opacity: 0 }}
                   transition={{ duration: 1, delay: 0.6 }}
                   className={cnb(styles.imageTopLayerCommon, 'object-right')}
+                  width={700}
+                  height={700}
                 />
               </AnimateInView>
             </Grid>

--- a/components/ImageOverlay.tsx
+++ b/components/ImageOverlay.tsx
@@ -22,6 +22,8 @@ type ImageOverlayProps = Omit<HTMLAttributes<HTMLImageElement>, 'src'> & {
   overlay?: OverlayType;
   overlayClasses?: string;
   loading?: 'lazy' | 'eager';
+  width?: number;
+  height?: number;
 };
 
 export const ImageOverlay = ({
@@ -29,6 +31,8 @@ export const ImageOverlay = ({
   overlay = 'black-40',
   overlayClasses,
   loading = 'lazy',
+  width,
+  height,
   className,
   ...props
 }: ImageOverlayProps) => (
@@ -37,6 +41,8 @@ export const ImageOverlay = ({
       src={imageSrc}
       alt=""
       loading={loading}
+      width={width}
+      height={height}
       className={cnb('absolute w-full h-full object-cover top-0 left-0', className)}
       {...props}
     />

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -11,12 +11,13 @@ export type SbStoryCardProps = {
     storyPicker?: {
       content?: {
         title?: string;
-        cardTitle?: string;
         dek?: string;
         topics?: string[];
         heroImage?: SbImageType;
         bgImage?: SbImageType;
-        mobileImage?: SbImageType;
+        cardTitle?: string;
+        cardTeaser?: string;
+        cardImage?: SbImageType;
       },
       full_slug?: string;
     };
@@ -38,18 +39,20 @@ export const SbStoryCard = ({
     storyPicker: {
       content: {
         title = '',
-        cardTitle = '',
         dek = '',
         topics = [],
         heroImage: { filename: heroFilename = '', focus: heroFocus = '' } = {},
         bgImage: { filename: bgFilename = '', focus: bgFocus = '' } = {},
-        mobileImage: { filename: mobileFilename = '', focus: mobileFocus = '' } = {},
+        cardTitle = '',
+        cardTeaser = '',
+        cardImage: { filename: storyCardFilename = '', focus: storyCardFocus = '' } = {},
       } = {},
       full_slug,
     } = {},
     heading,
     headingLevel,
     isSmallHeading,
+    // This is the manual image field in Story Card that overrides any storypicker images
     image: { filename: cardImage, focus: cardFocus } = {},
     tabColor: { value } = {},
     link,
@@ -63,9 +66,9 @@ export const SbStoryCard = ({
     heading={heading || cardTitle || title}
     headingLevel={headingLevel}
     isSmallHeading={isSmallHeading}
-    body={dek}
-    imageSrc={cardImage || mobileFilename || heroFilename || bgFilename }
-    imageFocus={cardFocus || mobileFocus || heroFocus || bgFocus}
+    body={cardTeaser || dek}
+    imageSrc={cardImage || storyCardFilename || heroFilename || bgFilename }
+    imageFocus={cardFocus || storyCardFocus || heroFocus || bgFocus}
     tabColor={paletteAccentColors[value]}
     link={link}
     href={`/${full_slug}`}

--- a/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
+++ b/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
@@ -31,13 +31,10 @@ export const SbStoryMvp = ({
     dek,
     publishedDate,
     heroImage,
-    mobileImage,
     bgImage,
     bgImageAlt,
     addBgBlur,
     addDarkOverlay,
-    aspectRatio,
-    mobileAspectRatio,
     alt,
     caption,
     isVerticalHero,
@@ -74,9 +71,6 @@ export const SbStoryMvp = ({
             byline={byline}
             publishedDate={publishedDate}
             heroImage={heroImage}
-            aspectRatio={aspectRatio}
-            mobileImage={mobileImage}
-            mobileAspectRatio={mobileAspectRatio}
             bgImage={bgImage}
             bgImageAlt={bgImageAlt}
             addBgBlur={addBgBlur}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update story cards so it can pull the card image and card teaser from a story
- Add width/height attribute to images when appropriate

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-173--giving-campaign.netlify.app/stories/from-human-health-to-climate-health
2. Scroll to related stories, and see that this image is showing for the Battery Super Power story. This is added as the "card image" field in the Battery story (not the hero foreground/background)
3. Look at code

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-268