### PR TITLE
GIVCAMP-267 | Allow grid to be unordered list

### DIFF
--- a/components/CreateBloks.tsx
+++ b/components/CreateBloks.tsx
@@ -2,12 +2,15 @@ import { StoryblokComponent, type SbBlokData } from '@storyblok/react/rsc';
 
 type CreateBloksProps = {
   blokSection: SbBlokData[];
+  isListItems?: boolean;
   [k: string]: any;
 };
 
-export const CreateBloks = ({ blokSection, ...props }: CreateBloksProps) => {
-  if (blokSection) {
-    return blokSection.map((blok) => <StoryblokComponent blok={blok} key={blok._uid} {...props} />);
+export const CreateBloks = ({ blokSection, isListItems, ...props }: CreateBloksProps) => {
+  if (blokSection && isListItems) {
+    return blokSection.map((blok) => <li key={blok._uid}><StoryblokComponent blok={blok} {...props} /></li>);
+  } else if (blokSection) {
+    return blokSection.map((blok) => <StoryblokComponent key={blok._uid} blok={blok} {...props} />);
   }
 
   // Return null if no content provided.

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -15,6 +15,7 @@ import * as types from './Grid.types';
 
 export type GridProps = HTMLAttributes<HTMLElement> & {
   as?: types.GridElementType;
+  isList?: boolean;
   gap?: types.GridGapType;
   rtl?: boolean;
   xs?: types.GridNumColsType;
@@ -36,7 +37,8 @@ export type GridProps = HTMLAttributes<HTMLElement> & {
 };
 
 export const Grid = ({
-  as: AsComponent = 'div',
+  isList,
+  as: AsComponent = isList ? 'ul' : 'div',
   gap,
   rtl,
   xs,
@@ -81,6 +83,7 @@ export const Grid = ({
       mt ? marginTops[mt] : '',
       mb ? marginBottoms[mb] : '',
       my ? marginVerticals[my] : '',
+      isList ? 'list-unstyled children:mb-0' : '',
       className,
     )}
   >

--- a/components/Storyblok/SbGrid.tsx
+++ b/components/Storyblok/SbGrid.tsx
@@ -7,6 +7,8 @@ import { type PaddingType, type MarginType } from '@/utilities/datasource';
 type SbGridProps = {
   blok: {
     _uid: string;
+    // Turn grid into <ul> and items into <li>
+    isList?: boolean;
     gap?: GridGapType;
     boundingWidth?: 'site' | 'full';
     width?: WidthType;
@@ -32,6 +34,7 @@ type SbGridProps = {
 
 export const SbGrid = ({
   blok: {
+    isList,
     gap,
     boundingWidth = 'full',
     width,
@@ -62,6 +65,7 @@ export const SbGrid = ({
     pb={paddingBottom}
   >
     <Grid
+      isList={isList}
       xs={xs}
       sm={sm}
       md={md}
@@ -71,7 +75,7 @@ export const SbGrid = ({
       gap={gap}
       rtl={rtl}
     >
-      <CreateBloks blokSection={items} />
+      <CreateBloks blokSection={items} isListItems={isList} />
     </Grid>
   </WidthBox>
 );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add option for grid to be an `ul` and grid cells to be `li` (for a11y)

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-178--giving-campaign.netlify.app/
2. Look at all the grids of cards (eg, the square story card grids, the 4 changemaker card grid)
3. Inspect the code and see that it's using the HTML `ul` for the grid and each item is wrapped in a `li`
![Screenshot 2023-12-18 at 9 55 03 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/cc7d2b60-4ce4-4ffa-b91e-5e0d326f327e)
4. Look at code

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-267