### PR TITLE
GIVCAMP-277: Revert "NoJira: Storyblok API Javascript client update to support fetch parameters

### DIFF
--- a/app/(editor)/editor/page.tsx
+++ b/app/(editor)/editor/page.tsx
@@ -67,7 +67,7 @@ async function getStoryData({ path }: PageProps['searchParams']): Promise<ISbRes
   const slug = path.replace(/\/$/, '') || 'home'; // Remove trailing slash or if no slash, use home.
 
   try {
-    const story: ISbResult = await storyblokApi.get(`cdn/stories/${slug}`, sbParams, { cache: 'no-store' });
+    const story: ISbResult = await storyblokApi.get(`cdn/stories/${slug}`, sbParams);
     return story;
   } catch (error) {
     if (typeof error === 'string') {

--- a/app/(storyblok)/[...slug]/not-found.tsx
+++ b/app/(storyblok)/[...slug]/not-found.tsx
@@ -44,7 +44,7 @@ async function getStoryData(slug = 'page-not-found') {
   };
 
   try {
-    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams, { cache: 'no-store' });
+    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams);
     return story;
   } catch (error) {
     if (typeof error === 'string') {

--- a/app/(storyblok)/[...slug]/page.tsx
+++ b/app/(storyblok)/[...slug]/page.tsx
@@ -59,7 +59,7 @@ export async function generateStaticParams() {
   };
 
   // Use the `cdn/links` endpoint to get a list of all stories without all the extra data.
-  const response = await storyblokApi.getAll('cdn/links', sbParams, null, { cache: 'no-store' });
+  const response = await storyblokApi.getAll('cdn/links', sbParams);
   const stories = response.filter((link) => link.is_folder === false);
   let paths: PathsType[] = [];
 
@@ -94,7 +94,7 @@ async function getStoryData(params: { slug: string[] }) {
   };
 
   try {
-    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams, { cache: 'no-store' });
+    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams);
     return story;
   }
   catch (error) {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -44,7 +44,7 @@ async function getStoryData(slug = 'page-not-found') {
   };
 
   try {
-    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams, { cache: 'no-store' });
+    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams);
     return story;
   } catch (error) {
     if (typeof error === 'string') {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,7 +48,7 @@ async function getStoryData() {
   };
 
   try {
-    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams, { cache: 'no-store' });
+    const story = await storyblokApi.get(`cdn/stories/${slug}`, sbParams);
     return story;
   }
   catch (error) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # BUILD Settings:
 # ##############################################################################
 [build]
-  command = "npm run build"
+  command = "npm run build:netlify"
   publish = ".next"
 
 # PLUGINS

--- a/package-lock.json
+++ b/package-lock.json
@@ -272,9 +272,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
-      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -487,19 +487,19 @@
       "dev": true
     },
     "node_modules/@storyblok/js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.0.4.tgz",
-      "integrity": "sha512-sI6M7Atal+27M8ZOMyy6V1BUe7SXoxuXbog5FWnoERUwj6mxxZwaMmlbFjjlzRi9GPa2TJLLqJmjcC7wE6s+lw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.0.1.tgz",
+      "integrity": "sha512-XiM4ZevnfwAT16xsJOjT9VzJ3IHAaJAvgmsL+eHspBYJ8Gmmxz27IxI6KF/I7VtKQPcEpKcPn/Y1kGxm0dQurg==",
       "dependencies": {
-        "storyblok-js-client": "^6.6.1"
+        "storyblok-js-client": "^6.4.1"
       }
     },
     "node_modules/@storyblok/react": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@storyblok/react/-/react-3.0.6.tgz",
