### PR TITLE
GIVCAMP-297 GIVCAMP-312 | Section background options + add light overlay options

### DIFF
--- a/components/BlurryPoster/BlurryPoster.styles.tsx
+++ b/components/BlurryPoster/BlurryPoster.styles.tsx
@@ -2,7 +2,7 @@ import { cnb } from 'cnbuilder';
 
 export const root = 'relative bg-no-repeat bg-cover overflow-hidden break-words';
 
-export const bgImage = 'absolute top-0 left-0 w-full h-full object-cover';
+export const bgImage = 'absolute top-0 left-0 size-full object-cover';
 
 export const blurWrapper = (
   addBgBlur?: boolean,
@@ -10,7 +10,7 @@ export const blurWrapper = (
   type?: 'hero' | 'poster',
   bgColor?: 'black' | 'white',
 ) => cnb(
-  'relative w-full h-full z-10', {
+  'relative size-full z-10', {
     'backdrop-blur-md' : addBgBlur,
     'lg:from-black-true/20 lg:to-black-true/70': type === 'poster' && addDarkOverlay && bgColor === 'black',
     'lg:bg-none': type === 'poster' && bgColor === 'black' && !addDarkOverlay,

--- a/components/Bookshelf/Book.tsx
+++ b/components/Bookshelf/Book.tsx
@@ -38,7 +38,7 @@ export const Book = ({
         // animate={{ backgroundColor: isOpen ? '#FF0088' : '#0055FF' }}
         className={cnb('group relative transition-colors mr-4 w-120 flex justify-center align-start shrink-0 rounded hocus-visible:underline decoration-white', buttonClassName)}
       >
-        <div className="absolute w-full h-full top-0 right-0 bg-gradient-to-r from-black-90/20 via-transparent to-black-90/20 mix-blend-overlay" />
+        <div className="absolute size-full top-0 right-0 bg-gradient-to-r from-black-90/20 via-transparent to-black-90/20 mix-blend-overlay" />
         <Text
           color="white"
           font="serif"

--- a/components/Bookshelf/BookAlt.tsx
+++ b/components/Bookshelf/BookAlt.tsx
@@ -45,7 +45,7 @@ export const BookAlt = ({
         <img
           src={getProcessedImage(imgSrc, '1600x1300')}
           alt=""
-          className="w-full h-full object-cover object-left-top"
+          className="size-full object-cover object-left-top"
         />
         <span className="absolute block bottom-0 right-0 bg-gradient-to-t from-gc-black via-50% via-gc-black/50 w-full h-2/5 group-hocus-visible:h-1/2 transition-all" />
         <Text

--- a/components/BracketCard/BracketCard.styles.ts
+++ b/components/BracketCard/BracketCard.styles.ts
@@ -27,7 +27,7 @@ export const imageWrapper = (textOnLeft: boolean) => cnb(
 export const imageAspectRatio = 'aspect-w-6 aspect-h-5';
 export const image = 'object-cover group-hocus-within:scale-105 transition-transform';
 export const imageOverlay = (textOnLeft: boolean) => cnb(
-  'hidden sm:block from-black-true/50 via-black-true/20 to-transparent via-20% sm:absolute w-full h-full sm:top-0 sm:left-0',
+  'hidden sm:block from-black-true/50 via-black-true/20 to-transparent via-20% sm:absolute size-full sm:top-0 sm:left-0',
   textOnLeft ? 'bg-gradient-to-r' : 'bg-gradient-to-l',
 );
 

--- a/components/ChangemakerCard/ChangemakerCard.styles.ts
+++ b/components/ChangemakerCard/ChangemakerCard.styles.ts
@@ -1,12 +1,12 @@
 export const root = 'relative w-full max-w-[29rem] sm:max-w-300 lg:max-w-[35rem] mx-auto break-words';
-export const cardInner = 'relative w-full h-full aspect-w-1 aspect-h-2';
+export const cardInner = 'relative size-full aspect-w-1 aspect-h-2';
 
-export const cardFront = 'absolute w-full h-full top-0 left-0';
+export const cardFront = 'absolute size-full top-0 left-0';
 export const imageWrapper = 'overflow-hidden aspect-w-1 aspect-h-2';
-export const info = 'rs-px-1 pb-150 absolute w-full h-full bottom-0 left-0 mb-0';
+export const info = 'rs-px-1 pb-150 absolute size-full bottom-0 left-0 mb-0';
 export const heading = 'mb-02em mt-auto';
 
-export const cardContent = 'absolute w-full h-full top-0 left-0 px-20 py-30 3xl:py-48 3xl:px-36 aria-hidden:opacity-0 opacity-100 backdrop-blur-sm transition-opacity duration-500 bg-gradient-to-b from-gc-black/60 to-gc-black/90 gc-changemaker *:*:*:!mb-1em';
+export const cardContent = 'absolute size-full top-0 left-0 px-20 py-30 3xl:py-48 3xl:px-36 aria-hidden:opacity-0 opacity-100 backdrop-blur-sm transition-opacity duration-500 bg-gradient-to-b from-gc-black/60 to-gc-black/90 gc-changemaker *:*:*:!mb-1em';
 
-export const button = 'group absolute w-full h-full top-0 left-0';
+export const button = 'group absolute size-full top-0 left-0';
 export const icon = 'absolute bottom-40 right-36 text-white w-65 h-65 border-2 border-white rounded-full p-16 group-hocus-visible:border-dashed group-aria-expanded:rotate-45 transition-transform';

--- a/components/FeaturedStories/FeatureMasonry.tsx
+++ b/components/FeaturedStories/FeatureMasonry.tsx
@@ -53,7 +53,7 @@ export const FeatureMasonry = ({
             )}
             overlay="black-10"
           />
-          <div className="absolute top-0 left-0 w-full h-full backdrop-blur-sm" />
+          <div className="absolute top-0 left-0 size-full backdrop-blur-sm" />
           <EmbedMedia
             mediaUrl={audioUrl}
             className="relative z-10 rs-py-6 *:w-4/5 *:mx-auto lg:*:*:aspect-w-2 lg:*:*:aspect-h-1 xl:*:*:aspect-w-4 xl:*:*:aspect-h-1"
@@ -83,11 +83,11 @@ export const FeatureMasonry = ({
             />
           </div>
         </FlexBox>
-        <div className="lg:col-span-6 w-full h-full">
+        <div className="lg:col-span-6 size-full">
           <img
             src={getProcessedImage(imageSrc1, '800x450', imageFocus1)}
             alt={imageAlt1 || ''}
-            className="w-full h-full object-cover"
+            className="size-full object-cover"
           />
         </div>
         <EmbedMedia

--- a/components/Hero/BasicHero.styles.ts
+++ b/components/Hero/BasicHero.styles.ts
@@ -10,8 +10,8 @@ export type HeroPaddingType = keyof typeof heroPaddings;
 
 export const root = 'relative break-words bg-black-70';
 
-export const bgImage = 'absolute top-0 left-0 w-full h-full object-cover';
-export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 w-full h-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
+export const bgImage = 'absolute top-0 left-0 size-full object-cover';
+export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
 
 export const contentWrapper = '*:mx-auto';
 export const superhead = 'relative z-10 xl:max-w-900 mx-auto rs-mb-0 text-shadow-sm';

--- a/components/Hero/StoryHero.styles.ts
+++ b/components/Hero/StoryHero.styles.ts
@@ -85,10 +85,10 @@ export const imageWrapper = (isVerticalHero: boolean, isLeftImage: boolean) => c
 });
 
 export const image = (renderTwoImages: boolean) => cnb(
-  'w-full h-full',
+  'size-full',
   renderTwoImages ? 'hidden lg:block' : '',
 );
-export const mobileImage = 'w-full h-full lg:hidden';
+export const mobileImage = 'size-full lg:hidden';
 
 export const caption = (isVerticalHero: boolean, isLeftImage: boolean) => cnb('text-current rs-mt-0 cc type-0', {
   'lg:pr-0': isVerticalHero && isLeftImage,

--- a/components/Hero/StoryHeroMvp.styles.ts
+++ b/components/Hero/StoryHeroMvp.styles.ts
@@ -22,9 +22,9 @@ export const mobileImageCrops = {
 };
 
 export const image = (renderTwoImages: boolean) => cnb(
-  'w-full h-full',
+  'size-full',
   renderTwoImages ? 'hidden lg:block' : '',
 );
-export const mobileImage = 'w-full h-full lg:hidden';
+export const mobileImage = 'size-full lg:hidden';
 export const captionWrapper = 'mt-06em';
 export const caption = 'caption *:leading-display mt-08em max-w-prose-wide';

--- a/components/Homepage/BelowBlockBanner.tsx
+++ b/components/Homepage/BelowBlockBanner.tsx
@@ -3,7 +3,7 @@ import { Grid } from '../Grid';
 
 export const BelowBlockBanner = ({ children }: { children: React.ReactNode }) => (
   <Container pb={9} className="relative overflow-hidden -mt-200 2xl:-mt-260 bg-gradient-to-t from-gc-black via-90% via-gc-black">
-    <div className="absolute w-full h-full bottom-0 left-0 bg-gradient-to-t from-[#35459A] via-gc-black via-50% z-10" />
+    <div className="absolute size-full bottom-0 left-0 bg-gradient-to-t from-[#35459A] via-gc-black via-50% z-10" />
     <div className="absolute w-full h-1/4 bottom-0 left-0 bg-gradient-to-t from-gc-sky via-[#35459A] z-20" />
     <Grid md={2} gap="default" className="relative md:[&>*:nth-child(even)]:rs-mt-9 2xl:w-11/12 mx-auto z-30">
       {children}

--- a/components/Homepage/Changemaker.tsx
+++ b/components/Homepage/Changemaker.tsx
@@ -20,7 +20,7 @@ export const Changemaker = ({
       style={{ backgroundImage: `url('${bgImage}')` }}
       py={10}
     >
-      <div className="absolute top-0 left-0 w-full h-full bg-gradient-to-t from-gc-black via-sapphire/60" />
+      <div className="absolute top-0 left-0 size-full bg-gradient-to-t from-gc-black via-sapphire/60" />
       <Container className="relative z-10">
         <Heading size="f7" font="serif" leading="tight" align="center" className="max-w-[110rem] mx-auto rs-mb-4">
           <AnimateInView animation="slideInFromRight">

--- a/components/Homepage/HomepageSplitHero.styles.ts
+++ b/components/Homepage/HomepageSplitHero.styles.ts
@@ -2,14 +2,14 @@ export const root = 'relative overflow-hidden';
 export const imageGridWrapper = 'relative max-h-[180rem] bg-black-true pt-170 sm:pt-[24vw] 2xl:pt-[16vw] 4xl:pt-[32rem] pb-[50vw] sm:pb-[40vw] 2xl:pb-[36vw] 4xl:pb-[64rem]';
 export const mobileBg = 'sm:hidden';
 export const bg = 'hidden sm:block';
-export const gradientOverlay = 'absolute top-0 left-0 w-full h-full bg-gradient-to-bl from-[#001c36ab] via-transparent via-60%';
+export const gradientOverlay = 'absolute top-0 left-0 size-full bg-gradient-to-bl from-[#001c36ab] via-transparent via-60%';
 export const imageGrid = 'relative w-11/12 sm:w-[70vw] mx-auto 4xl:max-w-[140rem]';
 export const imageWrapper = 'relative w-full aspect-w-2 aspect-h-3 sm:aspect-w-1 sm:aspect-h-1';
 
-export const imageTopLayerCommon = 'absolute top-0 right-0 w-full h-full object-cover mix-blend-lighten -scale-x-100';
-export const imageBottomLayerCommon = 'w-full h-full object-cover';
+export const imageTopLayerCommon = 'absolute top-0 right-0 size-full object-cover mix-blend-lighten -scale-x-100';
+export const imageBottomLayerCommon = 'size-full object-cover';
 
-export const textFlexbox = 'absolute w-full h-full top-0 left-0 cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)]';
+export const textFlexbox = 'absolute size-full top-0 left-0 cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)]';
 export const textWrapperTop = 'relative -top-60 sm:-top-[10vw] xl:-top-[8vw] 4xl:-top-[15rem] right-0';
 export const textWrapperBottom = 'relative top-[12%]';
 export const serifText = 'text-[clamp(2.5rem,2.74vw+1.51rem,7rem)]';

--- a/components/ImageOverlay.tsx
+++ b/components/ImageOverlay.tsx
@@ -43,13 +43,13 @@ export const ImageOverlay = ({
       loading={loading}
       width={width}
       height={height}
-      className={cnb('absolute w-full h-full object-cover top-0 left-0', className)}
+      className={cnb('absolute size-full object-cover top-0 left-0', className)}
       {...props}
     />
     {overlay && (
       <div
         className={cnb(
-          'absolute w-full h-full top-0 left-0',
+          'absolute size-full top-0 left-0',
           overlays[overlay],
           overlayClasses,
         )}

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -1,12 +1,12 @@
 import { cnb } from 'cnbuilder';
 
-export const root = 'group relative w-full h-full @container';
+export const root = 'group relative size-full @container';
 
 export const topWrapper = 'relative @320:text-18 @sm:text-21 @md:text-23';
 
 export const imageWrapper = 'bg-gc-black transition-all aspect-w-1 aspect-h-1 sm:aspect-w-3 sm:aspect-h-4 overflow-hidden';
 
-export const image = 'object-cover backface-hidden w-full h-full group-hocus-within:scale-105 transition-transform will-change-transform';
+export const image = 'object-cover backface-hidden size-full group-hocus-within:scale-105 transition-transform will-change-transform';
 
 export const heading = 'absolute bottom-0 w-full bg-black-true/60 text-white rs-p-1 mb-0 group-hocus-within:bg-black-true/70 group-hocus-within:border-y-4 border-transparent group-hocus-within:border-white transition-all text-shadow-sm group-hocus-within:rs-py-2';
 

--- a/components/LocalFooter/LocalFooterMvp.styles.tsx
+++ b/components/LocalFooter/LocalFooterMvp.styles.tsx
@@ -1,5 +1,5 @@
 export const root = 'relative overflow-hidden bg-no-repeat bg-bottom bg-cover md:bg-contain';
-export const overlay = 'absolute top-0 left-0 w-full h-full bg-gradient-to-b from-gc-black via-gc-black/80 to-gc-black/40';
+export const overlay = 'absolute top-0 left-0 size-full bg-gradient-to-b from-gc-black via-gc-black/80 to-gc-black/40';
 export const flexWrapper = 'items-start lg:items-center relative z-10 w-full';
 export const logo = 'scale-125 origin-left sm:scale-100 text-[1.67em] md:text-[1.72em] lg:text-[1.9em]';
 export const ul = 'list-unstyled divide-x divide-white *:inline-block *:mb-0 *:px-16 md:*:px-30 xl:*:px-48 *:leading-display first:*:pl-0 last:*:pr-0 lg:mx-auto w-fit rs-mt-2 gap-y-10';

--- a/components/MomentPoster/MomentPoster.styles.ts
+++ b/components/MomentPoster/MomentPoster.styles.ts
@@ -3,8 +3,8 @@ import { cnb } from 'cnbuilder';
 export const root = 'relative overflow-hidden';
 export const wrapper = 'relative w-full z-10';
 
-export const bgImage = 'absolute top-0 left-0 w-full h-full object-cover';
-export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 w-full h-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
+export const bgImage = 'absolute top-0 left-0 size-full object-cover';
+export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
 
 export const contentWrapper = 'lg:rs-pr-9 ml-0';
 

--- a/components/MomentPoster/MomentPoster.styles.ts
+++ b/components/MomentPoster/MomentPoster.styles.ts
@@ -4,7 +4,7 @@ export const root = 'relative overflow-hidden';
 export const wrapper = 'relative w-full z-10';
 
 export const bgImage = 'absolute top-0 left-0 size-full object-cover';
-export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
+export const overlay = (hasBgGradient: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
 
 export const contentWrapper = 'lg:rs-pr-9 ml-0';
 
@@ -14,7 +14,7 @@ export const headingWrapper = 'mx-auto w-fit gap-02em';
 export const thumbnailWrapper = 'inline-block';
 export const thumbnail = 'size-[0.75em]';
 
-export const body = 'max-w-prose mx-auto rs-mt-3 *:*:text-center text-balance mb-0 *:*:text-shadow-sm';
+export const body = (isDarktheme: boolean) => cnb('max-w-prose mx-auto rs-mt-3 *:*:text-center text-balance mb-0', isDarktheme && 'text-shadow-sm');
 
 export const cta = (isStackedCtas: boolean) => cnb(
   'gap-27 mx-auto w-fit *:mx-auto rs-mt-4', !isStackedCtas && 'md:flex-row',

--- a/components/MomentPoster/MomentPoster.tsx
+++ b/components/MomentPoster/MomentPoster.tsx
@@ -88,6 +88,7 @@ export const MomentPoster = ({
           <img
             src={getProcessedImage(bgImageSrc, bgBlur !== 'none' ? '1200x800' : '1800x1200', bgImageFocus)}
             alt=""
+            loading="lazy"
             width={1800}
             height={1200}
             className={styles.bgImage}

--- a/components/MomentPoster/MomentPoster.tsx
+++ b/components/MomentPoster/MomentPoster.tsx
@@ -28,6 +28,7 @@ type MomentPosterProps = HTMLAttributes<HTMLDivElement> & {
   bgImageFocus?: string;
   thumbnailSrc?: string;
   thumbnailFocus?: string;
+  isDarkTheme?: boolean;
   gradientTop?: GradientToType;
   gradientBottom?: GradientFromType;
   gradientVia?: GradientViaType;
@@ -46,6 +47,7 @@ export const MomentPoster = ({
   bgImageFocus,
   thumbnailSrc,
   thumbnailFocus,
+  isDarkTheme,
   gradientTop,
   gradientBottom,
   gradientVia,
@@ -57,7 +59,7 @@ export const MomentPoster = ({
   const hasBgGradient = !!gradientTop && !!gradientBottom;
 
   return (
-    <Container {...props} as="section" bgColor="black" width="full" py={8} className={styles.root}>
+    <Container {...props} as="section" bgColor={isDarkTheme ? 'black' : 'white'} width="full" py={8} className={styles.root}>
       {!!bgImageSrc && (
         <picture>
           <source
@@ -143,7 +145,6 @@ export const MomentPoster = ({
               font="serif"
               align="center"
               leading="display"
-              color="white"
             >
               {subhead}
             </Text>
@@ -151,7 +152,7 @@ export const MomentPoster = ({
         )}
         {body && (
           <AnimateInView animation="slideUp" delay={0.3}>
-            <Text font="serif" variant="big" weight="normal" className={styles.body}>
+            <Text font="serif" variant="big" weight="normal" className={styles.body(isDarkTheme)}>
               {body}
             </Text>
           </AnimateInView>

--- a/components/Scrollytelling/Scrollytelling.styles.ts
+++ b/components/Scrollytelling/Scrollytelling.styles.ts
@@ -23,8 +23,8 @@ export type OverlayType = keyof typeof overlays;
 
 export const wrapper = 'relative';
 export const imageWrapper = 'sticky top-0 h-screen w-full z-0';
-export const image = 'absolute w-full h-full object-cover top-0 left-0 z-0';
-export const imageOverlay = (overlay?: OverlayType) => cnb('absolute w-full h-full top-0 left-0 z-0 bg-black-true/50', overlays[overlay]);
+export const image = 'absolute size-full object-cover top-0 left-0 z-0';
+export const imageOverlay = (overlay?: OverlayType) => cnb('absolute size-full top-0 left-0 z-0 bg-black-true/50', overlays[overlay]);
 
 export const content = 'relative z-10 cc text-white rs-py-10';
 export const contentWrapper = (contentAlign: ContentAlignType) => cnb('w-full mx-auto md:w-2/3 xl:w-1/2', {

--- a/components/Scrollytelling/ScrollytellingDemo.tsx
+++ b/components/Scrollytelling/ScrollytellingDemo.tsx
@@ -95,14 +95,14 @@ export const ScrollytellingDemo = () => {
               Chapter 2
             </Text>
           </div>
-          <div className="w-full h-full">
+          <div className="size-full">
             <figure className="relative h-full w-full overflow-hidden">
               {section4InView && (
                 <>
                   <img
                     loading="eager"
                     src={getProcessedImage('https://a-us.storyblok.com/f/1005200/4240x4211/1319d3cf69/antennae_galaxies_reloaded.jpg', '2000x0')}
-                    className="relative object-cover w-full h-full"
+                    className="relative object-cover size-full"
                     alt=""
                   />
                   <figcaption
@@ -119,7 +119,7 @@ export const ScrollytellingDemo = () => {
                   <m.img
                     loading="eager"
                     src={getProcessedImage('https://a-us.storyblok.com/f/1005200/3600x2085/f78572796c/main_image_star-forming_region_carina_nircam_final-5mb.jpg', '3000x0')}
-                    className="relative object-cover w-full h-full object-left"
+                    className="relative object-cover size-full object-left"
                     alt=""
                     style={{ scale: animateImage5Scale, x: animateImage5XPan, y: animateImage5YPan }}
                   />
@@ -147,7 +147,7 @@ export const ScrollytellingDemo = () => {
                     muted
                     loop
                     aria-label="video of milky way rotating"
-                    className="block w-full h-full object-cover"
+                    className="block size-full object-cover"
                   >
                     <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/80ddd8341f/starloop.webm')} type="video/webm" />
                     <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/1a881ffc0a/starloop.mp4')} type="video/mp4" />

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -16,7 +16,7 @@ export const cardWrapper = (isHorizontal: boolean) => cnb(
 
 export const imageWrapper = 'transition-all aspect-w-1 aspect-h-1 overflow-hidden';
 
-export const image = 'object-cover w-full h-full group-hocus-within:scale-105 transition-transform';
+export const image = 'object-cover size-full group-hocus-within:scale-105 transition-transform';
 
 export const contentWrapper = (isHorizontal: boolean) => cnb({
   'rs-pr-4 rs-py-4': isHorizontal,

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -20,5 +20,5 @@ export const root = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : ''
 export const animateWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const figure = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const imageWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
-export const image = 'w-full h-full object-cover';
+export const image = 'size-full object-cover';
 export const caption = '*:*:leading-display caption mt-1em max-w-prose-wide';

--- a/components/StoryPoC/BrochureChapter2.tsx
+++ b/components/StoryPoC/BrochureChapter2.tsx
@@ -24,7 +24,7 @@ export const BrochureChapter2 = () => {
               <div className="overflow-hidden grow">
                 <img
                   src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2560x1708/640416d93f/charm_lab_1345_cmyk.jpg', '1000x1000')}
-                  className="object-cover w-full h-full"
+                  className="object-cover size-full"
                   alt=""
                 />
               </div>
@@ -80,7 +80,7 @@ export const BrochureChapter2 = () => {
               <div className="relative">
                 <img
                   src={getProcessedImage('https://a-us.storyblok.com/f/1005200/4000x2667/70562b0528/180914-1368_cmyk.jpg', '1500x1000')}
-                  className="object-cover w-full h-full object-left"
+                  className="object-cover size-full object-left"
                   loading="eager"
                   alt=""
                 />
@@ -91,7 +91,7 @@ export const BrochureChapter2 = () => {
               <div className="relative">
                 <img
                   src={getProcessedImage('https://a-us.storyblok.com/f/1005200/1858x1202/7a7e53079e/070201-021_cmyk.jpg', '1000x1000')}
-                  className="object-cover w-full h-full"
+                  className="object-cover size-full"
                   loading="eager"
                   alt=""
                 />
@@ -124,7 +124,7 @@ export const BrochureChapter2 = () => {
                 <div className="overflow-hidden grow">
                   <img
                     src={getProcessedImage('https://a-us.storyblok.com/f/1005200/7211x4810/bca2dd7c52/20220217_the_faces_of_ruth_asawa_n6a0428_cmyk.jpg', '1000x1000')}
-                    className="object-cover w-full h-full"
+                    className="object-cover size-full"
                     alt=""
                   />
                 </div>

--- a/components/StoryPoC/BrochureStory.tsx
+++ b/components/StoryPoC/BrochureStory.tsx
@@ -59,7 +59,7 @@ export const BrochureStory = () => {
                 <div className="overflow-hidden grow">
                   <img
                     src={getProcessedImage('https://a-us.storyblok.com/f/1005200/883x1040/d7d568e264/21664-15-0029_cmyk-1.jpg', '1000x1000')}
-                    className="object-cover w-full h-full"
+                    className="object-cover size-full"
                     alt=""
                   />
                 </div>
@@ -116,7 +116,7 @@ export const BrochureStory = () => {
                   <div className="overflow-hidden grow">
                     <img
                       src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2560x1708/e68ba35533/farm_1193_cmyk.jpg', '1000x1000')}
-                      className="object-cover w-full h-full"
+                      className="object-cover size-full"
                       alt=""
                     />
                   </div>

--- a/components/StoryPoC/ProgressStory.tsx
+++ b/components/StoryPoC/ProgressStory.tsx
@@ -14,7 +14,7 @@ export const ProgressStory = () => {
           src={getProcessedImage('https://a-us.storyblok.com/f/1005200/1901x1643/e36a942af8/progress-dish-cropped.jpg', '2000x0')}
           alt=""
           loading="eager"
-          className="absolute w-full h-full object-cover object-top top-0 left-0"
+          className="absolute size-full object-cover object-top top-0 left-0"
         />
         <Grid lg={12} className="relative" gap="default">
           <AnimateInView animation="slideUp" className="relative z-10 max-w-1200 col-span-12 2xl:col-start-2 2xl:col-span-8">
@@ -37,10 +37,10 @@ export const ProgressStory = () => {
           src={getProcessedImage('https://a-us.storyblok.com/f/1005200/4000x2250/0c54166208/vlad-hilitanu-pt7qzb4zlww-unsplash.jpg', '2000x2000')}
           alt=""
           loading="eager"
-          className="relative w-full h-full object-cover object-top"
+          className="relative size-full object-cover object-top"
         />
         <div
-          className="absolute w-full h-full top-0 left-0 bg-gradient-to-b from-[#020002] via-transparent via-40% to-gc-black z-10"
+          className="absolute size-full top-0 left-0 bg-gradient-to-b from-[#020002] via-transparent via-40% to-gc-black z-10"
         />
         <div className="absolute top-0 r-0 w-full 3xl:px-100 z-20">
           <Grid lg={12} className="w-full" gap="default">
@@ -87,10 +87,10 @@ export const ProgressStory = () => {
           src={getProcessedImage('https://a-us.storyblok.com/f/1005200/2100x1350/02b8df40d3/21664-12-0011_cmyk-1.jpg', '2000x1200')}
           alt=""
           loading="eager"
-          className="relative w-full h-full object-cover object-top"
+          className="relative size-full object-cover object-top"
         />
         <div
-          className="absolute w-full h-full top-0 left-0 bg-gradient-to-b from-gc-black via-gc-black/20 via-40% to-gc-black z-10"
+          className="absolute size-full top-0 left-0 bg-gradient-to-b from-gc-black via-gc-black/20 via-40% to-gc-black z-10"
         />
         <div className="absolute top-0 r-0 w-full 3xl:px-100 z-20">
           <Grid lg={12} className="w-full" gap="default">

--- a/components/StoryPoC/VideoScrollStory.tsx
+++ b/components/StoryPoC/VideoScrollStory.tsx
@@ -28,7 +28,7 @@ export const VideoScrollStory = () => {
           muted
           loop
           aria-label="Background Video"
-          className="block w-full h-full object-cover"
+          className="block size-full object-cover"
         >
           <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/80ddd8341f/starloop.webm')} type="video/webm" />
           <source src={getMaskedAsset('https://a-us.storyblok.com/f/1005200/x/1a881ffc0a/starloop.mp4')} type="video/mp4" />
@@ -36,9 +36,9 @@ export const VideoScrollStory = () => {
         </video>
         <m.div
           style={{ backgroundColor: colorChange }}
-          className="absolute top-0 r-0 w-full h-full mix-blend-overlay"
+          className="absolute top-0 r-0 size-full mix-blend-overlay"
         />
-        <div className="absolute top-0 r-0 w-full h-full bg-gc-black mix-blend-soft-light" />
+        <div className="absolute top-0 r-0 size-full bg-gc-black mix-blend-soft-light" />
       </div>
       <div ref={contentRef} className="relative w-2/3 lg:w-1/3 mx-auto text-white z-10 rs-py-10 -mt-[80vh]">
         <section>

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
@@ -2,11 +2,11 @@ import { cnb } from 'cnbuilder';
 
 export const root = 'relative overflow-hidden';
 export const bgImage = 'absolute top-0 left-0 size-full object-cover';
-export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b' : '');
+export const overlay = (hasBgGradient: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b' : '');
 export const header = 'relative overflow-hidden cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)] z-20';
-export const superhead = 'text-shadow-sm';
+export const superhead = (isDarkTheme: boolean) => isDarkTheme && 'text-shadow-sm';
 export const heading = 'fluid-type-7 md:gc-splash mb-0 whitespace-pre-line';
 export const introWrapper = 'cc relative z-20';
-export const intro = 'intro-text *:leading-display *:md:leading-cozy *:text-shadow-sm rs-mt-7 max-w-1000';
+export const intro = (isDarkTheme: boolean) => cnb('intro-text *:leading-display *:md:leading-cozy rs-mt-7 max-w-1000', isDarkTheme && 'text-shadow-sm');
 export const contentWrapper = 'relative z-20';
 export const cta = 'relative cc md:flex-row *:mx-auto rs-mt-6 gap-20 lg:gap-27 w-fit';

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
@@ -1,8 +1,8 @@
 import { cnb } from 'cnbuilder';
 
 export const root = 'relative overflow-hidden';
-export const bgImage = 'absolute top-0 left-0 w-full h-full object-cover';
-export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 w-full h-full z-10', hasBgGradient ? 'bg-gradient-to-b' : '');
+export const bgImage = 'absolute top-0 left-0 size-full object-cover';
+export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b' : '');
 export const header = 'relative overflow-hidden cc 3xl:px-100 4xl:px-[calc((100%-1800px)/2)] z-20';
 export const superhead = 'text-shadow-sm';
 export const heading = 'fluid-type-7 md:gc-splash mb-0 whitespace-pre-line';

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
@@ -31,6 +31,7 @@ type SbHomepageThemeSectionProps = {
     intro?: StoryblokRichtext;
     content?: SbBlokData[];
     cta?: SbBlokData[];
+    isDarkTheme?: boolean;
     bgImage?: SbImageType;
     bgBlur?: BgBlurType;
     gradientTop?: GradientToType;
@@ -46,6 +47,7 @@ export const SbHomepageThemeSection = ({
     intro,
     content,
     cta,
+    isDarkTheme,
     bgImage: { filename, focus } = {},
     bgBlur,
     gradientTop,
@@ -59,7 +61,7 @@ export const SbHomepageThemeSection = ({
   return (
     <Container
       as="section"
-      bgColor="black"
+      bgColor={isDarkTheme ? 'black' : 'white'}
       py={10}
       width="full"
       className={styles.root}
@@ -121,7 +123,8 @@ export const SbHomepageThemeSection = ({
             leading="tight"
             font="serif"
             weight="semibold"
-            className={styles.superhead}
+            color={isDarkTheme ? 'white' : 'black'}
+            className={styles.superhead(isDarkTheme)}
             aria-hidden={!!heading}
           >
             {superhead}
@@ -133,6 +136,7 @@ export const SbHomepageThemeSection = ({
             leading="none"
             uppercase
             font="druk"
+            color={isDarkTheme ? 'white' : 'black'}
             className={styles.heading}
           >
             {superhead && <SrOnlyText>{`${superhead}:`}</SrOnlyText>}{heading}
@@ -143,13 +147,13 @@ export const SbHomepageThemeSection = ({
         <AnimateInView animation="slideUp" delay={0.2} className={styles.introWrapper}>
           <RichText
             wysiwyg={intro}
-            textColor="white"
-            className={styles.intro}
+            textColor={isDarkTheme ? 'white' : 'black'}
+            className={styles.intro(isDarkTheme)}
           />
         </AnimateInView>
       )}
       <Container pt={8} width="full" className={styles.contentWrapper}>
-        <CreateBloks blokSection={content} isDarkTheme />
+        <CreateBloks blokSection={content} isDarkTheme={isDarkTheme} />
       </Container>
       {!!getNumBloks(cta) && (
         <FlexBox direction="col" className={styles.cta}>

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
@@ -12,7 +12,14 @@ import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { hasRichText } from '@/utilities/hasRichText';
 import * as styles from './SbHomepageThemeSection.styles';
 import {
-  bgBlurs, type BgBlurType, gradientFroms, type GradientFromType, gradientTos, type GradientToType,
+  gradientFroms,
+  type GradientFromType,
+  gradientTos,
+  type GradientToType,
+  gradientVias,
+  type GradientViaType,
+  bgBlurs,
+  type BgBlurType,
 } from '@/utilities/datasource';
 import { getNumBloks } from '@/utilities/getNumBloks';
 
@@ -28,6 +35,7 @@ type SbHomepageThemeSectionProps = {
     bgBlur?: BgBlurType;
     gradientTop?: GradientToType;
     gradientBottom?: GradientFromType;
+    gradientVia?: GradientViaType;
   };
 };
 
@@ -42,6 +50,7 @@ export const SbHomepageThemeSection = ({
     bgBlur,
     gradientTop,
     gradientBottom,
+    gradientVia,
   },
   blok,
 }: SbHomepageThemeSectionProps) => {
@@ -99,6 +108,7 @@ export const SbHomepageThemeSection = ({
                 bgBlurs[bgBlur],
                 gradientFroms[gradientTop],
                 gradientTos[gradientBottom],
+                gradientVias[gradientVia],
               )}
             />
           )}

--- a/components/Storyblok/SbMomentPoster.tsx
+++ b/components/Storyblok/SbMomentPoster.tsx
@@ -24,6 +24,7 @@ type SbMomentPosterProps = {
     cta?: SbBlokData[];
     bgImage?: SbImageType;
     thumbnail?: SbImageType;
+    isDarkTheme?: boolean;
     gradientTop?: GradientToType;
     gradientBottom?: GradientFromType;
     gradientVia?: GradientViaType;
@@ -42,6 +43,7 @@ export const SbMomentPoster = ({
     cta,
     bgImage: { filename, focus } = {},
     thumbnail: { filename: thumbnailFilename, focus: thumbnailFocus } = {},
+    isDarkTheme,
     gradientTop,
     gradientBottom,
     gradientVia,
@@ -51,7 +53,7 @@ export const SbMomentPoster = ({
   blok,
 }: SbMomentPosterProps) => {
   const Cta = !!getNumBloks(cta) ? <CreateBloks blokSection={cta} /> : undefined;
-  const Body = hasRichText(body) ? <RichText wysiwyg={body} textColor="white" /> : undefined;
+  const Body = hasRichText(body) ? <RichText wysiwyg={body} textColor={isDarkTheme ? 'white' : 'black'} /> : undefined;
 
   return (
     <MomentPoster
@@ -66,6 +68,7 @@ export const SbMomentPoster = ({
       bgImageFocus={focus}
       thumbnailSrc={thumbnailFilename}
       thumbnailFocus={thumbnailFocus}
+      isDarkTheme={isDarkTheme}
       gradientTop={gradientTop}
       gradientBottom={gradientBottom}
       gradientVia={gradientVia}

--- a/components/Storyblok/SbSection/SbSection.styles.ts
+++ b/components/Storyblok/SbSection/SbSection.styles.ts
@@ -37,5 +37,5 @@ export const contentWrapper = 'relative z-10';
 export const cta = 'cc md:flex-row *:mx-auto rs-mt-3 gap-20 lg:gap-27 w-fit';
 export const caption = 'caption *:leading-display mt-08em max-w-prose-wide';
 
-export const bgImage = 'absolute top-0 left-0 w-full h-full object-cover';
-export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 w-full h-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
+export const bgImage = 'absolute top-0 left-0 size-full object-cover';
+export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');

--- a/components/Storyblok/SbSection/SbSection.styles.ts
+++ b/components/Storyblok/SbSection/SbSection.styles.ts
@@ -36,3 +36,6 @@ export const subhead = (headerAlign?: AlignType) => cnb('relative z-10 rs-mt-3 '
 export const contentWrapper = 'relative z-10';
 export const cta = 'cc md:flex-row *:mx-auto rs-mt-3 gap-20 lg:gap-27 w-fit';
 export const caption = 'caption *:leading-display mt-08em max-w-prose-wide';
+
+export const bgImage = 'absolute top-0 left-0 w-full h-full object-cover';
+export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 w-full h-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');

--- a/components/Storyblok/SbSection/SbSection.tsx
+++ b/components/Storyblok/SbSection/SbSection.tsx
@@ -24,6 +24,16 @@ import { type SbImageType, type SbColorStopProps } from '../Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { hasRichText } from '@/utilities/hasRichText';
 import { getNumBloks } from '@/utilities/getNumBloks';
+import {
+  gradientFroms,
+  type GradientFromType,
+  gradientTos,
+  type GradientToType,
+  gradientVias,
+  type GradientViaType,
+  bgBlurs,
+  type BgBlurType,
+} from '@/utilities/datasource';
 import * as styles from './SbSection.styles';
 
 type SbSectionProps = {
@@ -45,6 +55,10 @@ type SbSectionProps = {
     }
     bgColor?: BgColorType;
     bgImage?: SbImageType;
+    gradientTop?: GradientToType;
+    gradientBottom?: GradientFromType;
+    gradientVia?: GradientViaType;
+    bgBlur?: BgBlurType;
     bgColorStops?: SbColorStopProps[];
     paddingTop?: PaddingType;
     paddingBottom?: PaddingType;
@@ -69,6 +83,10 @@ export const SbSection = ({
     barColor: { value: barColorValue } = {},
     bgColor,
     bgImage: { filename, focus } = {},
+    gradientTop,
+    gradientBottom,
+    gradientVia,
+    bgBlur,
     bgColorStops,
     paddingTop,
     paddingBottom,
@@ -78,6 +96,8 @@ export const SbSection = ({
   blok,
 }: SbSectionProps) => {
   const hasHeader = heading || superhead || subheading;
+  // To render a dark overlay, both a top and bottom gradient color must be selected
+  const hasBgGradient = !!gradientTop && !!gradientBottom;
 
   const ref = useRef<HTMLDivElement>(null);
   const stops = [];
@@ -126,10 +146,52 @@ export const SbSection = ({
           pb={paddingBottom}
           className={styles.wrapper}
         >
-          {filename && (
-            <ImageOverlay
-              imageSrc={getProcessedImage(filename, '2100x1400', focus)}
-              overlay={bgColor === 'black' ? 'black-50' : 'white-90'}
+          {!!filename && (
+            <picture>
+              <source
+                srcSet={getProcessedImage(filename, bgBlur !== 'none' ? '1200x800' : '2100x1400', focus)}
+                media="(min-width: 1200px)"
+                // Exact height and width don't matter as long as aspect ratio is the same as the image
+                width={2100}
+                height={1400}
+              />
+              <source
+                srcSet={getProcessedImage(filename, bgBlur !== 'none' ? '600x600' : '1200x1200', focus)}
+                media="(min-width: 768px)"
+                width={1200}
+                height={1200}
+              />
+              <source
+                srcSet={getProcessedImage(filename, bgBlur !== 'none' ? '400x600' : '800x1200', focus)}
+                media="(min-width: 461px)"
+                width={800}
+                height={1200}
+              />
+              <source
+                srcSet={getProcessedImage(filename, bgBlur !== 'none' ? '230x460' : '460x920', focus)}
+                media="(max-width: 460px)"
+                width={460}
+                height={920}
+              />
+              <img
+                src={getProcessedImage(filename, bgBlur !== 'none' ? '1200x800' : '1800x1200', focus)}
+                alt=""
+                width={1800}
+                height={1200}
+                className={styles.bgImage}
+              />
+            </picture>
+          )}
+          {/* Render the overlay if there's a background image, and if background blur or/and gradient is selected */}
+          {!!filename && (bgBlur !== 'none' || hasBgGradient) && (
+            <div
+              className={cnb(
+                styles.overlay(hasBgGradient),
+                bgBlurs[bgBlur],
+                gradientFroms[gradientTop],
+                gradientVias[gradientVia],
+                gradientTos[gradientBottom],
+              )}
             />
           )}
           {(heading || superhead) && (
@@ -174,7 +236,7 @@ export const SbSection = ({
                 font={isSerifHeader ? 'serif' : 'sans'}
                 weight={isSerifHeader ? 'semibold' : 'normal'}
                 align={headerAlign}
-                color={bgColor === 'black' ? 'black-20' : 'black-80'}
+                color={bgColor === 'black' ? 'black-20' : 'black-90'}
                 noMargin
                 className={styles.subhead(headerAlign)}
               >

--- a/components/Temporary/DemoContent.tsx
+++ b/components/Temporary/DemoContent.tsx
@@ -10,7 +10,7 @@ export const DemoContent = () => (
     <div className="h-400 lg:h-600 overflow-hidden relative">
       <Parallax>
         <div style={{ backgroundImage: 'url(https://www.space.com/images/i/000/082/219/original/VLT-Pano-MCloudsMilkyWay_6068-net.jpg?interpolation=lanczos-none&fit=around|1024:1024' }} className="-mt-100 h-800 flex items-center justify-center bg-center bg-cover" />
-        <div className="absolute top-0 left-0 w-full h-full block bg-black-true/40" />
+        <div className="absolute top-0 left-0 size-full block bg-black-true/40" />
       </Parallax>
       <div className="absolute top-1/2 left-1/2 translate-x-[-50%] translate-y-[-50%] text-shadow-lg z-10 max-w-800">
         <Text leading="none" align="center" font="druk-wide" size={7} color="white" weight="bold" className="">To infinity and beyond</Text>
@@ -117,7 +117,7 @@ export const DemoContent = () => (
     <div className="h-400 lg:h-600 overflow-hidden relative">
       <Parallax>
         <div style={{ backgroundImage: 'url(https://upload.wikimedia.org/wikipedia/commons/0/00/Crab_Nebula.jpg' }} className="-mt-100 h-800 flex items-center justify-center bg-center bg-cover" />
-        <div className="absolute top-0 left-0 w-full h-full block bg-black-true/40" />
+        <div className="absolute top-0 left-0 size-full block bg-black-true/40" />
       </Parallax>
       <div className="absolute top-1/2 left-1/2 translate-x-[-50%] translate-y-[-50%] z-10">
         <CtaLink

--- a/components/TexturedBar/TexturedBar.tsx
+++ b/components/TexturedBar/TexturedBar.tsx
@@ -23,7 +23,7 @@ export const TexturedBar = ({
       width={3000}
       height={60}
       sizes="100vw"
-      className="w-full h-full object-cover"
+      className="size-full object-cover"
     />
   </div>
 );

--- a/components/ThemeCard/ThemeCard.styles.tsx
+++ b/components/ThemeCard/ThemeCard.styles.tsx
@@ -4,7 +4,7 @@ export const cardWrapper = 'group relative';
 
 export const imageWrapper = 'transition-all aspect-w-1 aspect-h-1 overflow-hidden';
 
-export const image = 'object-cover w-full h-full group-hocus-within:scale-105 transition-transform';
+export const image = 'object-cover size-full group-hocus-within:scale-105 transition-transform';
 
 export const heading = 'mt-06em rs-mb-neg1 text-current';
 

--- a/components/Typography/typography.styles.ts
+++ b/components/Typography/typography.styles.ts
@@ -62,6 +62,7 @@ export const textColors = {
   'black-40': 'text-black-40',
   'black-60': 'text-black-60',
   'black-80': 'text-black-80',
+  'black-90': 'text-black-90',
 };
 
 export const textVariants = {

--- a/components/VerticalPoster/VerticalPoster.styles.ts
+++ b/components/VerticalPoster/VerticalPoster.styles.ts
@@ -1,7 +1,7 @@
 import { cnb } from 'cnbuilder';
 
 export const root = 'relative overflow-hidden break-words';
-export const blurWrapper = 'w-full h-full backdrop-blur-md';
+export const blurWrapper = 'size-full backdrop-blur-md';
 
 export const grid = 'w-full';
 

--- a/utilities/datasource.ts
+++ b/utilities/datasource.ts
@@ -79,6 +79,16 @@ export const gradientTos = {
   'black-80': 'to-black-true/80',
   'black-90': 'to-black-true/90',
   'gc-black': 'to-gc-black',
+  'white-10': 'to-white/10',
+  'white-20': 'to-white/20',
+  'white-30': 'to-white/30',
+  'white-40': 'to-white/40',
+  'white-50': 'to-white/50',
+  'white-60': 'to-white/60',
+  'white-70': 'to-white/70',
+  'white-80': 'to-white/80',
+  'white-90': 'to-white/90',
+  white: 'to-white',
 };
 export type GradientToType = keyof typeof gradientTos;
 
@@ -94,6 +104,16 @@ export const gradientFroms = {
   'black-80': 'from-black-true/80',
   'black-90': 'from-black-true/90',
   'gc-black': 'from-gc-black',
+  'white-10': 'from-white/10',
+  'white-20': 'from-white/20',
+  'white-30': 'from-white/30',
+  'white-40': 'from-white/40',
+  'white-50': 'from-white/50',
+  'white-60': 'from-white/60',
+  'white-70': 'from-white/70',
+  'white-80': 'from-white/80',
+  'white-90': 'from-white/90',
+  white: 'from-white',
 };
 export type GradientFromType = keyof typeof gradientFroms;
 
@@ -109,6 +129,16 @@ export const gradientVias = {
   'black-80': 'via-black-true/80',
   'black-90': 'via-black-true/90',
   'gc-black': 'via-gc-black',
+  'white-10': 'via-white/10',
+  'white-20': 'via-white/20',
+  'white-30': 'via-white/30',
+  'white-40': 'via-white/40',
+  'white-50': 'via-white/50',
+  'white-60': 'via-white/60',
+  'white-70': 'via-white/70',
+  'white-80': 'via-white/80',
+  'white-90': 'via-white/90',
+  white: 'via-white',
 };
 export type GradientViaType = keyof typeof gradientVias;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding more background options for Section and Homepage Theme/Story Section components
- Add light overlay and dark/light theme options to Section/Homepage ThemeStory/Moment poster
- replace all `w-full h-full` classes with `size-full`

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Pull down locally and review on the test/test-initiative-template page
2. Check homepage [on the preview](https://deploy-preview-248--giving-campaign.netlify.app/) that it still looks ok

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-297
