### PR TITLE
GIVCAMP-227 | Safari underline hover bug fix

### DIFF
--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -15,7 +15,7 @@ const mainNavBase = 'group bg-clip-padding inline-block border-2 font-normal dec
 const mainNavWhite = 'text-white border-white bg-gc-black hocus:text-white hocus:decoration-white hocus:ring-white';
 const mainNavDark = 'text-gc-black border-gc-black bg-white hocus:text-gc-black hocus:decoration-gc-black hocus:ring-gc-black';
 
-const mastheadGivingBase = 'inline-block w-fit font-normal decoration-transparent leading-display hocus:decoration-2 focus-visible:ring-2 focus-visible:ring-digital-red-xlight ring-offset-4 focus-visible:outline-none focus-visible:rounded underline-offset-4';
+const mastheadGivingBase = 'inline-block w-fit font-normal no-underline leading-display hocus:decoration-2 focus-visible:ring-2 focus-visible:ring-digital-red-xlight ring-offset-4 focus-visible:outline-none focus-visible:rounded underline-offset-4';
 const mastheadGivingWhite = 'text-white hocus:text-white hocus:decoration-white focus-visible:ring-offset-black';
 const mastheadGivingDark = 'text-gc-black hocus:text-gc-black hocus:decoration-gc-black focus-visible:ring-offset-white';
 

--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -30,7 +30,7 @@ export const ctaVariants = {
   ghost: ' block w-fit font-normal leading-display bg-transparent hocus:text-current border-2 border-current focus-visible:outline-none underline-offset-4 decoration-transparent hocus:decoration-current',
   'ghost-swipe': `${ghostSwipeBase} bg-transparent`,
   'ghost-swipe-overlay': `${ghostSwipeBase} bg-black-true/40`, // Use for split poster over images
-  link: '!p-0 inline-block w-fit font-normal decoration-transparent hocus:decoration-current leading-display text-current hocus:text-current hocus:decoration-2 focus-visible:ring-2 focus-visible:ring-digital-red-light focus-visible:outline-none focus-visible:rounded underline-offset-4',
+  link: '!p-0 inline-block w-fit font-normal leading-display text-current hocus:text-current no-underline decoration-2 underline-offset-4 focus-visible:ring-2 focus-visible:ring-digital-red-light focus-visible:outline-none focus-visible:rounded',
   back: 'inline-block font-normal no-underline leading-none group-hocus:underline text-black hocus:text-digital-red focus-visible:ring-2 focus-visible:ring-digital-red-light focus-visible:ring-offset-4 focus:outline-none rounded-[1px]',
   mainNav: `${mainNavBase} ${mainNavWhite} hocus-visible:bg-digital-red`, // Main nav buttons at the top of the page
   mainNavUp: `${mainNavBase} ${mainNavWhite} hocus-visible:bg-digital-red`, // Main nav buttons when scrolling up


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Weird Safari underline hover bug fix

# Review By (Date)
- Retro

# Criticality
- 2

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the homepage on Safari
2. Hover on the Giving to Stanford link, make sure you see an underline
![Screenshot 2024-01-11 at 4 05 38 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/11550f4d-0b0b-49f9-914b-cb3c42ca8c3a)

3. Scroll to local footer and hover on these 3 links under the logo, make sure you see an underline also
![Screenshot 2024-01-11 at 4 05 51 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/b2117d55-e693-4561-adee-6944e4d34211)

4. You can compare on https://dev--giving-campaign.netlify.app where it doesn't work quite right on Safari on hover (strangely it worked on focus). It doesn't seem to like the decoration-transparent class in combination with some other classes



# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-227