### PR TITLE
GIVCAMP-292 GIVCAMP-305 | Horizontal Initiative card and image aspect ratio options

### DIFF
--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -2,9 +2,13 @@ import { cnb } from 'cnbuilder';
 
 export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
 
-export const root = 'group relative size-full @container';
+export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-600 lg:max-w-full mx-auto', {
+  'lg:flex-row': isHorizontal,
+});
 
-export const topWrapper = 'relative @320:text-18 @sm:text-21 @md:text-23';
+export const topWrapper = (isHorizontal: boolean) => cnb('relative @320:text-18 @sm:text-21 @md:text-23', {
+  'lg:basis-1/2': isHorizontal,
+});
 
 export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black transition-all aspect-w-1 aspect-h-1 overflow-hidden', {
   'sm:aspect-w-3 sm:aspect-h-4': imageAspectRatio === '3x4',
@@ -12,9 +16,14 @@ export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) =
 
 export const image = 'object-cover backface-hidden size-full group-hocus-within:scale-105 transition-transform will-change-transform';
 
-export const heading = 'absolute bottom-0 w-full bg-black-true/60 text-white rs-p-1 mb-0 group-hocus-within:bg-black-true/70 group-hocus-within:border-y-4 border-transparent group-hocus-within:border-white transition-all text-shadow-sm group-hocus-within:rs-py-2';
+export const heading = (isHorizontal: boolean) => cnb('absolute bottom-0 w-full bg-black-true/60 text-white mb-0 group-hocus-within:bg-black-true/60 border-transparent group-hocus-within:border-white transition-all text-shadow-sm rs-p-1 group-hocus-within:rs-py-2', {
+  'group-hocus-within:border-y-4': !isHorizontal,
+  'lg:rs-px-3 lg:rs-py-2 lg:group-hocus-within:rs-py-4 group-hocus-within:border-y-4 lg:group-hocus-within:border-b-0': isHorizontal,
+});
 
-export const bodyWrapper = 'grow bg-gc-black text-black-10 rs-pt-2 rs-pr-1 @320:text-18 @sm:text-21 @md:text-23';
+export const bodyWrapper = (isHorizontal: boolean) => cnb('@container grow bg-gc-black text-black-10 rs-pt-2 rs-pr-1 @320:text-18 @sm:text-21 @md:text-23', {
+  'lg:basis-1/2': isHorizontal,
+});
 
 export const body = (hasTabColor: boolean) => cnb('rs-pl-1 text-current', {
   'border-l-[1.4rem] md:border-l-[2rem]': hasTabColor,

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -2,7 +2,7 @@ import { cnb } from 'cnbuilder';
 
 export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
 
-export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-600 lg:max-w-full mx-auto', {
+export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-500 lg:max-w-full mx-auto', {
   'lg:flex-row': isHorizontal,
 });
 
@@ -18,7 +18,7 @@ export const image = 'object-cover backface-hidden size-full group-hocus-within:
 
 export const heading = (isHorizontal: boolean) => cnb('absolute bottom-0 w-full bg-black-true/60 text-white mb-0 group-hocus-within:bg-black-true/60 border-transparent group-hocus-within:border-white transition-all text-shadow-sm rs-p-1 group-hocus-within:rs-py-2', {
   'group-hocus-within:border-y-4': !isHorizontal,
-  'lg:rs-px-3 lg:rs-py-2 lg:group-hocus-within:rs-py-4 group-hocus-within:border-y-4 lg:group-hocus-within:border-b-0': isHorizontal,
+  'lg:rs-px-3 lg:rs-py-2 lg:group-hocus-within:rs-py-3 group-hocus-within:border-y-4 lg:group-hocus-within:border-b-0': isHorizontal,
 });
 
 export const bodyWrapper = (isHorizontal: boolean) => cnb('@container grow bg-gc-black text-black-10 rs-pt-2 rs-pr-1 @320:text-18 @sm:text-21 @md:text-23', {
@@ -35,3 +35,5 @@ export const lastword = 'underline decoration-digital-red-light underline-offset
 export const icon = (hasLinkText?: boolean) => cnb('inline-block mb-0 mt-auto w-20 md:w-24 mr-0',
   hasLinkText? 'ml-10' : 'ml-auto',
 );
+
+export const horizontalCta = 'stretched-link mx-auto';

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -1,10 +1,14 @@
 import { cnb } from 'cnbuilder';
 
+export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
+
 export const root = 'group relative size-full @container';
 
 export const topWrapper = 'relative @320:text-18 @sm:text-21 @md:text-23';
 
-export const imageWrapper = 'bg-gc-black transition-all aspect-w-1 aspect-h-1 sm:aspect-w-3 sm:aspect-h-4 overflow-hidden';
+export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black transition-all aspect-w-1 aspect-h-1 overflow-hidden', {
+  'sm:aspect-w-3 sm:aspect-h-4': imageAspectRatio === '3x4',
+});
 
 export const image = 'object-cover backface-hidden size-full group-hocus-within:scale-105 transition-transform will-change-transform';
 

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -4,7 +4,7 @@ export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
 
 export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-500 mx-auto', {
   'xl:flex-row xl:max-w-1200': isHorizontal,
