### PR TITLE
GIVCAMP-333 | Story Card list view style

### DIFF
--- a/components/Grid/Grid.styles.ts
+++ b/components/Grid/Grid.styles.ts
@@ -58,6 +58,7 @@ export const gridGaps = {
   split: 'md:gap-x-60 lg:gap-x-100 xl:gap-x-200 2xl:gap-x-280',
   xs: 'gap-4',
   'xs-horizontal': 'gap-x-4 gap-y-50 xl:gap-y-70',
+  'story-list': 'gap-y-45 md:gap-y-90 2xl:gap-y-95',
 };
 
 export const gridJustifyContent = {

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -1,7 +1,7 @@
 import { cnb } from 'cnbuilder';
 
 export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
-  '@container relative z-10 mx-auto', {
+  '@container relative z-10 mx-auto focus-within:outline', {
   'max-w-300 sm:max-w-400 md:max-w-full': !isHorizontal,
   'max-w-600 lg:max-w-none': isHorizontal && !isListView,
   'max-w-300 sm:max-w-none': isListView,

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -3,7 +3,8 @@ import { cnb } from 'cnbuilder';
 export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
   '@container relative z-10 mx-auto', {
   'max-w-300 sm:max-w-400 md:max-w-full': !isHorizontal,
-  'max-w-700 lg:max-w-none': isHorizontal && !isListView,
+  'max-w-600 lg:max-w-none': isHorizontal && !isListView,
+  'max-w-300 sm:max-w-none': isListView,
   },
 );
 

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -2,7 +2,7 @@ import { cnb } from 'cnbuilder';
 
 export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
   '@container relative z-10 mx-auto', {
-  'max-w-300 sm:max-w-400 md:max-w-full': !isHorizontal,
+  'max-w-300 sm:max-w-400 md:max-w-full': !isHorizontal && !isListView,
   'max-w-600 lg:max-w-none': isHorizontal && !isListView,
   'max-w-300 sm:max-w-none': isListView,
   },
@@ -11,8 +11,8 @@ export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
 export const cardWrapper = (isHorizontal: boolean, isListView: boolean) => cnb(
   'relative group', {
   'grid lg:grid-cols-2 bg-black-true/50': isHorizontal && !isListView,
-  'grid sm:grid-cols-[3fr_5fr] lg:grid-cols-[3fr_7fr] 2xl:grid-cols-[1fr_3fr] items-start': isHorizontal && isListView,
-  '@200:text-15 @250:text-17 @280:!type-0 @md:!text-26': !isHorizontal,
+  'grid sm:grid-cols-[3fr_5fr] lg:grid-cols-[3fr_7fr] 2xl:grid-cols-[1fr_3fr] items-start': isListView,
+  '@200:text-15 @250:text-17 @280:!type-0 @md:!text-26': !isHorizontal && !isListView,
   },
 );
 
@@ -22,15 +22,15 @@ export const image = 'object-cover size-full group-hocus-within:scale-105 transi
 
 export const contentWrapper = (isHorizontal: boolean, isListView: boolean) => cnb({
   'rs-pr-4 rs-py-4': isHorizontal && !isListView,
-  'pt-20 md:pt-30 xl:pt-45 2xl:pt-48': isHorizontal && isListView,
+  'pt-20 md:pt-30 xl:pt-45 2xl:pt-48': isListView,
 });
 export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHeading: boolean, isListView: boolean) => cnb('text-current', {
   'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem]': hasTabColor && !isListView,
   'border-l-[1.2rem] xl:border-l-[1.8rem]': hasTabColor && isListView,
-  '@200:pl-12 @xs:pl-21 @200:pr-08em @320:pr-1em': hasTabColor && !isHorizontal,
-  'mt-06em rs-mb-neg1 pr-08em xl:pr-1em pl-12 xl:pl-21': !isHorizontal,
+  '@200:pl-12 @xs:pl-21 @200:pr-08em @320:pr-1em': hasTabColor && !isHorizontal && !isListView,
+  'mt-06em rs-mb-neg1 pr-08em xl:pr-1em pl-12 xl:pl-21': !isHorizontal && !isListView,
   'rs-pb-2 mb-0 rs-pl-2': isHorizontal && !isListView,
-  'rs-pb-0 mb-0 pl-20 xl:pl-38': isHorizontal && isListView,
+  'rs-pb-0 mb-0 pl-20 xl:pl-38': isListView,
   'type-3': !isHorizontal && !isSmallHeading,
   'type-2': !isHorizontal && isSmallHeading,
   'fluid-type-4 2xl:fluid-type-5': isHorizontal && !isSmallHeading && !isListView,

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -10,7 +10,7 @@ export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
 export const cardWrapper = (isHorizontal: boolean, isListView: boolean) => cnb(
   'relative group', {
   'grid lg:grid-cols-2 bg-black-true/50': isHorizontal && !isListView,
-  'grid sm:grid-cols-[3fr_5fr] lg:grid-cols-[3fr_7fr] items-start': isHorizontal && isListView,
+  'grid sm:grid-cols-[3fr_5fr] lg:grid-cols-[3fr_7fr] 2xl:grid-cols-[1fr_3fr] items-start': isHorizontal && isListView,
   '@200:text-15 @250:text-17 @280:!type-0 @md:!text-26': !isHorizontal,
   },
 );
@@ -21,16 +21,18 @@ export const image = 'object-cover size-full group-hocus-within:scale-105 transi
 
 export const contentWrapper = (isHorizontal: boolean, isListView: boolean) => cnb({
   'rs-pr-4 rs-py-4': isHorizontal && !isListView,
-  'pt-20 lg:rs-pt-3': isHorizontal && isListView,
+  'pt-20 md:pt-30 xl:pt-45 2xl:pt-48': isHorizontal && isListView,
 });
 export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHeading: boolean, isListView: boolean) => cnb('text-current', {
-  'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem]': hasTabColor,
+  'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem]': hasTabColor && !isListView,
+  'border-l-[1.2rem] xl:border-l-[1.8rem]': hasTabColor && isListView,
   '@200:pl-12 @xs:pl-21 @200:pr-08em @320:pr-1em': hasTabColor && !isHorizontal,
   'mt-06em rs-mb-neg1 pr-08em xl:pr-1em pl-12 xl:pl-21': !isHorizontal,
-  'rs-pb-2 mb-0 rs-pl-2': isHorizontal,
+  'rs-pb-2 mb-0 rs-pl-2': isHorizontal && !isListView,
+  'rs-pb-0 mb-0 pl-20 xl:pl-38': isHorizontal && isListView,
   'type-3': !isHorizontal && !isSmallHeading,
   'type-2': !isHorizontal && isSmallHeading,
-  'fluid-type-4 xl:fluid-type-5': isHorizontal && !isSmallHeading && !isListView,
+  'fluid-type-4 2xl:fluid-type-5': isHorizontal && !isSmallHeading && !isListView,
   'fluid-type-3 2xl:fluid-type-4': (isHorizontal && isSmallHeading && !isListView) || isListView,
 });
 
@@ -42,7 +44,8 @@ export const taxonomy = (hasTabColor: boolean) => cnb('list-unstyled leading-dis
 
 export const taxonomyItem = 'inline-block mb-0';
 
-export const body = (isHorizontal: boolean) => cnb('max-w-prose', {
-  'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem] rs-pl-2' : isHorizontal,
-  'pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 pr-08em xl:pr-1em @200:pr-08em @320:pr-1em ml-12 xl:ml-18 @200:ml-12 @xs:ml-18': !isHorizontal,
+export const body = (isHorizontal: boolean, isListView: boolean) => cnb('max-w-prose', {
+  'big-paragraph leading-snug border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem] rs-pl-2' : isHorizontal && !isListView,
+  'text-09em md:type-0 2xl:text-26 leading-display 2xl:leading-snug border-l-[1.2rem] xl:border-l-[1.8rem] pl-20 xl:pl-38': isListView,
+  'gc-card leading-display pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 pr-08em xl:pr-1em @200:pr-08em @320:pr-1em ml-12 xl:ml-18 @200:ml-12 @xs:ml-18': !isHorizontal && !isListView,
 });

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -1,7 +1,7 @@
 import { cnb } from 'cnbuilder';
 
 export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
-  '@container relative z-10 mx-auto focus-within:outline', {
+  '@container relative z-10 mx-auto', {
   'max-w-300 sm:max-w-400 md:max-w-full': !isHorizontal,
   'max-w-600 lg:max-w-none': isHorizontal && !isListView,
   'max-w-300 sm:max-w-none': isListView,
@@ -37,7 +37,7 @@ export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHead
   'fluid-type-3 2xl:fluid-type-4': (isHorizontal && isSmallHeading && !isListView) || isListView,
 });
 
-export const headingLink = 'stretched-link no-underline !font-bold !leading-tight';
+export const headingLink = 'stretched-link no-underline !font-bold !leading-tight focus-visible:after:outline focus-visible:after:outline-offset-2';
 
 export const taxonomy = (hasTabColor: boolean) => cnb('list-unstyled leading-display *:mr-12 last:*:ml-0 mr-18 ml-36', {
   '@200:ml-24 @xs:ml-36': hasTabColor,

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -1,15 +1,16 @@
 import { cnb } from 'cnbuilder';
 
-export const root = (isHorizontal: boolean) => cnb(
+export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
   '@container relative z-10 mx-auto', {
   'max-w-300 sm:max-w-400 md:max-w-full': !isHorizontal,
-  'max-w-700 lg:max-w-none': isHorizontal,
+  'max-w-700 lg:max-w-none': isHorizontal && !isListView,
   },
 );
 
-export const cardWrapper = (isHorizontal: boolean) => cnb(
+export const cardWrapper = (isHorizontal: boolean, isListView: boolean) => cnb(
   'relative group', {
-  'grid lg:grid-cols-2 bg-black-true/50': isHorizontal,
+  'grid lg:grid-cols-2 bg-black-true/50': isHorizontal && !isListView,
+  'grid sm:grid-cols-[3fr_5fr] lg:grid-cols-[3fr_7fr] items-start': isHorizontal && isListView,
   '@200:text-15 @250:text-17 @280:!type-0 @md:!text-26': !isHorizontal,
   },
 );
@@ -18,18 +19,19 @@ export const imageWrapper = 'transition-all aspect-w-1 aspect-h-1 overflow-hidde
 
 export const image = 'object-cover size-full group-hocus-within:scale-105 transition-transform';
 
-export const contentWrapper = (isHorizontal: boolean) => cnb({
-  'rs-pr-4 rs-py-4': isHorizontal,
+export const contentWrapper = (isHorizontal: boolean, isListView: boolean) => cnb({
+  'rs-pr-4 rs-py-4': isHorizontal && !isListView,
+  'pt-20 lg:rs-pt-3': isHorizontal && isListView,
 });
-export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHeading: boolean) => cnb('text-current', {
+export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHeading: boolean, isListView: boolean) => cnb('text-current', {
   'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem]': hasTabColor,
   '@200:pl-12 @xs:pl-21 @200:pr-08em @320:pr-1em': hasTabColor && !isHorizontal,
   'mt-06em rs-mb-neg1 pr-08em xl:pr-1em pl-12 xl:pl-21': !isHorizontal,
   'rs-pb-2 mb-0 rs-pl-2': isHorizontal,
   'type-3': !isHorizontal && !isSmallHeading,
   'type-2': !isHorizontal && isSmallHeading,
-  'fluid-type-4 xl:fluid-type-5': isHorizontal && !isSmallHeading,
-  'fluid-type-3 xl:fluid-type-4': isHorizontal && isSmallHeading,
+  'fluid-type-4 xl:fluid-type-5': isHorizontal && !isSmallHeading && !isListView,
+  'fluid-type-3 2xl:fluid-type-4': (isHorizontal && isSmallHeading && !isListView) || isListView,
 });
 
 export const headingLink = 'stretched-link no-underline !font-bold !leading-tight';
@@ -40,7 +42,7 @@ export const taxonomy = (hasTabColor: boolean) => cnb('list-unstyled leading-dis
 
 export const taxonomyItem = 'inline-block mb-0';
 
-export const body = (isHorizontal: boolean) => cnb('', {
+export const body = (isHorizontal: boolean) => cnb('max-w-prose', {
   'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem] rs-pl-2' : isHorizontal,
   'pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 pr-08em xl:pr-1em @200:pr-08em @320:pr-1em ml-12 xl:ml-18 @200:ml-12 @xs:ml-18': !isHorizontal,
 });

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -40,8 +40,8 @@ export const StoryCard = ({
   taxonomy,
   animation = 'none',
   delay,
-  isListView = true,
-  isHorizontal = isListView,
+  isListView,
+  isHorizontal,
   className,
   ...props
 }: StoryCardProps) => {
@@ -108,10 +108,10 @@ export const StoryCard = ({
             )}
             {body && (
               <Paragraph
-                variant={isHorizontal ? 'big' : 'card'}
-                leading={isHorizontal ? 'snug' : 'display'}
+                //variant={isHorizontal ? 'big' : 'card'}
+                //leading={isHorizontal ? 'snug' : 'display'}
                 noMargin
-                className={cnb(styles.body(isHorizontal), accentBorderColors[tabColor])}
+                className={cnb(styles.body(isHorizontal, isListView), accentBorderColors[tabColor])}
               >
                 {body}
               </Paragraph>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -1,14 +1,14 @@
 import { cnb } from 'cnbuilder';
-import { AnimateInView, type AnimationType } from '../Animate';
-import { CtaLink } from '../Cta/CtaLink';
+import { AnimateInView, type AnimationType } from '@/components/Animate';
+import { CtaLink } from '@/components/Cta/CtaLink';
+import { FlexBox } from '@/components/FlexBox';
 import {
   Heading, type HeadingType, Paragraph, type FontSizeType,
 } from '../Typography';
-import { SbLinkType } from '../Storyblok/Storyblok.types';
+import { SbLinkType } from '@/components/Storyblok/Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
 import * as styles from './StoryCard.styles';
-import { FlexBox } from '../FlexBox';
 
 export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
   heading?: string;
@@ -108,8 +108,6 @@ export const StoryCard = ({
             )}
             {body && (
               <Paragraph
-                //variant={isHorizontal ? 'big' : 'card'}
-                //leading={isHorizontal ? 'snug' : 'display'}
                 noMargin
                 className={cnb(styles.body(isHorizontal, isListView), accentBorderColors[tabColor])}
               >

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -24,6 +24,7 @@ export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
   animation?: AnimationType;
   delay?: number;
   isHorizontal?: boolean;
+  isListView?: boolean;
 };
 
 export const StoryCard = ({
@@ -39,7 +40,8 @@ export const StoryCard = ({
   taxonomy,
   animation = 'none',
   delay,
-  isHorizontal,
+  isListView = true,
+  isHorizontal = isListView,
   className,
   ...props
 }: StoryCardProps) => {
@@ -53,10 +55,10 @@ export const StoryCard = ({
   return (
     <AnimateInView animation={animation} delay={delay}>
       <article
-        className={cnb(styles.root(isHorizontal), className)}
+        className={cnb(styles.root(isHorizontal, isListView), className)}
         {...props}
       >
-        <div className={styles.cardWrapper(isHorizontal)}>
+        <div className={styles.cardWrapper(isHorizontal, isListView)}>
           {imageSrc && (
             <div className={styles.imageWrapper}>
               <picture>
@@ -88,13 +90,16 @@ export const StoryCard = ({
           <FlexBox
             direction="col"
             justifyContent={isHorizontal ? 'center' : undefined}
-            className={styles.contentWrapper(isHorizontal)}
+            className={styles.contentWrapper(isHorizontal, isListView)}
           >
             {heading && (
               <Heading
                 as={headingLevel}
                 leading="none"
-                className={cnb(styles.heading(!!tabColor, isHorizontal, isSmallHeading), accentBorderColors[tabColor])}
+                className={cnb(
+                  styles.heading(!!tabColor, isHorizontal, isSmallHeading, isListView),
+                  accentBorderColors[tabColor])
+                }
               >
                 <CtaLink sbLink={link} href={href} className={styles.headingLink}>
                   {heading}

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.styles.ts
@@ -7,6 +7,6 @@ export const header = 'relative overflow-hidden cc 3xl:px-100 4xl:px-[calc((100%
 export const superhead = (isDarkTheme: boolean) => isDarkTheme && 'text-shadow-sm';
 export const heading = 'fluid-type-7 md:gc-splash mb-0 whitespace-pre-line';
 export const introWrapper = 'cc relative z-20';
-export const intro = (isDarkTheme: boolean) => cnb('intro-text *:leading-display *:md:leading-cozy rs-mt-7 max-w-1000', isDarkTheme && 'text-shadow-sm');
+export const intro = (isDarkTheme: boolean) => cnb('intro-text *:leading-display *:md:leading-snug rs-mt-7 max-w-1000', isDarkTheme && 'text-shadow-sm');
 export const contentWrapper = 'relative z-20';
 export const cta = 'relative cc md:flex-row *:mx-auto rs-mt-6 gap-20 lg:gap-27 w-fit';

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -1,7 +1,7 @@
 import { storyblokEditable } from '@storyblok/react/rsc';
-import { type AnimationType } from '../Animate';
-import { type HeadingType } from '../Typography';
-import { StoryCard } from '../StoryCard';
+import { type AnimationType } from '@/components/Animate';
+import { type HeadingType } from '@/components/Typography';
+import { StoryCard } from '@/components/StoryCard';
 import { type SbImageType, type SbLinkType } from './Storyblok.types';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -32,6 +32,7 @@ export type SbStoryCardProps = {
     animation?: AnimationType;
     delay?: number;
     isHorizontal?: boolean;
+    isListView?: boolean;
   };
 };
 
@@ -60,6 +61,7 @@ export const SbStoryCard = ({
     animation,
     delay,
     isHorizontal,
+    isListView,
   },
   blok,
 }: SbStoryCardProps) => (
@@ -78,5 +80,6 @@ export const SbStoryCard = ({
     delay={delay}
     taxonomy={topics}
     isHorizontal={isHorizontal}
+    isListView={isListView}
   />
 );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- List view for Story Cards (for the story landing/filter page)

# Review By (Date)
- Retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

**Note:** This has been approved by Kerri on the design side. I'll add taxonomy chips in another ticket to all story cards

1. Go to storyblok test/home-new-test
2. Pick PR 272 from the visual editor
3. Look at the first section - these story cards

![Screenshot 2024-04-24 at 2 05 58 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/d50c481f-431d-48a2-b75d-d851679bea94)

4. Resize slowly and check all responsive styles
5. Go to https://deploy-preview-272--giving-campaign.netlify.app/ and make sure current story cards look the same as before.

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-333