### PR TITLE
NoJira: Remove Editor Token

### DIFF
--- a/app/(editor)/editor/page.tsx
+++ b/app/(editor)/editor/page.tsx
@@ -89,17 +89,14 @@ async function getStoryData({ path }: PageProps['searchParams']): Promise<ISbRes
 /**
  * Validate the editor token.
  *
- * We expect 3 hours as the time of a token being valid.
- * So basically that an editor will work max 3 hours (10800 seconds) on one page
- * before switching to another entry inside the editor or refreshing the browser window.
- * You can extend that by adjusting 10800 with the value you need.
+ * Removed time limit check to support client workflows of several days, or weeks 
+ * of using the preview link for review.
  */
 const validateEditor = (searchParams: PageProps['searchParams']) => {
   const validationString = searchParams['_storyblok_tk[space_id]'] + ':' + process.env.STORYBLOK_PREVIEW_EDITOR_TOKEN + ':' + searchParams['_storyblok_tk[timestamp]'];
   const validationToken = crypto.createHash('sha1').update(validationString).digest('hex');
-  if (searchParams['_storyblok_tk[token]'] == validationToken &&
-      Number(searchParams['_storyblok_tk[timestamp]']) > Math.floor(Date.now()/1000)-10800) {
-      // you're in the edit mode.
+  if (searchParams['_storyblok_tk[token]'] == validationToken) {
+      //You're in the edit mode.
       return true;
   }
   // Something didn't work out.


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Per client request: We really only share them with internal team members and leadership, but do rely on them working/being available for many days, sometimes weeks, for review – particularly by leadership.

This opens up the URL and editor to live for a very long time. The risk associated with this is the possibility of someone getting a hold of the API token and using it against the preview URL to see unpublished content. This is a low-risk item to me as they could also use the same API key to query the API directly to get the same content. The preview URL is just a convenient way. One could also just change the timestamp if they knew.

# Review By (Date)
- End of the week?

# Criticality
- Normal

# Review Tasks

1. Review code
2. Add Preview URL to Storyblok space
3. View content in Storyblok editor
4. Click on the preview button in the Storyblok editor to open up a full page preview
5. Save the URL somewhere and come back 4 hours later to see if it still works