-  'xl:max-w-full': !isHorizontal,
+  'md:max-w-600': !isHorizontal,
 });
 
 export const topWrapper = (isHorizontal: boolean) => cnb('relative @320:text-18 @sm:text-21 @md:text-23', {
@@ -30,11 +30,13 @@ export const body = (hasTabColor: boolean) => cnb('rs-pl-1 text-current', {
   'border-l-[1.4rem] md:border-l-[2rem]': hasTabColor,
 });
 
-export const cta = 'group/cta inline-block bg-gc-black text-white hocus:text-white stretched-link no-underline hocus:no-underline rs-py-1 rs-pr-1';
+export const cta = (isHorizontal: boolean) => cnb('group/cta inline-block bg-gc-black text-white hocus:text-white stretched-link no-underline hocus:no-underline rs-py-1 rs-pr-1', {
+  'xl:hidden': isHorizontal,
+});
 export const linkText = 'text-19 md:text-25 mr-0 ml-auto last:children:underline';
 export const lastword = 'underline decoration-digital-red-light underline-offset-4 group-hocus/cta:decoration-white';
 export const icon = (hasLinkText?: boolean) => cnb('inline-block mb-0 mt-auto w-20 md:w-24 mr-0',
   hasLinkText? 'ml-10' : 'ml-auto',
 );
 
-export const horizontalCta = 'stretched-link mx-auto rs-mt-2';
+export const horizontalCta = 'stretched-link mx-auto rs-mt-2 hidden xl:block';

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -11,7 +11,7 @@ export const topWrapper = (isHorizontal: boolean) => cnb('relative @320:text-18 
   'xl:basis-1/2': isHorizontal,
 });
 
-export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black aspect-w-1 aspect-h-1 h-full w-full overflow-hidden', {
+export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black aspect-w-1 aspect-h-1 size-full overflow-hidden', {
   'sm:aspect-w-3 sm:aspect-h-4': imageAspectRatio === '3x4',
 });
 

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -3,7 +3,7 @@ import { cnb } from 'cnbuilder';
 export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
 
 export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-500 mx-auto', {
-  'xl:flex-row xl:max-w-1200': isHorizontal,
+  'xl:flex-row xl:max-w-[124.2rem]': isHorizontal, // 1242px is the width of 10 of 12 columns at 2XL
   'md:max-w-600': !isHorizontal,
 });
 

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -2,12 +2,13 @@ import { cnb } from 'cnbuilder';
 
 export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
 
-export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-500 lg:max-w-full mx-auto', {
-  'lg:flex-row': isHorizontal,
+export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-500 mx-auto', {
+  'xl:flex-row xl:max-w-1200': isHorizontal,
+  'xl:max-w-full': !isHorizontal,
 });
 
 export const topWrapper = (isHorizontal: boolean) => cnb('relative @320:text-18 @sm:text-21 @md:text-23', {
-  'lg:basis-1/2': isHorizontal,
+  'xl:basis-1/2': isHorizontal,
 });
 
 export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black transition-all aspect-w-1 aspect-h-1 overflow-hidden', {
