### PR TITLE
GIVCAMP-225 | Improve social sharing and misc fixups

### DIFF
--- a/components/HeroIcon/HeroIcon.styles.tsx
+++ b/components/HeroIcon/HeroIcon.styles.tsx
@@ -19,7 +19,7 @@ import {
   PlusIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
-
+import { CheckIcon } from '@heroicons/react/16/solid';
 import { PlayIcon } from '@heroicons/react/24/solid';
 
 export const iconMap = {
@@ -30,6 +30,7 @@ export const iconMap = {
   'arrow-down': ArrowDownIcon,
   back: ArrowLeftIcon,
   copy: DocumentDuplicateIcon,
+  'check-circle': CheckIcon,
   'chevron-down': ChevronDownIcon,
   'chevron-right': ChevronRightIcon,
   'chevron-up': ChevronUpIcon,

--- a/components/Homepage/ThemeSection.tsx
+++ b/components/Homepage/ThemeSection.tsx
@@ -134,7 +134,7 @@ export const ThemeSection = ({
           <CtaButton onClick={() => setShouldAnimate(false)}>Reveal themes visually</CtaButton>
         </div>
         {/* This grid contains the 4 animated lines behind the theme cards */}
-        <Grid md={2} className="hidden md:grid absolute left-0 top-[160rem] 2xl:top-[170rem] w-full gap-y-[30rem]">
+        <Grid md={2} className="hidden md:grid absolute left-0 top-[160rem] 2xl:top-[170rem] w-full gap-y-300">
           <div className="max-w-full overflow-hidden">
             <m.svg className="mr-0 ml-auto" viewBox="0 0 952 461" fill="none" xmlns="http://www.w3.org/2000/svg">
               <m.path

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -37,7 +37,7 @@ export const TogetherSection = () => {
     <div ref={sectionRef} className="relative overflow-hidden rs-pb-8 w-full bg-gc-black text-white">
       <Container>
         <AnimateInView animation="slideUp">
-          <Heading size="f5" align="center" leading="tight" className="mx-auto max-w-1000">
+          <Heading size="f5" align="center" leading="tight" className="mx-auto max-w-900">
             True change will require all of us.
           </Heading>
         </AnimateInView>

--- a/components/SocialSharing/SocialSharing.styles.ts
+++ b/components/SocialSharing/SocialSharing.styles.ts
@@ -10,4 +10,4 @@ export const heading = 'mb-0';
 
 export const buttonWrapper = 'gap-6 md:gap-12';
 
-export const copiedTextBubble = 'text-15 absolute -ml-36 aria-hidden:mt-0 -mt-34 py-6 px-12 rounded-full bg-digital-red-light transition-all aria-hidden:opacity-0 opacity-100 delay-300 pointer-events-none';
+export const copiedTextBubble = 'text-15 absolute -ml-36 aria-hidden:mt-0 -mt-34 py-6 px-12 rounded-full bg-gc-black transition-all aria-hidden:opacity-0 opacity-100 delay-300 pointer-events-none';

--- a/components/SocialSharing/SocialSharing.styles.ts
+++ b/components/SocialSharing/SocialSharing.styles.ts
@@ -9,3 +9,5 @@ export const flexbox = (isTop?: boolean) => cnb('border-gc-black',
 export const heading = 'mb-0';
 
 export const buttonWrapper = 'gap-6 md:gap-12';
+
+export const copiedTextBubble = 'text-15 absolute -ml-36 aria-hidden:mt-0 -mt-34 py-6 px-12 rounded-full bg-digital-red-light transition-all aria-hidden:opacity-0 opacity-100 delay-300 pointer-events-none';

--- a/components/SocialSharing/SocialSharing.tsx
+++ b/components/SocialSharing/SocialSharing.tsx
@@ -11,6 +11,7 @@ import { LinkIcon } from './LinkIcon';
 import { WidthBox } from '../WidthBox';
 import { SocialButton } from './SocialButton';
 import { HeroIcon } from '../HeroIcon';
+import { Text } from '@/components/Typography/Text';
 import { config } from '@/utilities/config';
 import * as styles from './SocialSharing.styles';
 
@@ -55,10 +56,20 @@ export const SocialSharing = ({
           <FlexBox className={styles.buttonWrapper}>
             <SocialButton
               onClick={handleCopyClick}
-              aria-label={buttonState === 'copied' ? 'URL has been copied' : 'Copy story URL'}
+              aria-label={buttonState === 'copied' ? 'Story link has been copied' : 'Copy story link'}
             >
               {buttonState === 'copied' ? <HeroIcon icon="copy" /> : <LinkIcon aria-hidden width="20" />}
             </SocialButton>
+            <Text
+              color="white"
+              className={styles.copiedTextBubble}
+              weight="semibold"
+              leading="none"
+              icon="check-circle"
+              aria-hidden={buttonState !== 'copied'}
+            >
+              Link copied
+            </Text>
             <SocialButton
               aria-label="Share via email"
               href={`mailto:?subject=${title ? safeTitle : 'Check out this story'}&body=${safeUrl}`}

--- a/components/SocialSharing/SocialSharing.tsx
+++ b/components/SocialSharing/SocialSharing.tsx
@@ -40,6 +40,7 @@ export const SocialSharing = ({
   };
 
   const safeUrl = encodeURIComponent(`${config.siteUrlProd}/${slug}`);
+  const safeTitle = encodeURIComponent(title);
   const facebookBaseURL = 'https://www.facebook.com/sharer/sharer.php?u=';
   const twitterBaseURL = 'https://twitter.com/intent/tweet?url=';
   const linkedinBaseURL = 'https://www.linkedin.com/shareArticle?mini=true&url=';
@@ -60,7 +61,7 @@ export const SocialSharing = ({
             </SocialButton>
             <SocialButton
               aria-label="Share via email"
-              href={`mailto:?subject=${title ? title : 'Check out this story'}&body=${safeUrl}`}
+              href={`mailto:?subject=${title ? safeTitle : 'Check out this story'}&body=${safeUrl}`}
             >
               <EmailIcon aria-hidden width="18" />
             </SocialButton>
@@ -72,7 +73,7 @@ export const SocialSharing = ({
             </SocialButton>
             <SocialButton
               aria-label="Share on X (formerly Twitter)"
-              href={`${twitterBaseURL}${safeUrl}${title ? `&text=${title}` : ''}`}
+              href={`${twitterBaseURL}${safeUrl}${title ? `&text=${safeTitle}` : ''}`}
             >
               <TwitterX aria-hidden width="18" />
             </SocialButton>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
-        "@storyblok/react": "^3.0.2",
+        "@storyblok/react": "^3.0.8",
         "@typeform/embed-react": "^3.8.0",
         "cnbuilder": "^3.1.0",
         "cookies-next": "^4.0.0",
@@ -487,19 +487,19 @@
       "dev": true
     },
     "node_modules/@storyblok/js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.0.4.tgz",
-      "integrity": "sha512-sI6M7Atal+27M8ZOMyy6V1BUe7SXoxuXbog5FWnoERUwj6mxxZwaMmlbFjjlzRi9GPa2TJLLqJmjcC7wE6s+lw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.0.6.tgz",
+      "integrity": "sha512-Kbz5D1pcKWgjqecF+rz1bq5742YpCZe7+B8Zrtp979QOXFpAurHm2BrmzVZy75G2BevWR5CcsK9MzLnyief1Kw==",
       "dependencies": {
-        "storyblok-js-client": "^6.6.1"
+        "storyblok-js-client": "^6.6.3"
       }
     },
     "node_modules/@storyblok/react": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@storyblok/react/-/react-3.0.6.tgz",
-      "integrity": "sha512-j0lM5ed+JpZD7yWTwfaCzDgutDb/GQVYxFHE/93v3FSRmD2acDwhVbqOqGQtgPB4csW5ffG7ER1VOVyL6Fdwpw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@storyblok/react/-/react-3.0.8.tgz",
+      "integrity": "sha512-PtgkmhAeW8QJI9cGBtVW3v8Daw7lTZgZX56hBnXhxkukRmJOVgSl8Ywv8lBeEeRCvvYmrlM1FWAy95HPsJJxEA==",
       "dependencies": {
-        "@storyblok/js": "^3.0.4"
+        "@storyblok/js": "^3.0.6"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0",
@@ -4732,9 +4732,9 @@
       }
     },
     "node_modules/storyblok-js-client": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.6.2.tgz",
-      "integrity": "sha512-+ypSy9WYGnA/JbBExlmh2YDVEdd39f44N5tEsrlFJ0MPwIdUUBTWB+8RAE+++Q2o6/hAKMWibcT3wvYNI/IELw=="
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.6.3.tgz",
+      "integrity": "sha512-SF74HnxrddCmjzP6e1ABw36SaREV9SqGsEh0PBWKSs1AwGiVfmcZLfMfjNRC8wUamsk7Xho8Tc9Zia7upeYaMg=="
     },
     "node_modules/storyblok-rich-text-react-renderer-ts": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ood-giving-campaign",
       "version": "0.0.2",
       "dependencies": {
-        "@heroicons/react": "^2.0.18",
+        "@heroicons/react": "^2.1.1",
         "@storyblok/react": "^3.0.8",
         "@typeform/embed-react": "^3.8.0",
         "cnbuilder": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
-    "@storyblok/react": "^3.0.2",
+    "@storyblok/react": "^3.0.8",
     "@typeform/embed-react": "^3.8.0",
     "cnbuilder": "^3.1.0",
     "cookies-next": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@heroicons/react": "^2.0.18",
+    "@heroicons/react": "^2.1.1",
     "@storyblok/react": "^3.0.8",
     "@typeform/embed-react": "^3.8.0",
     "cnbuilder": "^3.1.0",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update to the social sharing widget
- Minor package updates and fixups

# Review By (Date)
- Whenever

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to any story, eg
https://deploy-preview-196--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
2. Click on the first button in the social sharing widget
3. Check that the text "Link copied" shows up above the button and stays for 5 seconds
![Screenshot 2024-01-22 at 2 14 21 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e021cd59-904b-4f6f-bdfc-3dea4336eef4)

4. Look at code for accessibility
5. Inspect the email and the Twitter button - check that the white space in the title has been converted to %20


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-225
