### PR TITLE
GIVCAMP-225 | misc cleanup and sitemap update

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,7 +19,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     cv: Date.now(),
   });
 
-  const ret = response.map((story) => {
+  // Exclude any stories with noindex set to true on Storyblok
+  const indexStories = response.filter((story) => !story.content?.noindex);
+
+  const ret = indexStories.map((story) => {
     return {
       url: story.path ?? `/${story.full_slug}`,
       lastModified: new Date(story.published_at),

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -5,7 +5,7 @@ import { Container } from '../Container';
 import { Grid } from '../Grid';
 import { FlexBox } from '../FlexBox';
 import {
-  Heading, Paragraph, Text, type HeadingType,
+  Heading, Paragraph, Text, type HeadingType, SrOnlyText,
 } from '../Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import {
@@ -122,6 +122,7 @@ export const BlurryPoster = ({
             {superhead && (
               <Text
                 size={1}
+                // If there is a heading, superhead will be rendered as screen reader text as part of the heading
                 aria-hidden={!!heading}
                 className={styles.superhead(imageOnLeft, isTwoCol)}
               >
@@ -144,7 +145,7 @@ export const BlurryPoster = ({
                     leading={headingFont === 'druk' ? 'none' : 'tight'}
                     className={styles.heading(imageOnLeft, isSmallHeading, headingFont, isTwoCol)}
                   >
-                    {heading}
+                    {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
                   </Heading>
                 )}
                 {/* Render custom mixed typography heading if entered */}

--- a/components/Storyblok/SbSection.tsx
+++ b/components/Storyblok/SbSection.tsx
@@ -142,7 +142,14 @@ export const SbSection = ({
               )}
               >
                 {superhead && (
-                  <Text size={2} leading="tight" font="serif" weight="semibold" align={rightAlignHeader ? 'right' : 'left'} aria-hidden>
+                  <Text
+                    size={2}
+                    leading="tight"
+                    font="serif"
+                    weight="semibold"
+                    align={rightAlignHeader ? 'right' : 'left'}
+                    aria-hidden={!!heading}
+                  >
                     {superhead}
                   </Text>
                 )}

--- a/components/Storyblok/SbTypeform.tsx
+++ b/components/Storyblok/SbTypeform.tsx
@@ -1,6 +1,6 @@
 import { storyblokEditable } from '@storyblok/react/rsc';
 import {
- PopOver, PopUp, SideTab, Slider, Widget,
+  PopOver, PopUp, SideTab, Slider, Widget,
 } from '@/components/TypeForm';
 import { Container } from '@/components/Container';
 import { type PaddingType } from '@/utilities/datasource';
@@ -16,7 +16,6 @@ export type SbTypeformProps = {
     embedType: 'slider' | 'popup' | 'popover' | 'sidetab' | 'widget';
     autoResize: boolean;
     fullScreen: boolean;
-    heading: string;
     hideFooter: boolean;
     hideHeader: boolean;
     buttonLabel: string;
@@ -32,7 +31,7 @@ export type SbTypeformProps = {
 };
 
 export const styles = {
-  container: 'cc flex flex-col place-items-center',
+  container: 'flex flex-col place-items-center',
   fauxCTA: cnb(CTAStyles.cta, CTAStyles.ctaVariants.solid, CTAStyles.ctaSizes.large),
 };
 
@@ -68,7 +67,6 @@ export const SbTypeform = ({
     case 'slider': {
       return (
         <Container
-          width="full"
           pt={paddingTop}
           pb={paddingBottom}
           {...storyblokEditable(blok)}
@@ -128,7 +126,6 @@ export const SbTypeform = ({
     case 'popup': {
       return (
         <Container
-          width="full"
           pt={paddingTop}
           pb={paddingBottom}
           {...storyblokEditable(blok)}
@@ -156,7 +153,6 @@ export const SbTypeform = ({
     default: {
       return (
         <Container
-          width="full"
           pt={paddingTop}
           pb={paddingBottom}
           {...storyblokEditable(blok)}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- First batch of misc updates
- Exclude pages with noindex=true in the sitemap

# Review By (Date)
- Soonish


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-183--giving-campaign.netlify.app/sitemap.xml
2. Confirm that `/page-not-found` isn't on the sitemap (I set it to noindex=true in Storyblok)
3. Go to https://deploy-preview-183--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
4. Inspect the code, check that in the hero, the superhead is set to aria-hidden=true
5. Check that the superhead is absorbed into the h1 as screen reader only text
![Screenshot 2024-01-04 at 12 52 18 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/094656c5-403a-415f-96ff-0d74c03ebea8)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-225