### PR TITLE
GIVCAMP-226 | Typeform a11y fixes

### DIFF
--- a/components/Storyblok/SbTypeform.tsx
+++ b/components/Storyblok/SbTypeform.tsx
@@ -143,8 +143,9 @@ export const SbTypeform = ({
             displayAsFullScreenModal={displayAsFullScreenModal}
             autoResize={resize}
             height={!resize ? embedHeight : undefined}
+            className={styles.fauxCTA}
           >
-            <span className={styles.fauxCTA}>{buttonLabel}</span>
+            {buttonLabel}
           </PopUp>
         </Container>
       );

--- a/components/TypeForm/PopUp.tsx
+++ b/components/TypeForm/PopUp.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useRef } from 'react';
 import { PopupButton } from '@typeform/embed-react';
 import { type PopupOptions } from '@typeform/embed';
 
@@ -11,8 +12,22 @@ export type PopUpProps = PopupOptions & {
 const PopUp = ({
   id, children, className, ...rest
 }:PopUpProps) => {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const handleClose = () => {
+    if (ref.current) {
+      ref.current.focus();
+    }
+  };
+
   return (
-    <PopupButton buttonProps={{ type: 'button' }} noHeading keepSession id={id} className={className} {...rest}>
+    <PopupButton
+      onClose={handleClose}
+      buttonProps={{ type: 'button', ref: ref, className: className }}
+      noHeading keepSession
+      id={id}
+      {...rest}
+    >
       {children}
     </PopupButton>
   );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Typeform pop up button style to the button element instead of a wrapper span, so the focus styles get honored.
- Return focus to the pop up button after modal is closed

# Review By (Date)
- Soonish

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to this story
2. Tab to this button and check that there is focus style (darker red background color, white underline)
![Screenshot 2024-01-26 at 5 35 02 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/0cb7d93c-9027-4c8a-99a5-c77002abaa22)

3. Open the modal
4. Close the modal with the escape button.
5. Check that the focus is back on the pop up button instead of to the top of the page

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-226