### PR TITLE
GIVCAMP-283 | Use "Home | Stanford Momentum" as search engine title for homepage

### DIFF
--- a/utilities/getPageMetadata.ts
+++ b/utilities/getPageMetadata.ts
@@ -51,6 +51,7 @@ export const getPageMetadata = ({
   const { siteTitle, siteDescription, siteUrlProd: siteUrl } = config;
 
   const title = seoTitle || pageTitle;
+  const searchTitle = slug === 'home' ? 'Home' : title;
   const description = seoDescription || dek || siteDescription;
   const ogTitle = og_title || title;
   const ogDescription = og_description || description;
@@ -78,7 +79,7 @@ export const getPageMetadata = ({
   const canonical = canonicalNotSelf || selfReferencingUrl;
 
   return {
-    title: `${title} | ${siteTitle}`,
+    title: `${searchTitle} | ${siteTitle}`,
     description: description,
     metadataBase: new URL(config.siteUrlProd),
     openGraph: {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update search engine/browser tab title for homepage so it's Home | Stanford Momentum

# Review By (Date)
- Soon (before Sat real launch)


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-220--giving-campaign.netlify.app/
2. Check the HTML head, see that the browser tab title is `Home | Stanford Momentum`, but the og:title is just `Stanford Momentum`
3. Go to any story, check that the browser tab title is `Story Title | Stanford Momentum`, the og:title is just the story title

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-283