### PR TITLE
NoJira: Long cache home page too.

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,11 @@ import { getPageMetadata } from '@/utilities/getPageMetadata';
 import ComponentNotFound from '@/components/Storyblok/ComponentNotFound';
 import { notFound } from 'next/navigation';
 
+// Bug in Safari + Netlify + Next where back button doesn't function correctly and returns the user
+// back to the page they hit the back button on after scrolling or interacting with the page they went back to.
+// Setting a long revalidate time patches this until Next/Netlify fix the bug in future releases of their stuff.
+export const revalidate = 60 * 60 * 24 * 365;
+
 // Storyblok bridge options.
 const bridgeOptions = {
   resolveRelations,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adds long revalidation time to home page
- Trying to avoid the loading showing up where I can
- Clicking on the logo will be a 'hard' navigation as we have turned off pre-fetching there. 

# Review By (Date)
- Whenever

# Criticality
- Low
 