@@ -18,11 +19,11 @@ export const image = 'object-cover backface-hidden size-full group-hocus-within:
 
 export const heading = (isHorizontal: boolean) => cnb('absolute bottom-0 w-full bg-black-true/60 text-white mb-0 group-hocus-within:bg-black-true/60 border-transparent group-hocus-within:border-white transition-all text-shadow-sm rs-p-1 group-hocus-within:rs-py-2', {
   'group-hocus-within:border-y-4': !isHorizontal,
-  'lg:rs-px-3 lg:rs-py-2 lg:group-hocus-within:rs-py-3 group-hocus-within:border-y-4 lg:group-hocus-within:border-b-0': isHorizontal,
+  'xl:rs-px-3 xl:rs-py-2 xl:group-hocus-within:rs-py-3 group-hocus-within:border-y-4 xl:group-hocus-within:border-b-0': isHorizontal,
 });
 
 export const bodyWrapper = (isHorizontal: boolean) => cnb('@container grow bg-gc-black text-black-10 rs-pt-2 rs-pr-1 @320:text-18 @sm:text-21 @md:text-23', {
-  'lg:basis-1/2': isHorizontal,
+  'xl:basis-1/2 flex flex-col justify-center': isHorizontal,
 });
 
 export const body = (hasTabColor: boolean) => cnb('rs-pl-1 text-current', {
@@ -36,4 +37,4 @@ export const icon = (hasLinkText?: boolean) => cnb('inline-block mb-0 mt-auto w-
   hasLinkText? 'ml-10' : 'ml-auto',
 );
 
-export const horizontalCta = 'stretched-link mx-auto';
+export const horizontalCta = 'stretched-link mx-auto rs-mt-2';

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -11,7 +11,7 @@ export const topWrapper = (isHorizontal: boolean) => cnb('relative @320:text-18 
   'xl:basis-1/2': isHorizontal,
 });
 
-export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black transition-all aspect-w-1 aspect-h-1 overflow-hidden', {
+export const imageWrapper = (imageAspectRatio: InitiativeCardImageAspectRatio) => cnb('bg-gc-black aspect-w-1 aspect-h-1 h-full w-full overflow-hidden', {
   'sm:aspect-w-3 sm:aspect-h-4': imageAspectRatio === '3x4',
 });
 

--- a/components/InitiativeCard/InitiativeCard.styles.ts
+++ b/components/InitiativeCard/InitiativeCard.styles.ts
@@ -2,9 +2,9 @@ import { cnb } from 'cnbuilder';
 
 export type InitiativeCardImageAspectRatio = '3x4' | '1x1';
 
-export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-500 mx-auto', {
+export const root = (isHorizontal: boolean) => cnb('group relative size-full max-w-600 mx-auto', {
   'xl:flex-row xl:max-w-[124.2rem]': isHorizontal, // 1242px is the width of 10 of 12 columns at 2XL
-  'md:max-w-600': !isHorizontal,
+  '2xl:max-w-700': !isHorizontal,
 });
 
 export const topWrapper = (isHorizontal: boolean) => cnb('relative @320:text-18 @sm:text-21 @md:text-23', {

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -111,6 +111,7 @@ export const InitiativeCard = ({
           >
             {body}
           </Paragraph>
+          {/* Only show the button styled CTA for XL breakpoint and up */}
           {isHorizontal && linkText && (
             <CtaLink
               variant="ghost"

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -75,11 +75,11 @@ export const InitiativeCard = ({
     <AnimateInView animation={animation} delay={delay}>
       <FlexBox
         as="article"
-        direction="col"
-        className={cnb(styles.root, className)}
+        direction='col'
+        className={cnb(styles.root(isHorizontal), className)}
         {...props}
       >
-        <div className={styles.topWrapper}>
+        <div className={styles.topWrapper(isHorizontal)}>
           <div className={styles.imageWrapper(imageAspectRatio)}>
             <img
               width={600}
@@ -93,15 +93,15 @@ export const InitiativeCard = ({
           <Heading
             as={headingLevel}
             font="druk-wide"
-            size={1}
+            size={isHorizontal ? 2 : 1}
             leading="tight"
             uppercase
-            className={styles.heading}
+            className={styles.heading(isHorizontal)}
           >
             {heading}
           </Heading>
         </div>
-        <div className={styles.bodyWrapper}>
+        <div className={styles.bodyWrapper(isHorizontal)}>
           <Paragraph
             variant="subheading"
             leading="display"
@@ -111,22 +111,24 @@ export const InitiativeCard = ({
             {body}
           </Paragraph>
         </div>
-        <CtaLink
-          variant="unset"
-          sbLink={link}
-          className={styles.cta}
-          icon={cardIcon}
-          iconProps={{ className: styles.icon(!!linkText) }}
-          animate={iconAnimation}
-        >
-          {linkText ? (
-            <Text as="span" weight="semibold" align="right" leading="none" className={styles.linkText}>
-              {firstPart} <span className={styles.lastword}>{lastWord}</span>
-            </Text>
-          ) : (
-            <SrOnlyText>{`Go to the ${heading} page`}</SrOnlyText>
-          )}
-        </CtaLink>
+        {!isHorizontal && (
+          <CtaLink
+            variant="unset"
+            sbLink={link}
+            className={styles.cta}
+            icon={cardIcon}
+            iconProps={{ className: styles.icon(!!linkText) }}
+            animate={iconAnimation}
+          >
+            {linkText ? (
+              <Text as="span" weight="semibold" align="right" leading="none" className={styles.linkText}>
+                {firstPart} <span className={styles.lastword}>{lastWord}</span>
+              </Text>
+            ) : (
+              <SrOnlyText>{`Go to the ${heading} page`}</SrOnlyText>
+            )}
+          </CtaLink>
+        )}
       </FlexBox>
     </AnimateInView>
   );

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -11,6 +11,7 @@ import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
 import * as styles from './InitiativeCard.styles';
 import { IconType } from '../HeroIcon';
+import { image } from '../Banner';
 
 export type InitiativeCardProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;
@@ -83,7 +84,7 @@ export const InitiativeCard = ({
           <div className={styles.imageWrapper(imageAspectRatio)}>
             <img
               width={600}
-              height={800}
+              height={imageAspectRatio === '3x4' ? 800 : 600}
               alt=""
               loading="lazy"
               src={getProcessedImage(imageSrc, imageSize, imageFocus) || ''}
@@ -124,24 +125,22 @@ export const InitiativeCard = ({
             </CtaLink>
           )}
         </div>
-        {!isHorizontal && (
-          <CtaLink
-            variant="unset"
-            sbLink={link}
-            className={styles.cta}
-            icon={cardIcon}
-            iconProps={{ className: styles.icon(!!linkText) }}
-            animate={iconAnimation}
-          >
-            {linkText ? (
-              <Text as="span" weight="semibold" align="right" leading="none" className={styles.linkText}>
-                {firstPart} <span className={styles.lastword}>{lastWord}</span>
-              </Text>
-            ) : (
-              <SrOnlyText>{`Go to the ${heading} page`}</SrOnlyText>
-            )}
-          </CtaLink>
-        )}
+        <CtaLink
+          variant="unset"
+          sbLink={link}
+          className={styles.cta(isHorizontal)}
+          icon={cardIcon}
+          iconProps={{ className: styles.icon(!!linkText) }}
+          animate={iconAnimation}
+        >
+          {linkText ? (
+            <Text as="span" weight="semibold" align="right" leading="none" className={styles.linkText}>
+              {firstPart} <span className={styles.lastword}>{lastWord}</span>
+            </Text>
+          ) : (
+            <SrOnlyText>{`Go to the ${heading} page`}</SrOnlyText>
+          )}
+        </CtaLink>
       </FlexBox>
     </AnimateInView>
   );

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -18,7 +18,9 @@ export type InitiativeCardProps = HTMLAttributes<HTMLDivElement> & {
   body?: string;
   imageSrc?: string;
   imageFocus?: string;
+  imageAspectRatio?: styles.InitiativeCardImageAspectRatio;
   tabColor?: AccentBorderColorType;
+  isHorizontal?: boolean;
   linkText?: string;
   link?: SbLinkType;
   animation?: AnimationType;
@@ -31,7 +33,9 @@ export const InitiativeCard = ({
   body,
   imageSrc = '',
   imageFocus,
+  imageAspectRatio = '3x4',
   tabColor,
+  isHorizontal,
   linkText,
   link,
   animation = 'none',
@@ -50,6 +54,8 @@ export const InitiativeCard = ({
 
   let cardIcon: IconType;
   let iconAnimation: IconAnimationType;
+
+  const imageSize = imageAspectRatio === '3x4' ? '510x680' : '700x700';
 
   switch (link?.linktype) {
     case 'asset':
@@ -74,13 +80,13 @@ export const InitiativeCard = ({
         {...props}
       >
         <div className={styles.topWrapper}>
-          <div className={styles.imageWrapper}>
+          <div className={styles.imageWrapper(imageAspectRatio)}>
             <img
               width={600}
               height={800}
               alt=""
               loading="lazy"
-              src={getProcessedImage(imageSrc, '510x680', imageFocus) || ''}
+              src={getProcessedImage(imageSrc, imageSize, imageFocus) || ''}
               className={styles.image}
             />
           </div>

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -118,7 +118,6 @@ export const InitiativeCard = ({
               sbLink={link}
               className={styles.horizontalCta}
               icon={cardIcon}
-              iconProps={{ className: styles.icon(!!linkText) }}
               animate={iconAnimation}
             >
               {linkText}

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -110,6 +110,20 @@ export const InitiativeCard = ({
           >
             {body}
           </Paragraph>
+          {isHorizontal && linkText && (
+            <CtaLink
+              variant="ghost"
+              color="white"
+              size="large"
+              sbLink={link}
+              className={styles.horizontalCta}
+              icon={cardIcon}
+              iconProps={{ className: styles.icon(!!linkText) }}
+              animate={iconAnimation}
+            >
+              {linkText}
+            </CtaLink>
+          )}
         </div>
         {!isHorizontal && (
           <CtaLink

--- a/components/MomentPoster/MomentPoster.styles.ts
+++ b/components/MomentPoster/MomentPoster.styles.ts
@@ -14,7 +14,7 @@ export const headingWrapper = 'mx-auto w-fit gap-02em';
 export const thumbnailWrapper = 'inline-block';
 export const thumbnail = 'size-[0.75em]';
 
-export const body = (isDarktheme: boolean) => cnb('max-w-prose mx-auto rs-mt-3 *:*:text-center text-balance mb-0', isDarktheme && 'text-shadow-sm');
+export const body = (isDarktheme: boolean) => cnb('max-w-prose mx-auto rs-mt-3 *:*:text-center *:*:leading-snug text-balance mb-0', isDarktheme && 'text-shadow-sm');
 
 export const cta = (isStackedCtas: boolean) => cnb(
   'gap-27 mx-auto w-fit *:mx-auto rs-mt-4', !isStackedCtas && 'md:flex-row',

--- a/components/Storyblok/SbInitiativeCard.tsx
+++ b/components/Storyblok/SbInitiativeCard.tsx
@@ -1,6 +1,6 @@
 import { storyblokEditable } from '@storyblok/react/rsc';
 import { type AnimationType } from '../Animate';
-import { InitiativeCard } from '../InitiativeCard';
+import { InitiativeCard, type InitiativeCardImageAspectRatio } from '../InitiativeCard';
 import { type HeadingType } from '../Typography';
 import { type SbImageType, type SbLinkType } from './Storyblok.types';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
@@ -12,6 +12,8 @@ type SbInitiativeCardProps = {
     headingLevel?: HeadingType;
     body?: string;
     image?: SbImageType;
+    imageAspectRatio?: InitiativeCardImageAspectRatio;
+    isHorizontal?: boolean;
     tabColor?: {
       value?: PaletteAccentHexColorType;
     }
@@ -28,7 +30,9 @@ export const SbInitiativeCard = ({
     headingLevel,
     body,
     image: { filename, focus } = {},
+    imageAspectRatio,
     tabColor: { value } = {},
+    isHorizontal,
     linkText,
     link,
     animation,
@@ -43,6 +47,8 @@ export const SbInitiativeCard = ({
     body={body}
     imageSrc={filename}
     imageFocus={focus}
+    imageAspectRatio={imageAspectRatio}
+    isHorizontal={isHorizontal}
     tabColor={paletteAccentColors[value]}
     linkText={linkText}
     link={link}

--- a/components/Storyblok/SbSection/SbSection.tsx
+++ b/components/Storyblok/SbSection/SbSection.tsx
@@ -236,7 +236,7 @@ export const SbSection = ({
                 font={isSerifHeader ? 'serif' : 'sans'}
                 weight={isSerifHeader ? 'semibold' : 'normal'}
                 align={headerAlign}
-                color={bgColor === 'black' ? 'black-20' : 'black-90'}
+                color={bgColor === 'black' ? 'black-20' : 'black'}
                 noMargin
                 className={styles.subhead(headerAlign)}
               >


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Horizontal Initiative card variant
- Add square image aspect ratio option

# Review By (Date)
- Retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to Storyblok /initiatives/stanford-arts and select PR 256 from the visual editor URL
2. Scroll to near the bottom and play with the initiative card options with the image aspect ratio and the horizontal card variant
![Screenshot 2024-04-01 at 1 25 36 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/f31cd900-88db-4602-b535-8c8ad312e693)
![Screenshot 2024-04-01 at 1 25 48 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/6eff5552-e569-4156-bd6e-9d0a34286ea8)


3. Check that this page is the same as live
https://deploy-preview-256--giving-campaign.netlify.app/initiatives

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-292, GIVCAMP-305
