### PR TITLE
GIVCAMP-226 | Update Typeform to latest for modal close button a11y issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.1.1",
         "@storyblok/react": "^3.0.8",
-        "@typeform/embed-react": "^3.8.0",
+        "@typeform/embed-react": "^3.11.0",
         "cnbuilder": "^3.1.0",
         "cookies-next": "^4.0.0",
         "framer-motion": "^10.16.4",
@@ -545,19 +545,19 @@
       }
     },
     "node_modules/@typeform/embed": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@typeform/embed/-/embed-4.4.1.tgz",
-      "integrity": "sha512-TMt/X17VzGcQp11TaQiJZei8JFRg8TGJs6xwssWsYhqwqkOPHDa7M5XWjSsGiCT+tun72MDgFDZc8KyVGRA3ew==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@typeform/embed/-/embed-4.5.0.tgz",
+      "integrity": "sha512-k6lLxxOxu+QcWqXkMgsxo2HA2KRyF3gpXEZzN+16LjeyHih8YzY6K7g3w+RPtHBKaV4ld8+7lS9yipaM4etriw==",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/@typeform/embed-react": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@typeform/embed-react/-/embed-react-3.10.0.tgz",
-      "integrity": "sha512-2ELxR0KtvKFTEDAMYQUGkck0TLw2ANdhgy1yZNy/lWlwh6wDyLHGaIAOoHhOLBgEDkTbzg24RPP9N+HR9CR1BA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@typeform/embed-react/-/embed-react-3.11.0.tgz",
+      "integrity": "sha512-FRCtoKoMLvvWxfMmGVtjQVqljPex5K0bw//+fGaR+TrexZgn2ydgj9KNdVhIhTeauwslknxoJ2/ptjpT9NiREA==",
       "dependencies": {
-        "@typeform/embed": "4.4.1",
+        "@typeform/embed": "4.5.0",
         "fast-deep-equal": "^3.1.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@heroicons/react": "^2.1.1",
     "@storyblok/react": "^3.0.8",
-    "@typeform/embed-react": "^3.8.0",
+    "@typeform/embed-react": "^3.11.0",
     "cnbuilder": "^3.1.0",
     "cookies-next": "^4.0.0",
     "framer-motion": "^10.16.4",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update @typeform/embed-react to v3.11.0 since they added an aria-label="Close" to the modal close button
https://github.com/Typeform/embed/issues/635#issuecomment-1916508324


# Review By (Date)
- Retro

# Criticality
- 3

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-214--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
2. Scroll to the "Take my exam" button to open up the typeform modal
3. Inspect the close "x" button
4. Check that you see the aria-label="Close"

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-226