-      "integrity": "sha512-j0lM5ed+JpZD7yWTwfaCzDgutDb/GQVYxFHE/93v3FSRmD2acDwhVbqOqGQtgPB4csW5ffG7ER1VOVyL6Fdwpw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@storyblok/react/-/react-3.0.2.tgz",
+      "integrity": "sha512-Ec4wrPrq3zXhA60AYtlo74GmZYsN+log/BdNGfDxYx5sPLSBK13DWgkj9OI4PqHKuAz1ZKTHnQsch3vemPeX/g==",
       "dependencies": {
-        "@storyblok/js": "^3.0.4"
+        "@storyblok/js": "^3.0.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0",
@@ -579,9 +579,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.2.tgz",
-      "integrity": "sha512-cZShBaVa+UO1LjWWBPmWRR4+/eY/JR/UIEcDlVsw3okjWEu+rB7/mH6X3B/L+qJVHDLjk9QW/y2upp9wp1yDXA==",
+      "version": "20.10.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
+      "integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -594,9 +594,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.48",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
-      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
+      "version": "18.2.47",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
+      "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/cookies-next/node_modules/@types/node": {
-      "version": "16.18.71",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz",
-      "integrity": "sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q=="
+      "version": "16.18.70",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.70.tgz",
+      "integrity": "sha512-8eIk20G5VVVQNZNouHjLA2b8utE2NvGybLjMaF4lyhA9uhGwnmXF8o+icdXKGSQSNANJewXva/sFUoZLwAaYAg=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -1605,9 +1605,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.630",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.630.tgz",
-      "integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg==",
+      "version": "1.4.627",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.627.tgz",
+      "integrity": "sha512-BPFdHKPzyGxYQpgiCoIGnkzlMlps3bRdnjeh3qd/Q2pSacL0YW81i4llqsTY/wNbN/Ztw++7HNfp8v4Rm8VDuA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2311,9 +2311,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
@@ -4557,9 +4557,9 @@
       ]
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
-      "integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.1.tgz",
+      "integrity": "sha512-Y5NejJTTliTyY4H7sipGqY+RX5P87i3F7c4Rcepy72nq+mNLhIsD0W4c7kEmduMDQCSqtPsXPlSTsFhh2LQv+g==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -4604,16 +4604,15 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
       "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.2",
+        "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4732,9 +4731,9 @@
       }
     },
     "node_modules/storyblok-js-client": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.6.2.tgz",
-      "integrity": "sha512-+ypSy9WYGnA/JbBExlmh2YDVEdd39f44N5tEsrlFJ0MPwIdUUBTWB+8RAE+++Q2o6/hAKMWibcT3wvYNI/IELw=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.4.1.tgz",
+      "integrity": "sha512-Gcwh/1nX3B7Vv5uTgJ2vATwiK/Y57gs+bKPXfsPOUr3Us475u1x2nlS8Sfe3zc+hDRUTD0WmwBNqI0qJLyp7kg=="
     },
     "node_modules/storyblok-rich-text-react-renderer-ts": {
       "version": "3.2.0",
@@ -5392,9 +5391,10 @@
       }
     },
     "node_modules/usehooks-ts": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.4.tgz",
-      "integrity": "sha512-VOSEbA+BGGORLttsICowNb5CG0D2/IEoVvMEl9OuuOoQi99W6XuNipo3SPFhWo3Bhdwi0Swj1D+IMQDQB9KrwQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.2.tgz",
+      "integrity": "sha512-fOzPeG01rs51CGYzqgioP/zs9v1Cgpe+zcXeqJPlDHYfdfG/wjsdjBWHJi+Ph1JgQAGUrDo5sJbPlaZd+Z9lxw==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=16.15.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:netlify": "rm -rf .next/cache && next build",
     "start": "next start",
     "lint": "next lint",
     "hps": "local-ssl-proxy --cert ./dev/localhost.pem --key ./dev/localhost-key.pem",


### PR DESCRIPTION
#  READY FOR REVIEW

# Summary
- Reverts back to killing the data cache on the server filesystem instead of trying to set the no-store on the fetch
- I'm punting on this as it looks like we are in a bit of a pickle and I've banged on this enough already. Looking at the threads there looks to be a couple of issues open with the datacache and static -> dynamic navigation. 
- I'd like to revisit this after the Netlify Next plugin update.
- Reverts: https://github.com/SU-SWS/ood-giving-campaign/pull/192

Issues:
* https://github.com/vercel/next.js/issues/43879
* https://github.com/vercel/next.js/issues/46737
* https://github.com/vercel/next.js/issues/42991
* https://github.com/vercel/storage/issues/213

# Review By (Date)
- When you'd like

# Criticality
- Regular

# Review Tasks

1. Review code
2. Review preview build