### PR TITLE
GIVCAMP-296 | Background image entrance options for Scrollytelling sections

### DIFF
--- a/components/FeaturedStories/FeatureMasonry.tsx
+++ b/components/FeaturedStories/FeatureMasonry.tsx
@@ -100,7 +100,7 @@ export const FeatureMasonry = ({
           previewAriaLabel={previewAriaLabel}
         />
       </Grid>
-      <Text variant="caption" leading="display" className="text-black-70 max-w-prose-wide mt-1em whitespace-pre-line">
+      <Text variant="caption" leading="display" className="text-black-70 max-w-prose-wide mt-06em whitespace-pre-line">
         {caption}
       </Text>
     </Container>

--- a/components/Scrollytelling/Scrollytelling.styles.ts
+++ b/components/Scrollytelling/Scrollytelling.styles.ts
@@ -8,16 +8,16 @@ export const contentAligns = {
 export type ContentAlignType = keyof typeof contentAligns;
 
 export const overlays = {
-  none: 'lg:bg-transparent',
-  'black-20': 'lg:bg-black-true/20',
-  'black-30': 'lg:bg-black-true/30',
-  'black-40': 'lg:bg-black-true/40',
-  'black-50': 'lg:bg-black-true/50',
-  'black-60': 'lg:bg-black-true/60',
-  'black-70': 'lg:bg-black-true/70',
-  'black-80': 'lg:bg-black-true/80',
-  'black-gradient-to-r': 'lg:bg-transparent lg:bg-gradient-to-r lg:from-black-true/70',
-  'black-gradient-to-l': 'lg:bg-transparent lg:bg-gradient-to-l lg:from-black-true/70',
+  none: 'bg-black-true/50 lg:bg-transparent',
+  'black-20': 'bg-black-true/50 lg:bg-black-true/20',
+  'black-30': 'bg-black-true/50 lg:bg-black-true/30',
+  'black-40': 'bg-black-true/50 lg:bg-black-true/40',
+  'black-50': 'bg-black-true/50',
+  'black-60': 'bg-black-true/60',
+  'black-70': 'bg-black-true/70',
+  'black-80': 'bg-black-true/80',
+  'black-gradient-to-r': 'bg-black-true/50 lg:bg-transparent lg:bg-gradient-to-r lg:from-black-true/70',
+  'black-gradient-to-l': 'bg-black-true/50 lg:bg-transparent lg:bg-gradient-to-l lg:from-black-true/70',
 };
 export type OverlayType = keyof typeof overlays;
 
@@ -36,7 +36,7 @@ export const imageWrapper = 'sticky top-0 h-screen w-full z-0';
 export const image = 'absolute size-full object-cover top-0 left-0 z-0';
 
 export const overlayBase = 'absolute size-full top-0 left-0 z-0';
-export const imageOverlay = (overlay?: OverlayType) => cnb(overlayBase, 'bg-black-true/50', overlays[overlay]);
+export const imageOverlay = (overlay?: OverlayType) => cnb(overlayBase, overlays[overlay]);
 export const filterOverlay = (imageEntrance: ImageEntranceType) => cnb(overlayBase, imageEntrances[imageEntrance]);
 
 export const content = 'relative z-10 cc text-white rs-py-10';

--- a/components/Scrollytelling/Scrollytelling.styles.ts
+++ b/components/Scrollytelling/Scrollytelling.styles.ts
@@ -24,13 +24,14 @@ export type OverlayType = keyof typeof overlays;
 export const imageEntrances = {
   none: '',
   'zoom-in': '',
+  'zoom-out': '',
   blur: 'backdrop-blur',
   grayscale: 'backdrop-saturate-0',
   sepia: 'backdrop-sepia',
 };
 export type ImageEntranceType = keyof typeof imageEntrances;
 
-export const wrapper = 'relative';
+export const wrapper = 'relative overflow-clip';
 export const imageWrapper = 'sticky top-0 h-screen w-full z-0';
 export const image = 'absolute size-full object-cover top-0 left-0 z-0';
 

--- a/components/Scrollytelling/Scrollytelling.styles.ts
+++ b/components/Scrollytelling/Scrollytelling.styles.ts
@@ -21,10 +21,22 @@ export const overlays = {
 };
 export type OverlayType = keyof typeof overlays;
 
+export const imageEntrances = {
+  none: '',
+  'zoom-in': '',
+  blur: 'backdrop-blur',
+  grayscale: 'backdrop-saturate-0',
+  sepia: 'backdrop-sepia',
+};
+export type ImageEntranceType = keyof typeof imageEntrances;
+
 export const wrapper = 'relative';
 export const imageWrapper = 'sticky top-0 h-screen w-full z-0';
 export const image = 'absolute size-full object-cover top-0 left-0 z-0';
-export const imageOverlay = (overlay?: OverlayType) => cnb('absolute size-full top-0 left-0 z-0 bg-black-true/50', overlays[overlay]);
+
+export const overlayBase = 'absolute size-full top-0 left-0 z-0';
+export const imageOverlay = (overlay?: OverlayType) => cnb(overlayBase, 'bg-black-true/50', overlays[overlay]);
+export const filterOverlay = (imageEntrance: ImageEntranceType) => cnb(overlayBase, imageEntrances[imageEntrance]);
 
 export const content = 'relative z-10 cc text-white rs-py-10';
 export const contentWrapper = (contentAlign: ContentAlignType) => cnb('w-full mx-auto md:w-2/3 xl:w-1/2', {

--- a/components/Scrollytelling/Scrollytelling.tsx
+++ b/components/Scrollytelling/Scrollytelling.tsx
@@ -106,7 +106,7 @@ export const Scrollytelling = ({
             className={styles.imageOverlay(overlay)}
             style={{ opacity: animateDarkOverlayOpacity, willChange }}
           />
-          {!!imageEntrance && imageEntrance !== 'zoom-in' && (
+          {!!imageEntrance && !imageEntrance?.includes('zoom') && (
             <m.div
               className={styles.filterOverlay(imageEntrance)}
               style={{ opacity: animateFilterOpacity, willChange }}

--- a/components/Scrollytelling/Scrollytelling.tsx
+++ b/components/Scrollytelling/Scrollytelling.tsx
@@ -49,8 +49,14 @@ export const Scrollytelling = ({
     target: contentRef,
     offset: ['start center', 'end start'],
   });
+  let imageZoomStart = 1;
+  if (imageEntrance === 'zoom-in') {
+    imageZoomStart = 0.8;
+  } else if (imageEntrance === 'zoom-out') {
+    imageZoomStart = 1.1;
+  }
   const animateDarkOverlayOpacity = useTransform(scrollYProgress, [0, 0.2], ['0%', '100%']);
-  const animateImageScale = useTransform(scrollYProgress, [0, 0.2], [0.8, 1]);
+  const animateImageScale = useTransform(scrollYProgress, [0, 0.3], [imageZoomStart, 1]);
   const animateFilterOpacity = useTransform(scrollYProgress, [0, 0.2], ['0', '100%']);
 
   return (
@@ -58,7 +64,10 @@ export const Scrollytelling = ({
       <Container width="full" bgColor="black" className={styles.wrapper} >
         <m.div
           className={styles.imageWrapper}
-          style={{ scale: imageEntrance === 'zoom-in' ? animateImageScale : undefined, willChange }}
+          style={{
+            scale: imageZoomStart !== 1 ? animateImageScale : undefined,
+            willChange,
+          }}
         >
           <picture>
             <source

--- a/components/Scrollytelling/Scrollytelling.tsx
+++ b/components/Scrollytelling/Scrollytelling.tsx
@@ -2,12 +2,13 @@ import { useRef } from 'react';
 import {
   m, useScroll, useTransform, useWillChange,
 } from 'framer-motion';
+import { AnimateInView } from '@/components/Animate';
 import { Container } from '@/components/Container';
 import { Heading, Text, type HeadingType } from '@/components/Typography';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { type MarginType } from '@/utilities/datasource';
 import * as styles from './Scrollytelling.styles';
-import { AnimateInView } from '../Animate';
+
 
 
 type ScrollytellingProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -19,6 +20,7 @@ type ScrollytellingProps = React.HTMLAttributes<HTMLDivElement> & {
   bgImageSrc?: string;
   bgImageFocus?: string;
   bgImageAlt?: string;
+  imageEntrance?: styles.ImageEntranceType;
   overlay?: styles.OverlayType;
   contentAlign?: styles.ContentAlignType;
   spacingTop?: MarginType;
@@ -33,6 +35,7 @@ export const Scrollytelling = ({
   bgImageSrc,
   bgImageFocus,
   bgImageAlt,
+  imageEntrance,
   overlay,
   contentAlign = 'center',
   spacingTop,
@@ -46,15 +49,16 @@ export const Scrollytelling = ({
     target: contentRef,
     offset: ['start center', 'end start'],
   });
-  const animateOpacity = useTransform(scrollYProgress, [0, 0.1], ['0%', '100%']);
-  const animateScale = useTransform(scrollYProgress, [0, 0.2], [0.8, 1]);
+  const animateDarkOverlayOpacity = useTransform(scrollYProgress, [0, 0.2], ['0%', '100%']);
+  const animateImageScale = useTransform(scrollYProgress, [0, 0.2], [0.8, 1]);
+  const animateFilterOpacity = useTransform(scrollYProgress, [0, 0.2], ['0', '100%']);
 
   return (
     <Container width="full" mt={spacingTop} mb={spacingBottom} {...props}>
       <Container width="full" bgColor="black" className={styles.wrapper} >
         <m.div
           className={styles.imageWrapper}
-          style={{ scale: animateScale, willChange }}
+          style={{ scale: imageEntrance === 'zoom-in' ? animateImageScale : undefined, willChange }}
         >
           <picture>
             <source
@@ -91,8 +95,14 @@ export const Scrollytelling = ({
           </picture>
           <m.div
             className={styles.imageOverlay(overlay)}
-            style={{ opacity: animateOpacity, willChange }}
+            style={{ opacity: animateDarkOverlayOpacity, willChange }}
           />
+          {!!imageEntrance && imageEntrance !== 'zoom-in' && (
+            <m.div
+              className={styles.filterOverlay(imageEntrance)}
+              style={{ opacity: animateFilterOpacity, willChange }}
+            />
+          )}
         </m.div>
         <div ref={contentRef} className={styles.content}>
           <div className={styles.contentWrapper(contentAlign)}>

--- a/components/Storyblok/SbFeatureMasonry.tsx
+++ b/components/Storyblok/SbFeatureMasonry.tsx
@@ -14,6 +14,7 @@ export type SbFeatureMasonryProps = {
     videoUrl?: string;
     previewAriaLabel?: string;
     caption?: string;
+    isHidden?: boolean;
   };
 };
 
@@ -28,22 +29,29 @@ export const SbFeatureMasonry = ({
     videoUrl,
     previewAriaLabel = 'Play video',
     caption,
+    isHidden,
   },
   blok,
-}: SbFeatureMasonryProps) => (
-  <FeatureMasonry
-    {...storyblokEditable(blok)}
-    audioUrl={audioUrl}
-    audioBgImageSrc={audioBgImageSrc}
-    audioBgImageFocus={audioBgImagFocus}
-    quoteBody={quoteBody}
-    quoteBgImageSrc={quoteBgImageSrc}
-    quoteBgImageFocus={quoteBgImageFocus}
-    imageSrc1={imageSrc1}
-    imageFocus1={imageFocus1}
-    imageAlt1={imageAlt1}
-    videoUrl={videoUrl}
-    previewAriaLabel={previewAriaLabel}
-    caption={caption}
-  />
-);
+}: SbFeatureMasonryProps) => {
+  if (isHidden) {
+    return null;
+  }
+
+  return (
+    <FeatureMasonry
+      {...storyblokEditable(blok)}
+      audioUrl={audioUrl}
+      audioBgImageSrc={audioBgImageSrc}
+      audioBgImageFocus={audioBgImagFocus}
+      quoteBody={quoteBody}
+      quoteBgImageSrc={quoteBgImageSrc}
+      quoteBgImageFocus={quoteBgImageFocus}
+      imageSrc1={imageSrc1}
+      imageFocus1={imageFocus1}
+      imageAlt1={imageAlt1}
+      videoUrl={videoUrl}
+      previewAriaLabel={previewAriaLabel}
+      caption={caption}
+    />
+  );
+};

--- a/components/Storyblok/SbScrollytelling.tsx
+++ b/components/Storyblok/SbScrollytelling.tsx
@@ -2,7 +2,12 @@ import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { CreateBloks } from '@/components/CreateBloks';
 import { RichText } from '@/components/RichText';
-import { Scrollytelling, type OverlayType, type ContentAlignType } from '@/components/Scrollytelling';
+import {
+  Scrollytelling,
+  type OverlayType,
+  type ContentAlignType,
+  type ImageEntranceType,
+} from '@/components/Scrollytelling';
 import { type SbImageType } from '@/components/Storyblok/Storyblok.types';
 import { type HeadingType } from '@/components/Typography';
 import { hasRichText } from '@/utilities/hasRichText';
@@ -18,6 +23,7 @@ type SbScrollytellingProps = {
     caption?: StoryblokRichtext;
     bgImage?: SbImageType;
     bgImageAlt?: string;
+    imageEntrance?: ImageEntranceType;
     overlay?: OverlayType;
     contentAlign?: ContentAlignType;
     spacingTop?: MarginType;
@@ -35,6 +41,7 @@ export const SbScrollytelling = ({
     caption,
     bgImage: { filename: bgImageSrc, focus: bgImageFocus } = {},
     bgImageAlt,
+    imageEntrance,
     overlay,
     contentAlign,
     spacingTop,
@@ -59,6 +66,7 @@ export const SbScrollytelling = ({
       bgImageSrc={bgImageSrc}
       bgImageFocus={bgImageFocus}
       bgImageAlt={bgImageAlt}
+      imageEntrance={imageEntrance}
       overlay={overlay}
       contentAlign={contentAlign}
       spacingTop={spacingTop}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add options for background image entrance for Scrollytelling sections
- misc updates

# Review By (Date)
- Retro

# Criticality
- 3
# Review Tasks

## Setup tasks and/or behavior to test

1. Go to Storyblok and select PR 266 from the visual editor
2. Add a scrollytelling section from the preset into the content region
3. Play with the "Background image entrance" options
4. Go to the Netlify preview of this story: https://deploy-preview-266--giving-campaign.netlify.app/stories/education-for-a-life-of-purpose
5. Scroll to the "Why College" scrolly telling section. Check that the background image still zooms in during the entrance as you scroll

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-296