### PR TITLE
GIVCAMP-311 | Add parallax window and hidden options to story image

### DIFF
--- a/components/EmbedMedia/EmbedMedia.styles.ts
+++ b/components/EmbedMedia/EmbedMedia.styles.ts
@@ -1,4 +1,4 @@
 export const mediaWrapper = '*:!w-full *:!h-full';
-export const caption = '*:*:leading-display mt-1em max-w-prose-wide';
+export const caption = '*:*:leading-display first:*:*:mt-0 mt-06em max-w-prose-wide';
 export const iconWrapper = 'size-50 sm:size-70 bg-black-true/70 border-3 rounded-full border-white group-hocus-within:scale-110 transition group-hocus-within:bg-digital-red';
 export const previewIcon = 'text-white size-24 sm:size-30';

--- a/components/Hero/StoryHeroMvp.styles.ts
+++ b/components/Hero/StoryHeroMvp.styles.ts
@@ -1,2 +1,2 @@
 export const root = 'relative';
-export const caption = 'caption mt-05em *:leading-display max-w-prose-wide first:*:mt-0';
+export const caption = 'gc-caption mt-06em *:leading-display max-w-prose-wide first:*:mt-0';

--- a/components/InitiativeCard/InitiativeCard.tsx
+++ b/components/InitiativeCard/InitiativeCard.tsx
@@ -11,7 +11,6 @@ import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
 import * as styles from './InitiativeCard.styles';
 import { IconType } from '../HeroIcon';
