### PR TITLE
GIVCAMP-226 | A11y better focus management for changemaker cards

### DIFF
--- a/components/ChangemakerCard/ChangemakerCard.styles.ts
+++ b/components/ChangemakerCard/ChangemakerCard.styles.ts
@@ -6,7 +6,7 @@ export const imageWrapper = 'overflow-hidden aspect-w-1 aspect-h-2';
 export const info = 'rs-px-1 pb-150 absolute w-full h-full bottom-0 left-0 mb-0';
 export const heading = 'mb-02em mt-auto';
 
-export const cardContent = 'absolute w-full h-full top-0 left-0 px-20 py-30 3xl:py-48 3xl:px-36 aria-hidden:opacity-0 opacity-100 backdrop-blur-sm transition-opacity duration-500 bg-gradient-to-b from-gc-black/60 to-gc-black/90 gc-changemaker *:*:*:!mb-1em aria-hidden:invisible';
+export const cardContent = 'absolute w-full h-full top-0 left-0 px-20 py-30 3xl:py-48 3xl:px-36 aria-hidden:opacity-0 opacity-100 backdrop-blur-sm transition-opacity duration-500 bg-gradient-to-b from-gc-black/60 to-gc-black/90 gc-changemaker *:*:*:!mb-1em';
 
 export const button = 'group absolute w-full h-full top-0 left-0';
 export const icon = 'absolute bottom-40 right-36 text-white w-65 h-65 border-2 border-white rounded-full p-16 group-hocus-visible:border-dashed group-aria-expanded:rotate-45 transition-transform';

--- a/components/ChangemakerCard/ChangemakerCard.styles.ts
+++ b/components/ChangemakerCard/ChangemakerCard.styles.ts
@@ -6,7 +6,7 @@ export const imageWrapper = 'overflow-hidden aspect-w-1 aspect-h-2';
 export const info = 'rs-px-1 pb-150 absolute w-full h-full bottom-0 left-0 mb-0';
 export const heading = 'mb-02em mt-auto';
 
-export const cardContent = 'absolute w-full h-full top-0 left-0 px-20 py-30 3xl:py-48 3xl:px-36 aria-hidden:opacity-0 opacity-100 backdrop-blur-sm transition-opacity duration-500 bg-gradient-to-b from-gc-black/60 to-gc-black/90 gc-changemaker *:*:*:!mb-1em';
+export const cardContent = 'absolute w-full h-full top-0 left-0 px-20 py-30 3xl:py-48 3xl:px-36 aria-hidden:opacity-0 opacity-100 backdrop-blur-sm transition-opacity duration-500 bg-gradient-to-b from-gc-black/60 to-gc-black/90 gc-changemaker *:*:*:!mb-1em aria-hidden:invisible';
 
 export const button = 'group absolute w-full h-full top-0 left-0';
 export const icon = 'absolute bottom-40 right-36 text-white w-65 h-65 border-2 border-white rounded-full p-16 group-hocus-visible:border-dashed group-aria-expanded:rotate-45 transition-transform';

--- a/components/ChangemakerCard/ChangemakerCard.tsx
+++ b/components/ChangemakerCard/ChangemakerCard.tsx
@@ -39,11 +39,20 @@ export const ChangemakerCard = ({
 }: ChangemakerCardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const contentId = useId();
   const headingId = useId();
   const [isShown, toggle, setIsShown] = useToggle();
 
-  // If card content is shown, clicking outside it will dismiss its
+  const handleClick = () => {
+    // toggle the card content and if it is shown, focus on contentRef
+    toggle();
+    if (!isShown) {
+      contentRef.current?.focus();
+    }
+  };
+
+  // If card content is shown, clicking outside it will dismiss it
   useOnClickOutside(cardRef, () => {
     if (isShown) {
       setIsShown(false);
@@ -51,9 +60,11 @@ export const ChangemakerCard = ({
   });
 
   // If card content is shown, pressing escape will dismiss it
+  // and focus on the button
   useEscape(() => {
     if (isShown) {
       setIsShown(false);
+      buttonRef.current?.focus();
     }
   });
 
@@ -104,12 +115,14 @@ export const ChangemakerCard = ({
             className={styles.cardContent}
             aria-hidden={!isShown}
           >
-            {children}
+            <div ref={contentRef} tabIndex={isShown ? 0 : -1}>
+              {children}
+            </div>
           </FlexBox>
           <button
             ref={buttonRef}
             type="button"
-            onClick={toggle}
+            onClick={handleClick}
             aria-label={isShown ? 'Dismiss' : `Read more about ${heading}`}
             aria-controls={contentId}
             aria-expanded={isShown}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- A11y fix for updated changemaker cards
- Comment from SODA:

> Although focus no longer moves to the top of the page, the newly visible text is bypassed.  Move focus to the first content element in the card (the text).
> 
> Note: On Safari with VoiceOver the hidden card content (aria-hidden="true") is still announced.  However, this is a know bug that has not been resolved: https://bugs.webkit.org/show_bug.cgi?id=201887

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the changemaker cards
2. Use keyboard tab to focus on a card
3. Click enter
4. Check that the focus is moved to the content
5. Tab again and check that the focus is moved back to the "Dismiss" button
6. Confirm that by clicking enter that you can actually dismiss the content
7. Open another card content
8. Click escape and make sure it return focus to the button (it will have outline around the whole card)
9. Note: I'm not sure I need to address the Safari bug because if VO announces everything with aria-hidden then a lot of the things people normally do for a11y don't really work 😬 

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-226