### PR TITLE
GIVCAMP-226 | SODA a11y fixes and add support to asset link in WYSIWYG

### DIFF
--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -97,6 +97,7 @@ export const BlurryPoster = ({
         <source
           srcSet={getProcessedImage(bgImageSrc, addBgBlur ? '1000x600' : '2000x1200', bgImageFocus)}
           media="(min-width: 1200px)"
+          // Exact height and width don't matter as long as aspect ratio is the same as the image
           width={2000}
           height={1200}
         />
@@ -123,7 +124,7 @@ export const BlurryPoster = ({
           alt={bgImageAlt || ''}
           width={2000}
           height={1200}
-          aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
+          aria-describedby={hasCaption && !!bgImageAlt ? 'story-hero-caption' : undefined}
           className={styles.bgImage}
           fetchPriority="high"
         />
@@ -241,7 +242,7 @@ export const BlurryPoster = ({
                     alt={alt || ''}
                     width={type === 'hero' && !isTwoCol ? 1800 : 750}
                     height={type === 'hero' && !isTwoCol ? 900 : 1000}
-                    aria-describedby={hasCaption ? 'story-hero-caption' : undefined}
+                    aria-describedby={hasCaption && !!alt ? 'story-hero-caption' : undefined}
                     fetchPriority={type === 'hero' ? 'high' : 'auto'}
                     className={styles.image}
                   />

--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -126,7 +126,7 @@ export const BlurryPoster = ({
           height={1200}
           aria-describedby={hasCaption && !!bgImageAlt ? 'story-hero-caption' : undefined}
           className={styles.bgImage}
-          fetchPriority="high"
+          fetchPriority={type === 'hero' ? 'high' : 'auto'}
         />
       </picture>
       <div className={cnb(styles.blurWrapper(

--- a/components/ChangemakerCard/ChangemakerCard.tsx
+++ b/components/ChangemakerCard/ChangemakerCard.tsx
@@ -81,7 +81,7 @@ export const ChangemakerCard = ({
             {imageSrc && (
               <div className={cnb(styles.imageWrapper)}>
                 <ImageOverlay
-                  imageSrc={getProcessedImage(imageSrc, '500x1000', imageFocus)}
+                  imageSrc={getProcessedImage(imageSrc, '400x800', imageFocus)}
                   overlay="gradient-changemaker"
                   loading="eager"
                   width={339}

--- a/components/Cta/CtaExternalLink.tsx
+++ b/components/Cta/CtaExternalLink.tsx
@@ -23,7 +23,7 @@ export const CtaExternalLink = React.forwardRef<HTMLAnchorElement, CtaExternalLi
       iconPosition = 'right',
       animate,
       iconProps,
-      srText = '(external link)',
+      srText,
       children,
       className,
       href,

--- a/components/GlobalFooter/GlobalFooter.tsx
+++ b/components/GlobalFooter/GlobalFooter.tsx
@@ -30,7 +30,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Stanford Home
-                <SrOnlyText />
               </a>
             </li>
             <li className={styles.listItem}>
@@ -40,7 +39,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Maps &amp; Directions
-                <SrOnlyText />
               </a>
             </li>
             <li className={styles.listItem}>
@@ -50,7 +48,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Search Stanford
-                <SrOnlyText />
               </a>
             </li>
             <li>
@@ -60,7 +57,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Emergency Info
-                <SrOnlyText />
               </a>
             </li>
           </ul>
@@ -73,7 +69,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Terms of Use
-                <SrOnlyText />
               </a>
             </li>
             <li className={styles.listItem}>
@@ -84,7 +79,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Privacy
-                <SrOnlyText />
               </a>
             </li>
             <li className={styles.listItem}>
@@ -95,7 +89,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Copyright
-                <SrOnlyText />
               </a>
             </li>
             <li className={styles.listItem}>
@@ -106,7 +99,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Trademarks
-                <SrOnlyText />
               </a>
             </li>
             <li className={styles.listItem}>
@@ -117,7 +109,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Non-Discrimination
-                <SrOnlyText />
               </a>
             </li>
             <li>
@@ -128,7 +119,6 @@ export const GlobalFooter = ({ className }: GlobalFooterProps) => (
                 className={styles.link}
               >
                 Accessibility
-                <SrOnlyText />
               </a>
             </li>
           </ul>

--- a/components/Homepage/TogetherSection.tsx
+++ b/components/Homepage/TogetherSection.tsx
@@ -62,9 +62,11 @@ export const TogetherSection = () => {
         Together
       </m.div>
       <m.img
-        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3014x1979/5d314e43ba/together_h412-18.jpg', '1200x0')}
+        src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3014x1979/5d314e43ba/together_h412-18.jpg', '800x0')}
         alt="A black and white archival photo of a conductor leading an orchestra"
         className="relative w-[90vw] sm:w-[60vw] xl:w-[42vw] mx-auto z-10"
+        width={800}
+        height={521}
         style={{
           marginTop: marginTopAnimation,
           scale: imageScaleAnimation,

--- a/components/RichText.tsx
+++ b/components/RichText.tsx
@@ -69,7 +69,8 @@ export const RichText = ({
         // Structure the link data so it takes the same shape as sbLink
         const sbLink = {
           linktype,
-          cached_url: linktype !== 'email' ? href : '',
+          cached_url: linktype === 'story' ? href : '',
+          url: linktype === 'asset' || 'url' ? href : '',
           email: linktype === 'email' ? href : '',
           anchor,
           // The WYSIWYG link adds a target="_self" by default which is unnecessary

--- a/components/Scrollytelling/Scrollytelling.styles.ts
+++ b/components/Scrollytelling/Scrollytelling.styles.ts
@@ -15,6 +15,7 @@ export const overlays = {
   'black-50': 'lg:bg-black-true/50',
   'black-60': 'lg:bg-black-true/60',
   'black-70': 'lg:bg-black-true/70',
+  'black-80': 'lg:bg-black-true/80',
   'black-gradient-to-r': 'lg:bg-transparent lg:bg-gradient-to-r lg:from-black-true/70',
   'black-gradient-to-l': 'lg:bg-transparent lg:bg-gradient-to-l lg:from-black-true/70',
 };

--- a/components/SocialSharing/SocialSharing.styles.ts
+++ b/components/SocialSharing/SocialSharing.styles.ts
@@ -10,4 +10,4 @@ export const heading = 'mb-0';
 
 export const buttonWrapper = 'gap-6 md:gap-12 list-unstyled *:mb-0';
 
-export const copiedTextBubble = 'text-15 absolute -ml-36 aria-hidden:mt-0 -mt-34 py-6 px-12 rounded-full bg-gc-black transition-all aria-hidden:opacity-0 opacity-100 delay-300 pointer-events-none';
+export const copiedTextBubble = 'text-15 absolute -ml-36 aria-hidden:mt-0 -mt-80 py-6 px-12 rounded-full bg-gc-black transition-all aria-hidden:opacity-0 opacity-100 delay-300 pointer-events-none';

--- a/components/SocialSharing/SocialSharing.styles.ts
+++ b/components/SocialSharing/SocialSharing.styles.ts
@@ -8,6 +8,6 @@ export const flexbox = (isTop?: boolean) => cnb('border-gc-black',
 
 export const heading = 'mb-0';
 
-export const buttonWrapper = 'gap-6 md:gap-12';
+export const buttonWrapper = 'gap-6 md:gap-12 list-unstyled *:mb-0';
 
 export const copiedTextBubble = 'text-15 absolute -ml-36 aria-hidden:mt-0 -mt-34 py-6 px-12 rounded-full bg-gc-black transition-all aria-hidden:opacity-0 opacity-100 delay-300 pointer-events-none';

--- a/components/SocialSharing/SocialSharing.tsx
+++ b/components/SocialSharing/SocialSharing.tsx
@@ -53,47 +53,57 @@ export const SocialSharing = ({
           <Heading as="h2" font="sans" size="base" weight="semibold" leading="none" className={styles.heading}>
             Share this story
           </Heading>
-          <FlexBox className={styles.buttonWrapper}>
-            <SocialButton
-              onClick={handleCopyClick}
-              aria-label={buttonState === 'copied' ? 'Story link has been copied' : 'Copy story link'}
-            >
-              {buttonState === 'copied' ? <HeroIcon icon="copy" /> : <LinkIcon aria-hidden width="20" />}
-            </SocialButton>
-            <Text
-              color="white"
-              className={styles.copiedTextBubble}
-              weight="semibold"
-              leading="none"
-              icon="check-circle"
-              aria-hidden={buttonState !== 'copied'}
-            >
-              Link copied
-            </Text>
-            <SocialButton
-              aria-label="Share via email"
-              href={`mailto:?subject=${title ? safeTitle : 'Check out this story'}&body=${safeUrl}`}
-            >
-              <EmailIcon aria-hidden width="18" />
-            </SocialButton>
-            <SocialButton
-              aria-label="Share on Facebook"
-              href={`${facebookBaseURL}${safeUrl}`}
-            >
-              <FacebookF aria-hidden width="12" />
-            </SocialButton>
-            <SocialButton
-              aria-label="Share on X (formerly Twitter)"
-              href={`${twitterBaseURL}${safeUrl}${title ? `&text=${safeTitle}` : ''}`}
-            >
-              <TwitterX aria-hidden width="18" />
-            </SocialButton>
-            <SocialButton
-              aria-label="Share on LinkedIn"
-              href={`${linkedinBaseURL}${safeUrl}`}
-            >
-              <LinkedinIn aria-hidden width="17" />
-            </SocialButton>
+          <FlexBox as="ul" className={styles.buttonWrapper}>
+            <li>
+              <SocialButton
+                onClick={handleCopyClick}
+                aria-label={buttonState === 'copied' ? 'Story link has been copied' : 'Copy story link'}
+              >
+                {buttonState === 'copied' ? <HeroIcon icon="copy" /> : <LinkIcon aria-hidden width="20" />}
+              </SocialButton>
+              <Text
+                color="white"
+                className={styles.copiedTextBubble}
+                weight="semibold"
+                leading="none"
+                icon="check-circle"
+                aria-hidden={buttonState !== 'copied'}
+              >
+                Link copied
+              </Text>
+            </li>
+            <li>
+              <SocialButton
+                aria-label="Share via email"
+                href={`mailto:?subject=${title ? safeTitle : 'Check out this story'}&body=${safeUrl}`}
+              >
+                <EmailIcon aria-hidden width="18" />
+              </SocialButton>
+            </li>
+            <li>
+              <SocialButton
+                aria-label="Share on Facebook"
+                href={`${facebookBaseURL}${safeUrl}`}
+              >
+                <FacebookF aria-hidden width="12" />
+              </SocialButton>
+            </li>
+            <li>
+              <SocialButton
+                aria-label="Share on X (formerly Twitter)"
+                href={`${twitterBaseURL}${safeUrl}${title ? `&text=${safeTitle}` : ''}`}
+              >
+                <TwitterX aria-hidden width="18" />
+              </SocialButton>
+            </li>
+            <li>
+              <SocialButton
+                aria-label="Share on LinkedIn"
+                href={`${linkedinBaseURL}${safeUrl}`}
+              >
+                <LinkedinIn aria-hidden width="17" />
+              </SocialButton>
+            </li>
           </FlexBox>
         </FlexBox>
       </WidthBox>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -49,10 +49,10 @@ export const StoryCard = ({
           <div className={styles.imageWrapper}>
             <img
               alt=""
-              width={600}
-              height={600}
+              width={500}
+              height={500}
               loading="lazy"
-              src={getProcessedImage(imageSrc, '600x600', imageFocus)}
+              src={getProcessedImage(imageSrc, '500x500', imageFocus)}
               className={styles.image}
             />
           </div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- SODA fixes (non 3rd party related ones)
- Add support to linking to assets inside WYSIWYG
- Further image size reduction

# Review By (Date)
- Soon

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to any story or this one:
https://deploy-preview-206--giving-campaign.netlify.app/stories/the-most-wicked-problems
2. Check that the social sharing buttons are wrap in ul/li structure
![Screenshot 2024-01-26 at 12 05 06 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/91c43ada-56a8-4089-b928-d3ec8d9cf0f0)
3. Scroll down to the scrollytelling section with the letter to Elizabeth Warren. Click on the link in the caption to read the PDF and see that it works.
![Screenshot 2024-01-26 at 12 06 17 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e98b9cdf-02b0-4d32-a278-fe3e09752993)
4. Go to this story
https://deploy-preview-206--giving-campaign.netlify.app/stories/the-second-envelope
5. Inspect the hero background image and confirms that it doesn't have a aria-describedby attribute that references the hero caption.
6. Inspect any external links on the site and check that screen reader text "(link is external)" have been removed.
7. Look at code
8. Go to https://docs.google.com/spreadsheets/d/1L5iu28GkU70ITLYX_rvManbHKrVd_z5e/edit#gid=793295331
and look at my column on the very right with short note and color code, and see that the assessments are right and we've performed any non 3rd party related fixes. I will open another PR if we find any solutions to fix 3rd party related issues.
Note: anything before row 11 were fixed previously after the initial round of tests


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-226