### PR TITLE
GIVCAMP-304 | Add CTA region to Section and Homepage Theme/Story Section

### DIFF
--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
@@ -9,3 +9,4 @@ export const heading = 'fluid-type-7 md:gc-splash mb-0 whitespace-pre-line';
 export const introWrapper = 'cc relative z-20';
 export const intro = 'intro-text *:leading-display *:md:leading-cozy *:text-shadow-sm rs-mt-7 max-w-1000';
 export const contentWrapper = 'relative z-20';
+export const cta = 'relative cc md:flex-row *:mx-auto rs-mt-6 gap-20 lg:gap-27 w-fit';

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
@@ -3,6 +3,7 @@ import { AnimateInView } from '@/components/Animate';
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { CreateBloks } from '@/components/CreateBloks';
+import { FlexBox } from '@/components/FlexBox';
 import { Heading, SrOnlyText, Text } from '@/components/Typography';
 import { Container } from '@/components/Container';
 import { RichText } from '@/components/RichText';
@@ -13,6 +14,7 @@ import * as styles from './SbHomepageThemeSection.styles';
 import {
   bgBlurs, type BgBlurType, gradientFroms, type GradientFromType, gradientTos, type GradientToType,
 } from '@/utilities/datasource';
+import { getNumBloks } from '@/utilities/getNumBloks';
 
 type SbHomepageThemeSectionProps = {
   blok: {
@@ -21,6 +23,7 @@ type SbHomepageThemeSectionProps = {
     heading?: string;
     intro?: StoryblokRichtext;
     content?: SbBlokData[];
+    cta?: SbBlokData[];
     bgImage?: SbImageType;
     bgBlur?: BgBlurType;
     gradientTop?: GradientToType;
@@ -34,6 +37,7 @@ export const SbHomepageThemeSection = ({
     heading,
     intro,
     content,
+    cta,
     bgImage: { filename, focus } = {},
     bgBlur,
     gradientTop,
@@ -137,6 +141,11 @@ export const SbHomepageThemeSection = ({
       <Container pt={8} width="full" className={styles.contentWrapper}>
         <CreateBloks blokSection={content} isDarkTheme />
       </Container>
+      {!!getNumBloks(cta) && (
+        <FlexBox direction="col" className={styles.cta}>
+          <CreateBloks blokSection={cta} />
+        </FlexBox>
+      )}
     </Container>
   );
 };

--- a/components/Storyblok/SbSection/SbSection.styles.ts
+++ b/components/Storyblok/SbSection/SbSection.styles.ts
@@ -1,4 +1,3 @@
-import { header } from '@/components/Scrollytelling';
 import { cnb } from 'cnbuilder';
 
 export type AlignType = 'left' | 'center' | 'right';

--- a/components/Storyblok/SbSection/SbSection.styles.ts
+++ b/components/Storyblok/SbSection/SbSection.styles.ts
@@ -35,4 +35,5 @@ export const subhead = (headerAlign?: AlignType) => cnb('relative z-10 rs-mt-3 '
   'max-w-prose': headerAlign !== 'center',
 });
 export const contentWrapper = 'relative z-10';
+export const cta = 'cc md:flex-row *:mx-auto rs-mt-3 gap-20 lg:gap-27 w-fit';
 export const caption = 'caption *:leading-display mt-08em max-w-prose-wide';

--- a/components/Storyblok/SbSection/SbSection.tsx
+++ b/components/Storyblok/SbSection/SbSection.tsx
@@ -23,6 +23,7 @@ import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities
 import { type SbImageType, type SbColorStopProps } from '../Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { hasRichText } from '@/utilities/hasRichText';
+import { getNumBloks } from '@/utilities/getNumBloks';
 import * as styles from './SbSection.styles';
 
 type SbSectionProps = {
@@ -36,6 +37,7 @@ type SbSectionProps = {
     headingLevel?: HeadingType;
     isSerifHeader?: boolean;
     subheading?: string;
+    cta?: SbBlokData[];
     caption?: StoryblokRichtext;
     captionColumnWidth?: '12' | '10' | '8' | '6' | '4';
     barColor?: {
@@ -61,6 +63,7 @@ export const SbSection = ({
     isSerifHeader,
     headingLevel,
     subheading,
+    cta,
     caption,
     captionColumnWidth,
     barColor: { value: barColorValue } = {},
@@ -182,6 +185,11 @@ export const SbSection = ({
           <Container pt={hasHeader ? 8 : undefined} width="full" className={styles.contentWrapper}>
             <CreateBloks blokSection={content} isDarkTheme={bgColor === 'black'} />
           </Container>
+          {!!getNumBloks(cta) && (
+            <FlexBox direction="col" className={styles.cta}>
+              <CreateBloks blokSection={cta} />
+            </FlexBox>
+          )}
         </Container>
       </m.div>
       {hasRichText(caption) && (


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add optional CTA(s) region after Section and Homepage Theme/Story Section components

# Review By (Date)
- Retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Pull down locally and go to test/yvonne-test-volunteer-leadership-summit
2. Scroll down to below the photo section
3. See that you can add CTA(s) at the bottom of the section that are center aligned like this
![Screenshot 2024-03-04 at 2 17 55 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/13b77c2f-edb0-45c5-b8fc-de204e03d567)
4. Go to test/home-new-test
5. Scroll to the bottom of the Preparing Citizens section
6. CHeck that you can also add CTA(s) at the bottom
![Screenshot 2024-03-04 at 2 26 19 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/35a85756-558b-4ecd-8655-cfee691c0846)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-304