### PR TITLE
GIVCAMP-278 | Conditionally render mobile/desktop story hero images

### DIFF
--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useEffect, useState } from 'react';
 import { useMediaQuery } from 'usehooks-ts';
 import { cnb } from 'cnbuilder';
 import { AnimateInView } from '@/components/Animate';
@@ -85,6 +85,12 @@ export const BlurryPoster = ({
   ...props
 }: BlurryPosterProps) => {
   const isDesktop = useMediaQuery(`(min-width: ${config.breakpoints.lg}px)`);
+  const [showDesktop, setShowDesktop] = useState(false);
+  // Use useEffect to update your local state from client side only after first render
+  useEffect(() => {
+    setShowDesktop(isDesktop);
+  }, [isDesktop]);
+
   const date = publishedDate && new Date(publishedDate);
   const formattedDate = date && date.toLocaleDateString('en-US', {
     month: 'long',
@@ -96,7 +102,7 @@ export const BlurryPoster = ({
 
   return (
     <Container {...props} bgColor={bgColor} width="full" className={styles.root}>
-      {isDesktop ? (
+      {showDesktop ? (
         <img
           src={getProcessedImage(bgImageSrc, '2000x1200', bgImageFocus)}
           alt={bgImageAlt || ''}
@@ -206,7 +212,7 @@ export const BlurryPoster = ({
           <Container width={isTwoCol ? 'full' : 'site'} className={styles.imageWrapper(imageOnLeft, isTwoCol, !!imageSrc)}>
             {imageSrc && (
               <AnimateInView animation="zoomSharpen" duration={1} className={styles.imageInnerWrapper}>
-                {isDesktop ? (
+                {showDesktop ? (
                   <img
                     src={getProcessedImage(imageSrc, type === 'hero' && !isTwoCol ? '1800x900' : '900x1200', imageFocus)}
                     alt={alt || ''}

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -1,13 +1,15 @@
 import React, { HTMLAttributes } from 'react';
+import { useMediaQuery } from 'usehooks-ts';
 import { cnb } from 'cnbuilder';
-import { AnimateInView } from '../Animate';
-import { Container } from '../Container';
-import { Grid } from '../Grid';
-import { FlexBox } from '../FlexBox';
+import { AnimateInView } from '@/components/Animate';
+import { Container } from '@/components/Container';
+import { Grid } from '@/components/Grid';
+import { FlexBox } from '@/components/FlexBox';
 import {
   Heading, Paragraph, Text, type HeadingType, SrOnlyText,
-} from '../Typography';
+} from '@/components/Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
+import { config } from '@/utilities/config';
 import {
   accentBorderColors,
   type AccentColorType,
@@ -82,6 +84,7 @@ export const BlurryPoster = ({
   className,
   ...props
 }: BlurryPosterProps) => {
+  const isDesktop = useMediaQuery(`(min-width: ${config.breakpoints.lg}px)`);
   const date = publishedDate && new Date(publishedDate);
   const formattedDate = date && date.toLocaleDateString('en-US', {
     month: 'long',
@@ -93,24 +96,27 @@ export const BlurryPoster = ({
 
   return (
     <Container {...props} bgColor={bgColor} width="full" className={styles.root}>
-      <img
-        src={getProcessedImage(bgImageSrc, '1000x1500', bgImageFocus)}
-        alt={bgImageAlt || ''}
-        aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
-        className={styles.bgImageMobile}
-        fetchPriority={type === 'hero' ? 'high' : 'auto'}
-        width={1000}
-        height={1500}
-      />
-      <img
-        src={getProcessedImage(bgImageSrc, '2000x1200', bgImageFocus)}
-        alt={bgImageAlt || ''}
-        aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
-        fetchPriority={type === 'hero' ? 'high' : 'auto'}
-        className={styles.bgImage}
-        width={2000}
-        height={1200}
-      />
+      {isDesktop ? (
+        <img
+          src={getProcessedImage(bgImageSrc, '2000x1200', bgImageFocus)}
+          alt={bgImageAlt || ''}
+          aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
+          fetchPriority={type === 'hero' ? 'high' : 'auto'}
+          className={styles.bgImage}
+          width={2000}
+          height={1200}
+        />
+      ) : (
+        <img
+          src={getProcessedImage(bgImageSrc, '1000x1500', bgImageFocus)}
+          alt={bgImageAlt || ''}
+          aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
+          className={styles.bgImageMobile}
+          fetchPriority={type === 'hero' ? 'high' : 'auto'}
+          width={1000}
+          height={1500}
+        />
+      )}
       <div className={cnb(styles.blurWrapper(
         addBgBlur,
         !!darkOverlay && darkOverlay !== 'none', type, bgColor,
@@ -200,24 +206,27 @@ export const BlurryPoster = ({
           <Container width={isTwoCol ? 'full' : 'site'} className={styles.imageWrapper(imageOnLeft, isTwoCol, !!imageSrc)}>
             {imageSrc && (
               <AnimateInView animation="zoomSharpen" duration={1} className={styles.imageInnerWrapper}>
-                <img
-                  src={getProcessedImage(imageSrc, type === 'hero' && !isTwoCol ? '1800x900' : '900x1200', imageFocus)}
-                  alt={alt || ''}
-                  width={type === 'hero' && !isTwoCol ? 1800 : 900}
-                  height={type === 'hero' && !isTwoCol ? 900 : 1200}
-                  aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
-                  fetchPriority={type === 'hero' ? 'high' : 'auto'}
-                  className={styles.image}
-                />
-                <img
-                  src={getProcessedImage(imageSrc, '1000x1000', imageFocus)}
-                  alt={alt || ''}
-                  width={1000}
-                  height={1000}
-                  aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
-                  fetchPriority={type === 'hero' ? 'high' : 'auto'}
-                  className={styles.imageMobile}
-                />
+                {isDesktop ? (
+                  <img
+                    src={getProcessedImage(imageSrc, type === 'hero' && !isTwoCol ? '1800x900' : '900x1200', imageFocus)}
+                    alt={alt || ''}
+                    width={type === 'hero' && !isTwoCol ? 1800 : 900}
+                    height={type === 'hero' && !isTwoCol ? 900 : 1200}
+                    aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
+                    fetchPriority={type === 'hero' ? 'high' : 'auto'}
+                    className={styles.image}
+                  />
+                ) : (
+                  <img
+                    src={getProcessedImage(imageSrc, '1000x1000', imageFocus)}
+                    alt={alt || ''}
+                    width={1000}
+                    height={1000}
+                    aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
+                    fetchPriority={type === 'hero' ? 'high' : 'auto'}
+                    className={styles.imageMobile}
+                  />
+                )}
               </AnimateInView>
             )}
           </Container>

--- a/utilities/getSbImageSize.ts
+++ b/utilities/getSbImageSize.ts
@@ -4,10 +4,10 @@
  * @returns An object containing the width and height of the image, or null if the URL is invalid.
  */
 export const getSbImageSize = (imageSrc: string): { width: number, height: number } | null => {
-  if (imageSrc.startsWith('http')) {
+  if (imageSrc?.startsWith('http')) {
     const imageSize = {
-      width: parseInt(imageSrc.split('/')[5].split('x')[0], 10),
-      height: parseInt(imageSrc.split('/')[5].split('x')[1], 10),
+      width: parseInt(imageSrc?.split('/')[5].split('x')[0], 10),
+      height: parseInt(imageSrc?.split('/')[5].split('x')[1], 10),
     };
 
     return imageSize;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use the useMediaQuery hook to conditionally render desktop or mobile image for Story Hero/Blurry Poster
- See if it solve the problem of story hero rendering delay.

# Review By (Date)
- Retro

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to stories
2. See if hero image appears right away or if there's a delay (2 second ish)
3. Look at code

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-278
