### PR TITLE
GIVCAMP-342 | Add taxonomy chips and light/dark mode to all variants of Story Cards

### DIFF
--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -20,7 +20,7 @@ const brochureIlluminating = 'from-illuminating to-illuminating';
 const brochurePoppy = 'from-poppy to-poppy';
 
 const chipBase = 'relative inline-block border leading-display rounded-full font-normal no-underline underline-offset-4 hocus:underline hocus:bg-digital-red-light hocus:text-white';
-const chipLight = 'border border-gc-black-20 bg-gc-black-10 text-gc-black-80 hocus:border-digital-red-xlight';
+const chipLight = 'border-gc-black/10 bg-gc-black-10 text-gc-black-80 hocus:border-digital-red-xlight';
 const chipDark = 'border-gc-black-80 bg-gc-black-90 text-gc-black-40 hocus:border-digital-red-xlight';
 
 export const ctaVariants = {

--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -9,7 +9,7 @@ import {
 
 export const cta = 'group hocus:underline transition-all';
 
-const ghostSwipeBase = 'relative z-[10] block w-fit decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 font-normal leading-display hocus:text-white border-2 border-current hocus:border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-[0] after:h-full after:bg-gradient-to-r after:from-digital-red after:to-cardinal-red after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden';
+const ghostSwipeBase = 'relative z-[10] block w-fit decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 font-normal leading-display hocus:text-white border-2 border-current hocus:border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-digital-red after:to-cardinal-red after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden';
 
 const mastheadGivingBase = 'inline-block w-fit font-normal no-underline leading-display hocus:decoration-2 focus-visible:ring-2 focus-visible:ring-digital-red-xlight ring-offset-4 focus-visible:outline-none focus-visible:rounded underline-offset-4';
 const mastheadGivingWhite = 'text-white hocus:text-white hocus:decoration-white focus-visible:ring-offset-black';
@@ -19,8 +19,12 @@ const brochureBase = 'inline-block font-bold font-serif no-underline hocus:no-un
 const brochureIlluminating = 'from-illuminating to-illuminating';
 const brochurePoppy = 'from-poppy to-poppy';
 
+const chipBase = 'relative inline-block leading-display rounded-full font-normal no-underline underline-offset-4 hocus:underline';
+const chipLight = 'bg-gc-black-10 hocus:bg-digital-red-light text-gc-black-80 hocus:text-white';
+const chipDark = 'bg-gc-black-90 hocus:bg-digital-red-light text-gc-black-40 hocus:text-white';
+
 export const ctaVariants = {
-  solid: 'block w-fit relative z-[10] font-normal decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 leading-display bg-digital-red text-white hocus:text-white border-2 border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-[0] after:h-full after:bg-gradient-to-r after:from-cardinal-red after:to-cardinal-red-dark after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden',
+  solid: 'block w-fit relative z-[10] font-normal decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 leading-display bg-digital-red text-white hocus:text-white border-2 border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-cardinal-red after:to-cardinal-red-dark after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden',
   inline: 'inline underline decoration-1 hocus:decoration-2 underline-offset-2',
   inlineDark: 'inline text-digital-red-xlight hocus:text-white underline decoration-1 hocus:decoration-2 underline-offset-2',
   ghost: ' block w-fit font-normal leading-display bg-transparent hocus:text-current border-2 border-current focus-visible:outline-none underline-offset-4 decoration-transparent hocus:decoration-current',
@@ -33,7 +37,8 @@ export const ctaVariants = {
   close: 'inline-block font-semibold leading-none text-digital-red-light hocus:text-digital-red-xlight focus:outline-none',
   'close-x': 'leading-none',
   chip: 'inline-block leading-display no-underline text-current rounded-full border-2 border-current hocus:text-current font-normal underline-offset-4 decoration-transparent hocus-visible:decoration-current hocus-visible:decoration-2',
-  storyCardTag: 'inline-block text-current hocus:text-current font-normal decoration-2 underline-offset-4 decoration-black-50 hocus:decoration-current hocus:decoration-4',
+  storyCardChip: `${chipBase} ${chipLight}`,
+  storyCardChipDark: `${chipBase} ${chipDark}`,
   brochure: `${brochureBase} ${brochureIlluminating}`,
   brochurePoppy: `${brochureBase} ${brochurePoppy}`,
   unset: '',
@@ -78,7 +83,7 @@ export const ctaSizes: CtaSizeObjectType = {
   back: 'text-16',
   close: 'text-18 md:text-21',
   chip: 'py-7 px-22 text-18',
-  storyCardTag: 'text-16 lg:text-18',
+  storyCardChip: 'text-15 py-6 px-16 lg:text-17 lg:pt-8 lg:pb-7 lg:px-18',
   brochure: 'text-20 xl:text-30 py-12',
   unset: '',
 };
@@ -97,7 +102,8 @@ export const ctaSizeMap: CtaSizeMapType = {
   'close-x': 'unset',
   back: 'back',
   chip: 'chip',
-  storyCardTag: 'storyCardTag',
+  storyCardChip: 'storyCardChip',
+  storyCardChipDark: 'storyCardChip',
   brochure: 'brochure',
   brochurePoppy: 'brochure',
   unset: 'unset',

--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -9,7 +9,7 @@ import {
 
 export const cta = 'group hocus:underline transition-all';
 
-const ghostSwipeBase = 'relative z-[10] block w-fit decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 font-normal leading-display hocus:text-white border-2 border-current hocus:border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-digital-red after:to-cardinal-red after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden';
+const ghostSwipeBase = 'relative z-10 block w-fit decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 font-normal leading-display hocus:text-white border-2 border-current hocus:border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-digital-red after:to-cardinal-red after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden';
 
 const mastheadGivingBase = 'inline-block w-fit font-normal no-underline leading-display hocus:decoration-2 focus-visible:ring-2 focus-visible:ring-digital-red-xlight ring-offset-4 focus-visible:outline-none focus-visible:rounded underline-offset-4';
 const mastheadGivingWhite = 'text-white hocus:text-white hocus:decoration-white focus-visible:ring-offset-black';
@@ -24,7 +24,7 @@ const chipLight = 'border border-gc-black-20 bg-gc-black-10 text-gc-black-80 hoc
 const chipDark = 'border-gc-black-80 bg-gc-black-90 text-gc-black-40 hocus:border-digital-red-xlight';
 
 export const ctaVariants = {
-  solid: 'block w-fit relative z-[10] font-normal decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 leading-display bg-digital-red text-white hocus:text-white border-2 border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-cardinal-red after:to-cardinal-red-dark after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden',
+  solid: 'block w-fit relative z-10 font-normal decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 leading-display bg-digital-red text-white hocus:text-white border-2 border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-cardinal-red after:to-cardinal-red-dark after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden',
   inline: 'inline underline decoration-1 hocus:decoration-2 underline-offset-2',
   inlineDark: 'inline text-digital-red-xlight hocus:text-white underline decoration-1 hocus:decoration-2 underline-offset-2',
   ghost: ' block w-fit font-normal leading-display bg-transparent hocus:text-current border-2 border-current focus-visible:outline-none underline-offset-4 decoration-transparent hocus:decoration-current',

--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -21,7 +21,7 @@ const brochurePoppy = 'from-poppy to-poppy';
 
 const chipBase = 'relative inline-block leading-display rounded-full font-normal no-underline underline-offset-4 hocus:underline';
 const chipLight = 'bg-gc-black-10 hocus:bg-digital-red-light text-gc-black-80 hocus:text-white';
-const chipDark = 'bg-gc-black-90 hocus:bg-digital-red-light text-gc-black-40 hocus:text-white';
+const chipDark = 'border border-gc-black-80 bg-gc-black-90 hocus:bg-digital-red-light text-gc-black-40 hocus:text-white';
 
 export const ctaVariants = {
   solid: 'block w-fit relative z-[10] font-normal decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 leading-display bg-digital-red text-white hocus:text-white border-2 border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-cardinal-red after:to-cardinal-red-dark after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden',

--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -19,9 +19,9 @@ const brochureBase = 'inline-block font-bold font-serif no-underline hocus:no-un
 const brochureIlluminating = 'from-illuminating to-illuminating';
 const brochurePoppy = 'from-poppy to-poppy';
 
-const chipBase = 'relative inline-block leading-display rounded-full font-normal no-underline underline-offset-4 hocus:underline';
-const chipLight = 'bg-gc-black-10 hocus:bg-digital-red-light text-gc-black-80 hocus:text-white';
-const chipDark = 'border border-gc-black-80 bg-gc-black-90 hocus:bg-digital-red-light text-gc-black-40 hocus:text-white';
+const chipBase = 'relative inline-block border leading-display rounded-full font-normal no-underline underline-offset-4 hocus:underline hocus:bg-digital-red-light hocus:text-white';
+const chipLight = 'border border-gc-black-20 bg-gc-black-10 text-gc-black-80 hocus:border-digital-red-xlight';
+const chipDark = 'border-gc-black-80 bg-gc-black-90 text-gc-black-40 hocus:border-digital-red-xlight';
 
 export const ctaVariants = {
   solid: 'block w-fit relative z-[10] font-normal decoration-2 decoration-transparent underline-offset-4 hocus:decoration-white/80 leading-display bg-digital-red text-white hocus:text-white border-2 border-digital-red-light focus-visible:outline-none after:block after:content-[""] after:absolute after:top-0 after:left-0 after:w-0 after:h-full after:bg-gradient-to-r after:from-cardinal-red after:to-cardinal-red-dark after:transition-all after:z-[-1] hocus:after:w-full overflow-hidden',

--- a/components/Scrollytelling/Scrollytelling.tsx
+++ b/components/Scrollytelling/Scrollytelling.tsx
@@ -119,7 +119,7 @@ export const Scrollytelling = ({
               <AnimateInView animation="slideUp" delay={0.1} className={styles.header}>
                 {heading && (
                   <Heading
-                    as={headingLevel}
+                    as={headingLevel || 'h2'}
                     size={5}
                     color="white"
                     align="center"

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -46,7 +46,7 @@ export const body = (isHorizontal: boolean, isListView: boolean) => cnb('max-w-p
 export const taxonomy = (isHorizontal: boolean, isListView: boolean) => cnb('flex flex-wrap gap-10 list-unstyled leading-display', {
   'rs-mt-2 xl:rs-mt-4 ml-32 sm:ml-38 md:ml-44 xl:ml-[5.4rem] 2xl:ml-[5.6rem]': isHorizontal && !isListView,
   'mt-18 lg:mt-36 2xl:mt-38 ml-32 xl:ml-[5.6rem]': isListView,
-  'rs-mt-0 mr-20 sm:ml-24': !isHorizontal && !isListView,
+  'rs-mt-0 mr-20 ml-24 xl:ml-39 @200:ml-24 @xs:ml-39': !isHorizontal && !isListView,
 });
 export const taxonomyItem = 'inline-block mb-0';
 export const taxonomyLink = 'relative z-20';

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -21,35 +21,32 @@ export const imageWrapper = 'transition-all aspect-w-1 aspect-h-1 overflow-hidde
 export const image = 'object-cover size-full group-hocus-within:scale-105 transition-transform';
 
 export const contentWrapper = (isHorizontal: boolean, isListView: boolean) => cnb({
-  'rs-pr-4 rs-py-4': isHorizontal && !isListView,
+  'rs-pr-4 rs-pt-4 pb-50 md:rs-py-4': isHorizontal && !isListView,
   'pt-20 md:pt-30 xl:pt-45 2xl:pt-48': isListView,
 });
-export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHeading: boolean, isListView: boolean) => cnb('text-current', {
-  'border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem]': hasTabColor && !isListView,
-  'border-l-[1.2rem] xl:border-l-[1.8rem]': hasTabColor && isListView,
-  '@200:pl-12 @xs:pl-21 @200:pr-08em @320:pr-1em': hasTabColor && !isHorizontal && !isListView,
-  'mt-06em rs-mb-neg1 pr-08em xl:pr-1em pl-12 xl:pl-21': !isHorizontal && !isListView,
-  'rs-pb-2 mb-0 rs-pl-2': isHorizontal && !isListView,
-  'rs-pb-0 mb-0 pl-20 xl:pl-38': isListView,
-  'type-3': !isHorizontal && !isSmallHeading,
-  'type-2': !isHorizontal && isSmallHeading,
-  'fluid-type-4 2xl:fluid-type-5': isHorizontal && !isSmallHeading && !isListView,
-  'fluid-type-3 2xl:fluid-type-4': (isHorizontal && isSmallHeading && !isListView) || isListView,
+export const heading = (isHorizontal: boolean, isSmallHeading: boolean, isListView: boolean) => cnb('text-current', {
+  'mt-06em rs-mb-neg1 pr-20 xl:pr-24 pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 @200:pr-08em @320:pr-1em border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem]': !isHorizontal && !isListView, // Vertical card
+  'rs-pb-2 mb-0 rs-pl-1 xl:rs-pl-2 border-l-[1.2rem] sm:border-l-[1.8rem]': isHorizontal && !isListView, // Horizontal card
+  'rs-pb-0 mb-0 pl-20 xl:pl-38 border-l-[1.2rem] xl:border-l-[1.8rem]': isListView, // List card
+  'type-3': !isHorizontal && !isListView && !isSmallHeading, // Vertical + regular heading
+  'type-2': !isHorizontal && !isListView && isSmallHeading, // Vertical + small heading
+  'fluid-type-4 lg:type-3 xl:fluid-type-4 2xl:fluid-type-5': isHorizontal && !isSmallHeading && !isListView, // Horizontal + regular heading
+  'type-3 2xl:fluid-type-4': (isHorizontal && isSmallHeading && !isListView) || isListView, // Horizontal + small heading or list view
+  'xl:max-w-[30ch]': isListView,
 });
 
 export const headingLink = 'stretched-link no-underline !font-bold !leading-tight focus-visible:after:outline focus-visible:after:outline-offset-2';
 
 export const body = (isHorizontal: boolean, isListView: boolean) => cnb('max-w-prose', {
-  'big-paragraph leading-snug border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem] rs-pl-2' : isHorizontal && !isListView,
+  'big-paragraph leading-snug border-l-[1.2rem] sm:border-l-[1.8rem] rs-pl-1 xl:rs-pl-2' : isHorizontal && !isListView,
   'text-09em md:type-0 2xl:text-26 leading-display 2xl:leading-snug border-l-[1.2rem] xl:border-l-[1.8rem] pl-20 xl:pl-38': isListView,
-  'gc-card leading-display pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 pr-08em xl:pr-1em @200:pr-08em @320:pr-1em ml-12 xl:ml-18 @200:ml-12 @xs:ml-18': !isHorizontal && !isListView,
+  'gc-card leading-display pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 pr-20 xl:pr-24 @200:pr-20 @320:pr-24 ml-12 xl:ml-18 @200:ml-12 @xs:ml-18': !isHorizontal && !isListView,
 });
 
-export const taxonomy = (hasTabColor: boolean, isHorizontal: boolean, isListView: boolean) => cnb('flex flex-wrap gap-10 list-unstyled leading-display mr-18 ml-36', {
-  '@200:ml-24 @xs:ml-36': hasTabColor,
-  'rs-mt-4': isHorizontal && !isListView,
-  'mt-18 md:mt-36 2xl:mt-38': isListView,
-  'rs-mt-0': !isHorizontal && !isListView,
+export const taxonomy = (isHorizontal: boolean, isListView: boolean) => cnb('flex flex-wrap gap-10 list-unstyled leading-display', {
+  'rs-mt-2 xl:rs-mt-4 ml-32 sm:ml-38 md:ml-44 xl:ml-[5.4rem] 2xl:ml-[5.6rem]': isHorizontal && !isListView,
+  'mt-18 lg:mt-36 2xl:mt-38 ml-32 xl:ml-[5.6rem]': isListView,
+  'rs-mt-0 mr-20 sm:ml-24': !isHorizontal && !isListView,
 });
-
 export const taxonomyItem = 'inline-block mb-0';
+export const taxonomyLink = 'relative z-20';

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -8,9 +8,11 @@ export const root = (isHorizontal: boolean, isListView: boolean) => cnb(
   },
 );
 
-export const cardWrapper = (isHorizontal: boolean, isListView: boolean) => cnb(
+export const cardWrapper = (isHorizontal: boolean, isListView: boolean, isDark: boolean) => cnb(
   'relative group', {
-  'grid lg:grid-cols-2 bg-black-true/50': isHorizontal && !isListView,
+  'grid lg:grid-cols-2': isHorizontal && !isListView,
+  'bg-black-true/50': isHorizontal && isDark && !isListView,
+  'bg-white/50': isHorizontal && !isDark && !isListView,
   'grid sm:grid-cols-[3fr_5fr] lg:grid-cols-[3fr_7fr] 2xl:grid-cols-[1fr_3fr] items-start': isListView,
   '@200:text-15 @250:text-17 @280:!type-0 @md:!text-26': !isHorizontal && !isListView,
   },

--- a/components/StoryCard/StoryCard.styles.tsx
+++ b/components/StoryCard/StoryCard.styles.tsx
@@ -39,14 +39,17 @@ export const heading = (hasTabColor: boolean, isHorizontal: boolean, isSmallHead
 
 export const headingLink = 'stretched-link no-underline !font-bold !leading-tight focus-visible:after:outline focus-visible:after:outline-offset-2';
 
-export const taxonomy = (hasTabColor: boolean) => cnb('list-unstyled leading-display *:mr-12 last:*:ml-0 mr-18 ml-36', {
-  '@200:ml-24 @xs:ml-36': hasTabColor,
-});
-
-export const taxonomyItem = 'inline-block mb-0';
-
 export const body = (isHorizontal: boolean, isListView: boolean) => cnb('max-w-prose', {
   'big-paragraph leading-snug border-l-[1.2rem] xl:border-l-[1.8rem] @200:border-l-[1.2rem] @xs:border-l-[1.8rem] rs-pl-2' : isHorizontal && !isListView,
   'text-09em md:type-0 2xl:text-26 leading-display 2xl:leading-snug border-l-[1.2rem] xl:border-l-[1.8rem] pl-20 xl:pl-38': isListView,
   'gc-card leading-display pl-12 xl:pl-21 @200:pl-12 @xs:pl-21 pr-08em xl:pr-1em @200:pr-08em @320:pr-1em ml-12 xl:ml-18 @200:ml-12 @xs:ml-18': !isHorizontal && !isListView,
 });
+
+export const taxonomy = (hasTabColor: boolean, isHorizontal: boolean, isListView: boolean) => cnb('flex flex-wrap gap-10 list-unstyled leading-display mr-18 ml-36', {
+  '@200:ml-24 @xs:ml-36': hasTabColor,
+  'rs-mt-4': isHorizontal && !isListView,
+  'mt-18 md:mt-36 2xl:mt-38': isListView,
+  'rs-mt-0': !isHorizontal && !isListView,
+});
+
+export const taxonomyItem = 'inline-block mb-0';

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -8,7 +8,7 @@ import {
 import { SbLinkType } from '@/components/Storyblok/Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
-import { initiativesMap } from '@/utilities/taxonomyMaps';
+import { initiativesMap, type InitiativesType } from '@/utilities/taxonomyMaps';
 import * as styles from './StoryCard.styles';
 
 export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -21,7 +21,7 @@ export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
   tabColor?: AccentBorderColorType;
   href?: string;
   link?: SbLinkType;
-  taxonomy?: string[];
+  taxonomy?: InitiativesType[];
   animation?: AnimationType;
   delay?: number;
   isHorizontal?: boolean;

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -26,6 +26,7 @@ export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
   delay?: number;
   isHorizontal?: boolean;
   isListView?: boolean;
+  isDark?: boolean;
 };
 
 export const StoryCard = ({
@@ -43,6 +44,7 @@ export const StoryCard = ({
   delay,
   isListView,
   isHorizontal,
+  isDark,
   className,
   ...props
 }: StoryCardProps) => {
@@ -119,7 +121,7 @@ export const StoryCard = ({
               <ul className={styles.taxonomy(isHorizontal, isListView)}>
                 {taxonomy.slice(0, 3).map((item) => (
                   <li key={item} className={styles.taxonomyItem}>
-                    <CtaLink href={`/stories/list/item`} variant="storyCardChipDark" className={styles.taxonomyLink}>
+                    <CtaLink href={`/stories/list/${item}`} variant="storyCardChipDark" className={styles.taxonomyLink}>
                       {initiativesMap[item]}
                     </CtaLink>
                   </li>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -98,7 +98,7 @@ export const StoryCard = ({
                 as={headingLevel}
                 leading="none"
                 className={cnb(
-                  styles.heading(!!tabColor, isHorizontal, isSmallHeading, isListView),
+                  styles.heading(isHorizontal, isSmallHeading, isListView),
                   accentBorderColors[tabColor])
                 }
               >
@@ -116,10 +116,10 @@ export const StoryCard = ({
               </Paragraph>
             )}
             {!!taxonomy?.length && (
-              <ul className={styles.taxonomy(!!tabColor, isHorizontal, isListView)}>
+              <ul className={styles.taxonomy(isHorizontal, isListView)}>
                 {taxonomy.slice(0, 3).map((item) => (
                   <li key={item} className={styles.taxonomyItem}>
-                    <CtaLink href={`/stories/list/item`} variant="storyCardChipDark" className="z-20">
+                    <CtaLink href={`/stories/list/item`} variant="storyCardChipDark" className={styles.taxonomyLink}>
                       {initiativesMap[item]}
                     </CtaLink>
                   </li>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -116,10 +116,12 @@ export const StoryCard = ({
               </Paragraph>
             )}
             {!!taxonomy?.length && (
-              <ul className={styles.taxonomy(!!tabColor)}>
+              <ul className={styles.taxonomy(!!tabColor, isHorizontal, isListView)}>
                 {taxonomy.slice(0, 3).map((item) => (
                   <li key={item} className={styles.taxonomyItem}>
-                    <CtaLink href={`/stories/list/item`} variant="storyCardTag">{initiativesMap[item]}</CtaLink>
+                    <CtaLink href={`/stories/list/item`} variant="storyCardChipDark" className="z-20">
+                      {initiativesMap[item]}
+                    </CtaLink>
                   </li>
                 ))}
               </ul>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -61,7 +61,7 @@ export const StoryCard = ({
         className={cnb(styles.root(isHorizontal, isListView), className)}
         {...props}
       >
-        <div className={styles.cardWrapper(isHorizontal, isListView)}>
+        <div className={styles.cardWrapper(isHorizontal, isListView, isDark)}>
           {imageSrc && (
             <div className={styles.imageWrapper}>
               <picture>
@@ -98,6 +98,7 @@ export const StoryCard = ({
             {heading && (
               <Heading
                 as={headingLevel}
+                color={isDark ? 'white' : 'black'}
                 leading="none"
                 className={cnb(
                   styles.heading(isHorizontal, isSmallHeading, isListView),
@@ -111,6 +112,7 @@ export const StoryCard = ({
             )}
             {body && (
               <Paragraph
+                color={isDark ? 'white' : 'black'}
                 noMargin
                 className={cnb(styles.body(isHorizontal, isListView), accentBorderColors[tabColor])}
               >
@@ -121,7 +123,7 @@ export const StoryCard = ({
               <ul className={styles.taxonomy(isHorizontal, isListView)}>
                 {taxonomy.slice(0, 3).map((item) => (
                   <li key={item} className={styles.taxonomyItem}>
-                    <CtaLink href={`/stories/list/${item}`} variant="storyCardChipDark" className={styles.taxonomyLink}>
+                    <CtaLink href={`/stories/list/${item}`} variant={isDark ? 'storyCardChipDark' : 'storyCardChip'} className={styles.taxonomyLink}>
                       {initiativesMap[item]}
                     </CtaLink>
                   </li>

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -8,6 +8,7 @@ import {
 import { SbLinkType } from '@/components/Storyblok/Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
+import { initiativesMap } from '@/utilities/taxonomyMaps';
 import * as styles from './StoryCard.styles';
 
 export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -113,6 +114,15 @@ export const StoryCard = ({
               >
                 {body}
               </Paragraph>
+            )}
+            {!!taxonomy?.length && (
+              <ul className={styles.taxonomy(!!tabColor)}>
+                {taxonomy.slice(0, 3).map((item) => (
+                  <li key={item} className={styles.taxonomyItem}>
+                    <CtaLink href={`/stories/list/item`} variant="storyCardTag">{initiativesMap[item]}</CtaLink>
+                  </li>
+                ))}
+              </ul>
             )}
           </FlexBox>
         </div>

--- a/components/Storyblok/SbStory.tsx
+++ b/components/Storyblok/SbStory.tsx
@@ -1,7 +1,12 @@
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { CreateBloks } from '@/components/CreateBloks';
 import { Masthead } from '@/components/Masthead';
-import { StoryHero, type StoryHeroProps } from '@/components/Hero';
+import { type StoryHeroProps } from '@/components/Hero';
+
+/**
+ * This is the POC Story page type. Currently not in used.
+ * Please see SbStoryMvp for the ative Story page type.
+ */
 
 type SbStoryProps = {
   blok: {

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -19,6 +19,9 @@ export type SbStoryCardProps = {
         cardTitle?: string;
         cardTeaser?: string;
         cardImage?: SbImageType;
+        tabColor?: {
+          value?: PaletteAccentHexColorType;
+        }
       },
       full_slug?: string;
     };
@@ -49,6 +52,7 @@ export const SbStoryCard = ({
         cardTitle = '',
         cardTeaser = '',
         cardImage: { filename: storyCardFilename = '', focus: storyCardFocus = '' } = {},
+        tabColor: { value: storyTabColorValue } = {},
       } = {},
       full_slug,
     } = {},
@@ -74,7 +78,7 @@ export const SbStoryCard = ({
     body={cardTeaser || dek}
     imageSrc={cardImage || storyCardFilename || heroFilename || bgFilename }
     imageFocus={cardFocus || storyCardFocus || heroFocus || bgFocus}
-    tabColor={paletteAccentColors[value]}
+    tabColor={paletteAccentColors[value || storyTabColorValue]}
     link={link}
     href={`/${full_slug}`}
     animation={animation}

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -3,6 +3,7 @@ import { type AnimationType } from '@/components/Animate';
 import { type HeadingType } from '@/components/Typography';
 import { StoryCard } from '@/components/StoryCard';
 import { type SbImageType, type SbLinkType } from './Storyblok.types';
+import { type InitiativesType } from '@/utilities/taxonomyMaps';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 
 export type SbStoryCardProps = {
@@ -12,7 +13,7 @@ export type SbStoryCardProps = {
       content?: {
         title?: string;
         dek?: string;
-        initiatives?: string[];
+        initiatives?: InitiativesType[];
         heroImage?: SbImageType;
         bgImage?: SbImageType;
         cardTitle?: string;

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -12,7 +12,7 @@ export type SbStoryCardProps = {
       content?: {
         title?: string;
         dek?: string;
-        topics?: string[];
+        initiatives?: string[];
         heroImage?: SbImageType;
         bgImage?: SbImageType;
         cardTitle?: string;
@@ -42,7 +42,7 @@ export const SbStoryCard = ({
       content: {
         title = '',
         dek = '',
-        topics = [],
+        initiatives = [],
         heroImage: { filename: heroFilename = '', focus: heroFocus = '' } = {},
         bgImage: { filename: bgFilename = '', focus: bgFocus = '' } = {},
         cardTitle = '',
@@ -78,7 +78,7 @@ export const SbStoryCard = ({
     href={`/${full_slug}`}
     animation={animation}
     delay={delay}
-    taxonomy={topics}
+    taxonomy={initiatives}
     isHorizontal={isHorizontal}
     isListView={isListView}
   />

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -37,6 +37,7 @@ export type SbStoryCardProps = {
     delay?: number;
     isHorizontal?: boolean;
     isListView?: boolean;
+    isDark?: boolean;
   };
 };
 
@@ -67,6 +68,7 @@ export const SbStoryCard = ({
     delay,
     isHorizontal,
     isListView,
+    isDark,
   },
   blok,
 }: SbStoryCardProps) => (
@@ -86,5 +88,6 @@ export const SbStoryCard = ({
     taxonomy={initiatives}
     isHorizontal={isHorizontal}
     isListView={isListView}
+    isDark={isDark}
   />
 );

--- a/tailwind/plugins/theme/gc-colors.js
+++ b/tailwind/plugins/theme/gc-colors.js
@@ -12,6 +12,13 @@ module.exports = function () {
     sapphire: '#005776',
     slate: '#4E4B48',
     'gc-sky': '#4287BD', // For homepage hero sky gradient
-    'gc-black': '#17171A',
+    'gc-black': {
+      DEFAULT: '#17171A',
+      // For taxonomy chips
+      10: '#F3F3F9',
+      40: '#C4C4C7',
+      80: '#5A5A68',
+      90: '#393945',
+    }
   };
 };

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -1,0 +1,16 @@
+export const initiativesMap = {
+  'ethics-society-and-technology': 'Ethics, Society & Technology',
+  'human-centered-artificial-intelligence': 'Human-Centered Artificial Intelligence',
+  'innovative-medicines-accelerator': 'innovative-medicines-accelerator',
+  'racial-justice-initiative' : 'Racial Justice Initiative',
+  'stanford-accelerator-for-learning': 'Stanford Accelerator for Learning',
+  'stanford-arts': 'Stanford Arts',
+  'stanford-athletics': 'Stanford Athletics',
+  'stanford-business': 'Stanford Business',
+  'stanford-data-science': 'Stanford Data Science',
+  'stanford-impact-labs': 'Stanford Impact Labs',
+  'stanford-public-humanities': 'Stanford Public Humanities',
+  'stanford-science-fellows': 'Stanford Science Fellows',
+  'undergraduate-education-and-student-life': 'Undergraduate Education & Student Life',
+  'undergraduate-financial-aid': 'Undergraduate Financial Aid',
+};

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -14,3 +14,4 @@ export const initiativesMap = {
   'undergraduate-education-and-student-life': 'Undergraduate Education & Student Life',
   'undergraduate-financial-aid': 'Undergraduate Financial Aid',
 };
+export type InitiativesType = keyof typeof initiativesMap;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add taxonomy chips (initiative only for now) to all variants of Story Cards
- Add light/dark mode to Story Cards (it was inheriting parent container text color currently so it still sort of work, but this actual light/dark mode selection will modify the variant of the chips also (light/dark)

# Review By (Date)
- Retro

# Criticality
- 6

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to Storyblok `test/home-new-test` and select PR 273 from the visual editor URL
2. See the chips on the horizontal, list, and default (vertical) story card variants
3. Test responsive behavior and see that all chips are left aligned with the card body copy.
4. Go to the newsletter page and look at the light mode cards with the light mode tags. NOTE: Once this is live, we'll change the grid behavior of some of these card grids since the story cards are now too small when they have tags added.
![Screenshot 2024-05-01 at 4 55 30 PM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/fe6089b8-daae-453f-9760-8fa3d43b9d33)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-342