### PR TITLE
GIVCAMP-275 | Add support for linking to assets; tighten padding for basic page hero

### DIFF
--- a/components/Cta/CtaLink.tsx
+++ b/components/Cta/CtaLink.tsx
@@ -7,6 +7,7 @@ import { CtaExternalLink } from './CtaExternalLink';
 import { CtaNextLink } from './CtaNextLink';
 import { type SbLinkType } from '../Storyblok/Storyblok.types';
 import { UrlObject } from 'url';
+import { getMaskedAsset } from '@/utilities/getMaskedAsset';
 
 /**
  * Use this component for CTA links.
@@ -55,6 +56,8 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       }
     } else if (linktype === 'email') {
       myLink = `mailto:${email}`;
+    } else if (linktype === 'asset') {
+      myLink = getMaskedAsset(url || href);
     } else {
       myLink = url || cachedUrl || href;
     }

--- a/components/Hero/BasicHeroMvp.tsx
+++ b/components/Hero/BasicHeroMvp.tsx
@@ -22,7 +22,7 @@ export const BasicHeroMvp = ({
   imageFocus,
   heroContent,
 }: BasicHeroMvpProps) => (
-  <Container width="full" bgColor={imageSrc ? undefined : 'black'} className="relative bg-black-70 py-[40vw] md:py-[30vw] xl:py-[20vw] 3xl:py-[34rem]">
+  <Container width="full" bgColor={imageSrc ? undefined : 'black'} className="relative bg-black-70 py-[34vw] md:py-[24vw] xl:py-[16vw] 3xl:py-[26rem]">
     {imageSrc && (
       <>
         <ImageOverlay


### PR DESCRIPTION
# READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Add support for linking to assets uploaded to Storyblok
- tighten padding for basic page hero

# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- How critical is this PR on a 1-10 scale? Also see [Severity Assessment](https://stanfordits.atlassian.net/browse/D8CORE-1705).
- E.g., it affects one site, or every site and product?

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-187--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
2. Scroll to the banner near the footer
![Screenshot 2024-01-09 at 4 18 55 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/0eda55fb-fb23-41b9-a2ce-e3687d947360)

3. Check that the link to the PDF in the button has the assets.stanford.edu domain. Check that you can click on it and go to the pdf.
4. Go to https://deploy-preview-187--giving-campaign.netlify.app/newsletter/sign-up
5. Check out the smaller vertical padding on the hero

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-275
