### PR TITLE
GIVCAMP-289: Inline External Script Loading.

### DIFF
--- a/components/Embed/Embed.tsx
+++ b/components/Embed/Embed.tsx
@@ -83,7 +83,7 @@ id, src, content, boundingWidth, spacingTop, spacingBottom, className, width, ..
     );
   }
 
-  return (<p className='bg-red text-white text-3xl'>You must provide either an src or content to the embed</p>);
+  return (<p className='bg-digital-red text-white text-30'>You must provide either an src or content to the embed</p>);
 };
 
 export default Embed;

--- a/components/Embed/Embed.tsx
+++ b/components/Embed/Embed.tsx
@@ -1,0 +1,86 @@
+/**
+ * A NextJS Embed Component
+ *
+ * Credit where credit is deserved.
+ * @see: https://github.com/christo-pr/dangerously-set-html-content
+ *
+ * Use this widget with caution. There are no safeguards on what it can do. It
+ * is also not good practice to inject and manipulate the page outside of
+ * REACT as that can lead to irregularities and troubles.
+ */
+import React, { useRef, useEffect } from 'react';
+import { WidthBox, type WidthType } from '../WidthBox';
+import { type PaddingType } from '@/utilities/datasource';
+
+export interface EmbedProps extends  React.HTMLAttributes<HTMLDivElement> {
+  id?: string;
+  src?: string;
+  content?: string;
+  boundingWidth?: 'site' | 'full';
+  width?: WidthType;
+  spacingTop?: PaddingType;
+  spacingBottom?: PaddingType;
+  className?: string;
+}
+
+const Embed = ({
+id, src, content, boundingWidth, spacingTop, spacingBottom, className, width, ...props
+}:EmbedProps) => {
+
+  const myEmbed = useRef(null);
+
+  useEffect(() => {
+    // If there is no content or src, return.
+    if (!content && !src) return;
+
+    // Clear the container.
+    myEmbed.current.innerHTML = '';
+
+    if (src.length > 1) {
+      // Create a script tag.
+      const script = document.createElement('script');
+      // Set the src to the src provided.
+      script.src = src;
+      myEmbed.current.appendChild(script);
+    }
+
+    if (content.length > 1) {
+      // Create a 'tiny' document and parse the html string.
+      // https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
+      const miniDom = document.createRange().createContextualFragment(content);
+      // Force the scripts in the embed script field to load sync.
+      const scripts = miniDom.querySelectorAll('script');
+      if (scripts.length >= 1) {
+        for (const item of scripts) {
+          if (item.src && item.src.length > 1) {
+            item.async = false;
+            item.defer = false;
+          }
+        }
+      }
+    // Append the new content.
+    myEmbed.current.appendChild(miniDom);
+    }
+
+
+  }, [content, src]);
+
+  if (content) {
+    return (
+      <WidthBox
+        {...props}
+        boundingWidth={boundingWidth}
+        width={width}
+        pt={spacingTop}
+        pb={spacingBottom}
+        className={className}
+      >
+        <div ref={myEmbed} />
+      </WidthBox>
+    );
+  }
+
+  return (<p className='bg-red text-white text-3xl'>You must provide either an src or content to the embed</p>);
+};
+
+export default Embed;

--- a/components/Embed/Embed.tsx
+++ b/components/Embed/Embed.tsx
@@ -32,16 +32,16 @@ id, src, content, boundingWidth, spacingTop, spacingBottom, className, width, ..
   useEffect(() => {
     // If there is no content or src, return.
     if (!content && !src) return;
-
+    const domElement = myEmbed.current;
     // Clear the container.
-    myEmbed.current.innerHTML = '';
+    domElement.innerHTML = '';
 
     if (src.length > 1) {
       // Create a script tag.
       const script = document.createElement('script');
       // Set the src to the src provided.
       script.src = src;
-      myEmbed.current.appendChild(script);
+      domElement.appendChild(script);
     }
 
     if (content.length > 1) {
@@ -59,10 +59,13 @@ id, src, content, boundingWidth, spacingTop, spacingBottom, className, width, ..
         }
       }
     // Append the new content.
-    myEmbed.current.appendChild(miniDom);
+    domElement.appendChild(miniDom);
     }
 