-import { image } from '../Banner';
 
 export type InitiativeCardProps = HTMLAttributes<HTMLDivElement> & {
   heading?: string;

--- a/components/Parallax/Parallax.tsx
+++ b/components/Parallax/Parallax.tsx
@@ -31,7 +31,7 @@ export const Parallax = ({ children, offset = 60 }: ParallaxProps) => {
   useLayoutEffect(() => {
     const element = ref.current;
     const onResize = () => {
-      const topOfElement = (element?.getBoundingClientRect()?.top ?? 0) + window.scrollY || window.pageYOffset;
+      const topOfElement = (element?.getBoundingClientRect()?.top ?? 0) + window.scrollY;
       setElementTop(topOfElement);
       setClientHeight(window.innerHeight);
     };

--- a/components/Parallax/Parallax.tsx
+++ b/components/Parallax/Parallax.tsx
@@ -1,17 +1,17 @@
 'use client';
-import {
-  useState, useRef, useLayoutEffect, ReactNode,
-} from 'react';
+import { useRef, ReactNode } from 'react';
 import {
   m,
   useScroll,
   useTransform,
   useSpring,
   useReducedMotion,
+  MotionValue,
 } from 'framer-motion';
 
 type ParallaxProps = {
   /**
+   * This is the vertical offset in px that the element will move in response to the scroll.
    * The larger the offset, the more apparent the parallax effect.
    * For a realistic effect, use a lower value for the background layer and a higher value for the foreground element.
    */
@@ -19,7 +19,7 @@ type ParallaxProps = {
   children: ReactNode;
 };
 
-export const Parallax = ({ children, offset }: ParallaxProps) => {
+export const Parallax = ({ children, offset = 60 }: ParallaxProps) => {
   const prefersReducedMotion = useReducedMotion();
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({

--- a/components/Parallax/index.ts
+++ b/components/Parallax/index.ts
@@ -1,0 +1,1 @@
+export * from './Parallax';

--- a/components/Scrollytelling/Scrollytelling.styles.ts
+++ b/components/Scrollytelling/Scrollytelling.styles.ts
@@ -36,4 +36,4 @@ export const heading = 'relative z-10 mb-02em whitespace-pre-line';
 export const subhead = 'sm:max-w-[40ch] mx-auto';
 export const children = 'grid gap-y-30 md:gap-y-40 xl:gap-y-60';
 
-export const caption = 'relative *:*:leading-display caption mt-07em *:max-w-prose-wide ml-0';
+export const caption = 'relative *:*:leading-display first:*:*:mt-0 gc-caption mt-06em *:max-w-prose-wide ml-0';

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -1,7 +1,8 @@
 import { cnb } from 'cnbuilder';
 
-export const imageCrops = {
-  '1x1': '1400x1400',
+// 2XL and up >= 1500px
+export const imageCropsDesktop = {
+  '1x1': '1400x1400', // We rarely have square or portrait images edge to edge so they can be smaller than the viewport size
   '1x2': '1000x2000',
   '2x1': '2000x1000',
   '2x3': '1200x1800',
@@ -14,7 +15,55 @@ export const imageCrops = {
   '16x9': '2000x1125',
   'free': '2000x0',
 };
-export type ImageCropType = keyof typeof imageCrops;
+export type ImageCropType = keyof typeof imageCropsDesktop;
+
+// LG-XL - 992px - 1499px
+export const imageCropsSmallDesktop = {
+  '1x1': '1000x1000',
+  '1x2': '1000x2000',
+  '2x1': '1500x750',
+  '2x3': '1200x1800',
+  '3x2': '1500x1000',
+  '3x4': '1200x1600',
+  '4x3': '1600x1200',
+  '5x8': '1000x1600',
+  '8x5': '1600x1000',
+  '9x16': '900x1600',
+  '16x9': '1600x900',
+  'free': '1500x0',
+};
+
+// SM-MD - 576px - 991px
+export const imageCropsTablet = {
+  '1x1': '1000x1000',
+  '1x2': '1000x2000',
+  '2x1': '1000x500',
+  '2x3': '1000x1500',
+  '3x2': '1000x667',
+  '3x4': '1000x1333',
+  '4x3': '1000x750',
+  '5x8': '1000x1600',
+  '8x5': '1000x625',
+  '9x16': '900x1600',
+  '16x9': '1000x563',
+  'free': '1000x0',
+};
+
+// XS - up to 575px
+export const imageCropsMobile = {
+  '1x1': '600x600',
+  '1x2': '600x1200',
+  '2x1': '600x300',
+  '2x3': '600x900',
+  '3x2': '600x400',
+  '3x4': '600x800',
+  '4x3': '600x450',
+  '5x8': '600x960',
+  '8x5': '640x400',
+  '9x16': '630x1120',
+  '16x9': '640x360',
+  'free': '575x0',
+};
 
 export const root = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const animateWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -24,4 +24,4 @@ export const imageWrapper = (isFullHeight: boolean, isParallax: boolean) => cnb(
   isParallax ? 'overflow-hidden' : '',
 );
 export const image = (isParallax: boolean) => cnb('w-full object-cover', isParallax ? 'h-[calc(100%_+_12rem)] -mt-60' : 'h-full');
-export const caption = '*:*:leading-display caption mt-1em max-w-prose-wide';
+export const caption = '*:*:leading-display mt-06em max-w-prose-wide first:*:*:mt-0';

--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -18,7 +18,10 @@ export type ImageCropType = keyof typeof imageCrops;
 
 export const root = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const animateWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
-export const figure = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
-export const imageWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
-export const image = 'size-full object-cover';
+export const figure = (isFullHeight: boolean) => cnb(isFullHeight ? 'h-full' : '');
+export const imageWrapper = (isFullHeight: boolean, isParallax: boolean) => cnb(
+  isFullHeight ? 'h-full' : '',
+  isParallax ? 'overflow-hidden' : '',
+);
+export const image = (isParallax: boolean) => cnb('w-full object-cover', isParallax ? 'h-[calc(100%_+_12rem)] -mt-60' : 'h-full');
 export const caption = '*:*:leading-display caption mt-1em max-w-prose-wide';

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -25,6 +25,7 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   isCaptionInset?: boolean;
   animation?: AnimationType;
   delay?: number;
+  isHidden?: boolean;
 };
 
 export const StoryImage = ({
@@ -43,6 +44,7 @@ export const StoryImage = ({
   isCaptionInset,
   animation = 'none',
   delay,
+  isHidden,
   className,
   ...props
 }: StoryImageProps) => {
@@ -57,6 +59,10 @@ export const StoryImage = ({
     ? Math.round(originalHeight * 2000 / originalWidth)
     : parseInt(cropSize?.split('x')[1], 10);
 
+  if (isHidden) {
+    return null;
+  }
+
   return (
     <WidthBox
       {...props}
@@ -70,7 +76,7 @@ export const StoryImage = ({
         <figure className={styles.figure(isFullHeight)}>
           <div className={cnb(imageAspectRatios[aspectRatio], styles.imageWrapper(isFullHeight, isParallax))}>
             {!!imageSrc && (
-              <Parallax offset={60}>
+              <Parallax offset={isParallax ? 60 : 0}>
                 <img
                   src={getProcessedImage(imageSrc, cropSize, imageFocus)}
                   loading={isLoadingEager ? 'eager' : 'lazy'}

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -1,12 +1,12 @@
 import { cnb } from 'cnbuilder';
-import { AnimateInView } from '../Animate';
-import { Container } from '../Container';
-import { WidthBox, type WidthType } from '../WidthBox';
+import { AnimateInView, type AnimationType } from '@/components/Animate';
+import { Container } from '@/components/Container';
+import { Parallax } from '@/components/Parallax';
+import { WidthBox, type WidthType } from '@/components/WidthBox';
 import { type PaddingType } from '@/utilities/datasource';
 import { imageAspectRatios, type ImageAspectRatioType } from '@/utilities/datasource';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { getSbImageSize } from '@/utilities/getSbImageSize';
-import { type AnimationType } from '../Animate';
 import * as styles from './StoryImage.styles';
 
 type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -68,16 +68,18 @@ export const StoryImage = ({
     >
       <AnimateInView animation={animation} delay={delay} className={styles.animateWrapper(isFullHeight)}>
         <figure className={styles.figure(isFullHeight)}>
-          <div className={cnb(imageAspectRatios[aspectRatio], styles.imageWrapper(isFullHeight))}>
+          <div className={cnb(imageAspectRatios[aspectRatio], styles.imageWrapper(isFullHeight, isParallax))}>
             {!!imageSrc && (
-              <img
-                src={getProcessedImage(imageSrc, cropSize, imageFocus)}
-                loading={isLoadingEager ? 'eager' : 'lazy'}
-                width={cropWidth}
-                height={cropHeight}
-                alt={alt || ''}
-                className={styles.image}
-              />
+              <Parallax offset={60}>
+                <img
+                  src={getProcessedImage(imageSrc, cropSize, imageFocus)}
+                  loading={isLoadingEager ? 'eager' : 'lazy'}
+                  width={cropWidth}
+                  height={cropHeight}
+                  alt={alt || ''}
+                  className={styles.image(isParallax)}
+                />
+              </Parallax>
             )}
           </div>
           {caption && (

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -13,6 +13,7 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   imageSrc: string;
   imageFocus?: string;
   isLoadingEager?: boolean;
+  isParallax?: boolean;
   alt?: string;
   caption?: React.ReactNode;
   aspectRatio?: ImageAspectRatioType;
@@ -30,6 +31,7 @@ export const StoryImage = ({
   imageSrc,
   imageFocus,
   isLoadingEager,
+  isParallax,
   alt,
   caption,
   aspectRatio,

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -25,7 +25,6 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   isCaptionInset?: boolean;
   animation?: AnimationType;
   delay?: number;
-  isHidden?: boolean;
 };
 
 export const StoryImage = ({
@@ -44,10 +43,10 @@ export const StoryImage = ({
   isCaptionInset,
   animation = 'none',
   delay,
-  isHidden,
   className,
   ...props
 }: StoryImageProps) => {
+
   const { width: originalWidth, height: originalHeight } = getSbImageSize(imageSrc);
   const cropSize = styles.imageCrops[aspectRatio];
   /**
@@ -58,10 +57,6 @@ export const StoryImage = ({
   const cropHeight = aspectRatio === 'free'
     ? Math.round(originalHeight * 2000 / originalWidth)
     : parseInt(cropSize?.split('x')[1], 10);
-
-  if (isHidden) {
-    return null;
-  }
 
   return (
     <WidthBox

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -48,7 +48,7 @@ export const StoryImage = ({
 }: StoryImageProps) => {
 
   const { width: originalWidth, height: originalHeight } = getSbImageSize(imageSrc);
-  const cropSize = styles.imageCrops[aspectRatio];
+  const cropSize = styles.imageCropsDesktop[aspectRatio];
   /**
    * Crop width and height are used for width and height attributes on the img element.
    * They don't need to be exact as long as the aspect ratio is correct.
@@ -72,14 +72,32 @@ export const StoryImage = ({
           <div className={cnb(imageAspectRatios[aspectRatio], styles.imageWrapper(isFullHeight, isParallax))}>
             {!!imageSrc && (
               <Parallax offset={isParallax ? 60 : 0}>
-                <img
-                  src={getProcessedImage(imageSrc, cropSize, imageFocus)}
-                  loading={isLoadingEager ? 'eager' : 'lazy'}
-                  width={cropWidth}
-                  height={cropHeight}
-                  alt={alt || ''}
-                  className={styles.image(isParallax)}
-                />
+                <picture>
+                  <source
+                    srcSet={getProcessedImage(imageSrc, cropSize, imageFocus)}
+                    media="(min-width: 1500px)"
+                  />
+                  <source
+                    srcSet={getProcessedImage(imageSrc, styles.imageCropsSmallDesktop[aspectRatio], imageFocus)}
+                    media="(min-width: 992px)"
+                  />
+                  <source
+                    srcSet={getProcessedImage(imageSrc, styles.imageCropsTablet[aspectRatio], imageFocus)}
+                    media="(min-width: 576px)"
+                  />
+                  <source
+                    srcSet={getProcessedImage(imageSrc, styles.imageCropsMobile[aspectRatio], imageFocus)}
+                    media="(max-width: 575px)"
+                  />
+                  <img
+                    src={getProcessedImage(imageSrc, cropSize, imageFocus)}
+                    loading={isLoadingEager ? 'eager' : 'lazy'}
+                    width={cropWidth}
+                    height={cropHeight}
+                    alt={alt || ''}
+                    className={styles.image(isParallax)}
+                  />
+                </picture>
               </Parallax>
             )}
           </div>

--- a/components/Storyblok/SbSection/SbSection.styles.ts
+++ b/components/Storyblok/SbSection/SbSection.styles.ts
@@ -35,7 +35,7 @@ export const subhead = (headerAlign?: AlignType) => cnb('relative z-10 rs-mt-3 t
 });
 export const contentWrapper = 'relative z-10';
 export const cta = 'cc md:flex-row *:mx-auto rs-mt-3 gap-20 lg:gap-27 w-fit';
-export const caption = 'caption *:leading-display mt-08em max-w-prose-wide';
+export const caption = 'gc-caption first:*:mt-0 *:leading-display mt-06em max-w-prose-wide';
 
 export const bgImage = 'absolute top-0 left-0 size-full object-cover';
 export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -15,6 +15,7 @@ type SbStoryImageProps = {
     image: SbImageType;
     alt?: string;
     isLoadingEager?: boolean;
+    isParallax?: boolean;
     caption?: StoryblokRichtext;
     aspectRatio?: ImageAspectRatioType;
     isFullHeight?: boolean;
@@ -34,6 +35,7 @@ export const SbStoryImage = ({
     image: { filename, focus } = {},
     alt,
     isLoadingEager,
+    isParallax,
     caption,
     aspectRatio,
     isFullHeight,
@@ -57,6 +59,7 @@ export const SbStoryImage = ({
       imageFocus={focus}
       alt={alt}
       isLoadingEager={isLoadingEager}
+      isParallax={isParallax}
       caption={Caption}
       aspectRatio={aspectRatio}
       isFullHeight={isFullHeight}

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -54,6 +54,10 @@ export const SbStoryImage = ({
 }: SbStoryImageProps) => {
   const Caption = hasRichText(caption) ? <RichText textColor={isCaptionLight ? 'white' : 'black-70'} wysiwyg={caption} /> : undefined;
 
+  if (isHidden) {
+    return null;
+  }
+
   return (
     <StoryImage
       {...storyblokEditable(blok)}
@@ -72,7 +76,6 @@ export const SbStoryImage = ({
       isCaptionInset={isCaptionInset}
       animation={animation}
       delay={delay}
-      isHidden={isHidden}
     />
   );
 };

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -27,6 +27,7 @@ type SbStoryImageProps = {
     isCaptionLight?: boolean;
     animation?: AnimationType;
     delay?: number;
+    isHidden?: boolean;
   };
 };
 
@@ -47,6 +48,7 @@ export const SbStoryImage = ({
     isCaptionLight,
     animation = 'none',
     delay,
+    isHidden,
   },
   blok,
 }: SbStoryImageProps) => {
@@ -70,6 +72,7 @@ export const SbStoryImage = ({
       isCaptionInset={isCaptionInset}
       animation={animation}
       delay={delay}
+      isHidden={isHidden}
     />
   );
 };

--- a/components/Typography/typography.styles.ts
+++ b/components/Typography/typography.styles.ts
@@ -76,7 +76,7 @@ export const textVariants = {
    * Momentum typography styles
    * (-gc ones are Decanter styles with Momentum modifications)
    */
-  caption: 'caption',
+  caption: 'gc-caption',
   card: 'gc-card',
   changemaker: 'gc-changemaker',
   intro: 'gc-intro-text',

--- a/components/VerticalPoster/VerticalPoster.styles.ts
+++ b/components/VerticalPoster/VerticalPoster.styles.ts
@@ -52,7 +52,7 @@ export const imageWrapper = (imageOnLeft: boolean) => cnb('w-full bg-gc-black bg
 export const imageInnerWrapper = 'size-full';
 export const image = 'size-full object-cover object-center';
 
-export const caption = (imageOnLeft: boolean) => cnb('relative mt-05em caption *:*:leading-display *:max-w-prose-wide first:*:*:mt-0 *:ml-0',
+export const caption = (imageOnLeft: boolean) => cnb('relative mt-06em gc-caption *:*:leading-display *:max-w-prose-wide first:*:*:mt-0 *:ml-0',
   imageOnLeft ? '' : '*:lg:mr-0 *:lg:ml-auto lg:*:text-right',
 );
 

--- a/tailwind/plugins/base/gc-base.js
+++ b/tailwind/plugins/base/gc-base.js
@@ -30,6 +30,9 @@ module.exports = function () {
           color: config('theme.colors.digital-red.dark'),
         },
       },
+      figcaption: {
+        fontSize: 'max(1.5rem, 0.81em)',
+      },
     });
   };
 };

--- a/tailwind/plugins/components/gc-typography.js
+++ b/tailwind/plugins/components/gc-typography.js
@@ -15,6 +15,9 @@ module.exports = function () {
           fontSize: '3.4rem',
         },
       },
+      '.gc-caption': {
+        fontSize: 'max(1.5rem, 0.81em)',
+      },
       '.gc-card': {
         fontSize: '0.93em',
         lineHeight: theme('lineHeight.snug'),


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Add parallax option to story image
- Standardize all caption font size and top margin
- Add option to hide a story image

# Review By (Date)
- Retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to storyblok test/test-stories/yvonne-test-arts-feature
2. Pick PR 261 from the visual editor and scroll down to see the images with parallax enabled
![Screenshot 2024-04-10 at 10 00 00 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/e1ffc81a-01a9-41a2-a43b-bf474754a1b1)

3. Enabled reduced motion in the Mac OS or iOS and refresh. Check that the images still shows up but there's no parallax effect.
4. Check out a page with many story images like this and see that the images without parallax still look ok
https://deploy-preview-261--giving-campaign.netlify.app/volunteer-leadership-summit

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-311 GIVCAMP-325