### PR TITLE
GIVCAMP-351 | Add themes to taxonomy in story cards

### DIFF
--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -8,7 +8,7 @@ import {
 import { SbLinkType } from '@/components/Storyblok/Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
-import { initiativesMap, type InitiativesType } from '@/utilities/taxonomyMaps';
+import { taxonomyMap, type TaxonomyType } from '@/utilities/taxonomyMaps';
 import * as styles from './StoryCard.styles';
 
 export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -21,7 +21,7 @@ export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
   tabColor?: AccentBorderColorType;
   href?: string;
   link?: SbLinkType;
-  taxonomy?: InitiativesType[];
+  taxonomy?: TaxonomyType[];
   animation?: AnimationType;
   delay?: number;
   isHorizontal?: boolean;
@@ -124,7 +124,7 @@ export const StoryCard = ({
                 {taxonomy.slice(0, 3).map((item) => (
                   <li key={item} className={styles.taxonomyItem}>
                     <CtaLink href={`/stories/list/${item}`} variant={isDark ? 'storyCardChipDark' : 'storyCardChip'} className={styles.taxonomyLink}>
-                      {initiativesMap[item]}
+                      {taxonomyMap[item]}
                     </CtaLink>
                   </li>
                 ))}

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -3,8 +3,8 @@ import { AnimateInView, type AnimationType } from '@/components/Animate';
 import { CtaLink } from '@/components/Cta/CtaLink';
 import { FlexBox } from '@/components/FlexBox';
 import {
-  Heading, type HeadingType, Paragraph, type FontSizeType,
-} from '../Typography';
+  Heading, Paragraph, type HeadingType, type HeadingLevelNumberType,
+} from '@/components/Typography';
 import { SbLinkType } from '@/components/Storyblok/Storyblok.types';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { accentBorderColors, type AccentBorderColorType } from '@/utilities/datasource';
@@ -48,12 +48,11 @@ export const StoryCard = ({
   className,
   ...props
 }: StoryCardProps) => {
-  let headingSize: FontSizeType = 3;
-  if (isHorizontal) {
-    headingSize = 'f5';
-  } else if (isSmallHeading && !isHorizontal) {
-    headingSize = 2;
-  };
+  // The heading level of the tags should be one more than the heading level of the card, but maxes out at h6
+  const tagsHeadingLevelNumber: HeadingLevelNumberType =
+    Math.min(parseInt(headingLevel?.slice(1), 10) + 1, 6) as HeadingLevelNumberType;
+
+  const tagsHeadingLevel: HeadingType = `h${tagsHeadingLevelNumber}`;
 
   return (
     <AnimateInView animation={animation} delay={delay}>
@@ -119,6 +118,7 @@ export const StoryCard = ({
                 {body}
               </Paragraph>
             )}
+            <Heading as={tagsHeadingLevel} className="sr-only">Story tags:</Heading>
             {!!taxonomy?.length && (
               <ul className={styles.taxonomy(isHorizontal, isListView)}>
                 {taxonomy.slice(0, 3).map((item) => (

--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -121,12 +121,14 @@ export const StoryCard = ({
             <Heading as={tagsHeadingLevel} className="sr-only">Story tags:</Heading>
             {!!taxonomy?.length && (
               <ul className={styles.taxonomy(isHorizontal, isListView)}>
-                {taxonomy.slice(0, 3).map((item) => (
-                  <li key={item} className={styles.taxonomyItem}>
-                    <CtaLink href={`/stories/list/${item}`} variant={isDark ? 'storyCardChipDark' : 'storyCardChip'} className={styles.taxonomyLink}>
-                      {taxonomyMap[item]}
-                    </CtaLink>
-                  </li>
+                {taxonomy.map((item) => (
+                  taxonomyMap[item] ? (
+                    <li key={item} className={styles.taxonomyItem}>
+                      <CtaLink href={`/stories/list/${item}`} variant={isDark ? 'storyCardChipDark' : 'storyCardChip'} className={styles.taxonomyLink}>
+                        {taxonomyMap[item]}
+                      </CtaLink>
+                    </li>
+                  ) : null // Don't display the list item if the taxonomy item is not in the taxonomy map
                 ))}
               </ul>
             )}

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -3,7 +3,7 @@ import { type AnimationType } from '@/components/Animate';
 import { type HeadingType } from '@/components/Typography';
 import { StoryCard } from '@/components/StoryCard';
 import { type SbImageType, type SbLinkType } from './Storyblok.types';
-import { type InitiativesType } from '@/utilities/taxonomyMaps';
+import { type InitiativesType, type ThemesType } from '@/utilities/taxonomyMaps';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 
 export type SbStoryCardProps = {
@@ -14,6 +14,7 @@ export type SbStoryCardProps = {
         title?: string;
         dek?: string;
         initiatives?: InitiativesType[];
+        themes?: ThemesType[];
         heroImage?: SbImageType;
         bgImage?: SbImageType;
         cardTitle?: string;
@@ -48,6 +49,7 @@ export const SbStoryCard = ({
         title = '',
         dek = '',
         initiatives = [],
+        themes = [],
         heroImage: { filename: heroFilename = '', focus: heroFocus = '' } = {},
         bgImage: { filename: bgFilename = '', focus: bgFocus = '' } = {},
         cardTitle = '',
@@ -71,23 +73,27 @@ export const SbStoryCard = ({
     isDark,
   },
   blok,
-}: SbStoryCardProps) => (
-  <StoryCard
-    {...storyblokEditable(blok)}
-    heading={heading || cardTitle || title}
-    headingLevel={headingLevel}
-    isSmallHeading={isSmallHeading}
-    body={cardTeaser || dek}
-    imageSrc={cardImage || storyCardFilename || heroFilename || bgFilename }
-    imageFocus={cardFocus || storyCardFocus || heroFocus || bgFocus}
-    tabColor={paletteAccentColors[value || storyTabColorValue]}
-    link={link}
-    href={`/${full_slug}`}
-    animation={animation}
-    delay={delay}
-    taxonomy={initiatives}
-    isHorizontal={isHorizontal}
-    isListView={isListView}
-    isDark={isDark}
-  />
-);
+}: SbStoryCardProps) => {
+  const taxonomyArray = [...initiatives, ...themes];
+
+  return (
+    <StoryCard
+      {...storyblokEditable(blok)}
+      heading={heading || cardTitle || title}
+      headingLevel={headingLevel}
+      isSmallHeading={isSmallHeading}
+      body={cardTeaser || dek}
+      imageSrc={cardImage || storyCardFilename || heroFilename || bgFilename }
+      imageFocus={cardFocus || storyCardFocus || heroFocus || bgFocus}
+      tabColor={paletteAccentColors[value || storyTabColorValue]}
+      link={link}
+      href={`/${full_slug}`}
+      animation={animation}
+      delay={delay}
+      taxonomy={taxonomyArray}
+      isHorizontal={isHorizontal}
+      isListView={isListView}
+      isDark={isDark}
+    />
+  );
+};

--- a/components/Typography/typography.types.ts
+++ b/components/Typography/typography.types.ts
@@ -1,6 +1,7 @@
 import * as styles from './typography.styles';
 
-export type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type HeadingLevelNumberType = 1 | 2 | 3 | 4 | 5 | 6;
+export type HeadingType = `h${HeadingLevelNumberType}`;
 
 export type NonHeadingTypographyType = 'p' | 'span' | 'div' | 'label' | 'legend' | 'figcaption' | 'blockquote' | 'cite' | 'q' | 'small' | 'strong' | 'em' | 'del' | 'ins' | 'sub' | 'sup' | 'address' | 'pre' | 'ul' | 'ol' | 'li' | 'time';
 

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -15,3 +15,16 @@ export const initiativesMap = {
   'undergraduate-financial-aid': 'Undergraduate Financial Aid',
 };
 export type InitiativesType = keyof typeof initiativesMap;
+
+export const themesMap = {
+  'accelerating-solutions': 'Accelerating Solutions',
+  'catalyzing-discovery': 'Catalyzing Discovery',
+  'preparing-citizens': 'Preparing Citizens',
+};
+export type ThemesType = keyof typeof themesMap;
+
+export const taxonomyMap = {
+  ...initiativesMap,
+  ...themesMap,
+};
+export type TaxonomyType = keyof typeof taxonomyMap;

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -1,3 +1,6 @@
+// TODO after vacation: https://stanfordits.atlassian.net/browse/GIVCAMP-355
+// Per PR discussion with Shea https://github.com/SU-SWS/ood-giving-campaign/pull/290#discussion_r1602386147
+
 export const initiativesMap = {
   'ethics-society-and-technology': 'Ethics, Society & Technology',
   'human-centered-artificial-intelligence': 'Human-Centered Artificial Intelligence',

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -1,7 +1,7 @@
 export const initiativesMap = {
   'ethics-society-and-technology': 'Ethics, Society & Technology',
   'human-centered-artificial-intelligence': 'Human-Centered Artificial Intelligence',
-  'innovative-medicines-accelerator': 'innovative-medicines-accelerator',
+  'innovative-medicines-accelerator': 'Innovative Medicines Accelerator',
   'racial-justice-initiative' : 'Racial Justice Initiative',
   'stanford-accelerator-for-learning': 'Stanford Accelerator for Learning',
   'stanford-arts': 'Stanford Arts',

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -20,6 +20,7 @@ export const themesMap = {
   'accelerating-solutions': 'Accelerating Solutions',
   'catalyzing-discovery': 'Catalyzing Discovery',
   'preparing-citizens': 'Preparing Citizens',
+  'sustaining-life': 'Sustaining Life',
 };
 export type ThemesType = keyof typeof themesMap;
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This gets merged into the integration branch `story-list-pages` after approval
- Add themes to the taxonomy tags
- Content authors will self governed (decided in meeting) to not tag more than 3 items and they will order them in Storyblok
- Initiative tags go before any theme tags

# Review By (Date)
- Retro

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-290--giving-campaign.netlify.app/ and see the story tags on the story cards.
1. Go to Test -> Home New Test and select PR290 from the visual editor in Storyblok
2. Play around with taxonomies (initiatives and Themes only). Check that they're displayed with initiative tags first, followed by theme tags
3. For a story card, select any heading level except h6, check that the screen reader only tag heading "Story tags:"  level is one level down. Select heading level h6, check code that the tag heading has heading level h6 because h7 doesn't exist.
4. Look at code and things called out

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-351