-
+    return () => {
+      // Clean up the script tag.
+      domElement.innerHTML = '';
+    };
   }, [content, src]);
 
   if (content) {

--- a/components/Embed/index.ts
+++ b/components/Embed/index.ts
@@ -1,0 +1,2 @@
+import Embed from './Embed';
+export { Embed };

--- a/components/Storyblok/SbEmbed.tsx
+++ b/components/Storyblok/SbEmbed.tsx
@@ -6,6 +6,10 @@ type SbEmbedProps = {
     _uid: string;
     src?: string;
     content?: string;
+    boundingWidth?: 'site' | 'full';
+    width?: WidthType;
+    spacingTop?: PaddingType;
+    spacingBottom?: PaddingType;
   };
 };
 

--- a/components/Storyblok/SbEmbed.tsx
+++ b/components/Storyblok/SbEmbed.tsx
@@ -1,5 +1,7 @@
 import { storyblokEditable} from '@storyblok/react/rsc';
 import { Embed } from '@/components/Embed';
+import { type WidthType } from '../WidthBox';
+import { type PaddingType } from '@/utilities/datasource';
 
 type SbEmbedProps = {
   blok: {

--- a/components/Storyblok/SbEmbed.tsx
+++ b/components/Storyblok/SbEmbed.tsx
@@ -19,7 +19,7 @@ export const SbEmbed = ({ blok, blok: { _uid } }:SbEmbedProps) => {
 
   return (
     <Embed
-      {...storyblokEditable}
+      {...storyblokEditable(blok)}
       {...blok}
       id={_uid}
     />

--- a/components/Storyblok/SbEmbed.tsx
+++ b/components/Storyblok/SbEmbed.tsx
@@ -1,0 +1,21 @@
+import { storyblokEditable} from '@storyblok/react/rsc';
+import { Embed } from '@/components/Embed';
+
+type SbEmbedProps = {
+  blok: {
+    _uid: string;
+    src?: string;
+    content?: string;
+  };
+};
+
+export const SbEmbed = ({ blok, blok: { _uid } }:SbEmbedProps) => {
+
+  return (
+    <Embed
+      {...storyblokEditable}
+      {...blok}
+      id={_uid}
+    />
+  );
+};

--- a/components/StoryblokProvider.tsx
+++ b/components/StoryblokProvider.tsx
@@ -6,6 +6,7 @@ import { SbBlurryPoster } from '@/components/Storyblok/SbBlurryPoster';
 import { SbCardWysiwyg } from '@/components/Storyblok/SbCardWysiwyg';
 import { SbChangemakerCard } from '@/components/Storyblok/SbChangemakerCard';
 import { SbCta } from '@/components/Storyblok/SbCta';
+import { SbEmbed } from '@/components/Storyblok/SbEmbed';
 import { SbEmbedMedia } from '@/components/Storyblok/SbEmbedMedia';
 import { SbGrid } from '@/components/Storyblok/SbGrid';
 import { SbGridAlternating } from '@/components/Storyblok/SbGridAlternating';
@@ -36,6 +37,7 @@ export const components = {
   sbCardWysiwyg: SbCardWysiwyg,
   sbChangemakerCard: SbChangemakerCard,
   sbCta: SbCta,
+  sbEmbedScript: SbEmbed,
   sbEmbedMedia: SbEmbedMedia,
   sbGrid: SbGrid,
   sbGridAlternating: SbGridAlternating,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allows content authors to embed external scripts and markup inline with content
- Provides container controls
- Added new block to content only for now
- TBD permissions to this block type?

# Review By (Date)
End of the sprint

# Criticality
Normal

# Review Tasks

1. Check out this branch locally and fire up an https dev environment
2. Review the editor at https://app.storyblok.com/#/me/spaces/1005200/stories/0/0/4582847
3. Navigate to the embed script block in the content
4. Review fields, descriptions, and options
5. Navigate to the block library and review the 'Embed Script' component (Atoms -> sbEmbedScript) https://app.storyblok.com/#/me/spaces/1005200/components/145576
6. Try out a few of the options and/or load additional scripts
7. Review code