### PR TITLE
GIVCAMP-358 | Add filtered story lists

### DIFF
--- a/app/(editor)/editor/page.tsx
+++ b/app/(editor)/editor/page.tsx
@@ -149,20 +149,9 @@ async function getStoryList({ path }: PageProps['searchParams']) {
     return storyList;
   }
   catch (error) {
-    if (typeof error === 'string') {
-      try {
-        const parsedError = JSON.parse(error);
-        if (parsedError.status === 404) {
-          return { data: 404 };
-        }
-      }
-      catch (e) {
-        console.error('Error', error);
-      }
-    }
+    console.error('Error fetching stories:', error);
+    return [];
   }
-
-  return [];
 }
 
 /**
@@ -196,7 +185,10 @@ export default async function Page({ searchParams }: PageProps) {
 
   // Get data out of the API.
   const { data } = await getStoryData(searchParams);
-  const storyList = await getStoryList(searchParams);
+  let storyList;
+  if (slug === 'stories' || slug.includes('stories/list/')) {
+    storyList = await getStoryList(searchParams);
+  }
 
   // Failed to fetch from API because story slug was not found.
   if (data === 404) {

--- a/app/(editor)/editor/page.tsx
+++ b/app/(editor)/editor/page.tsx
@@ -131,7 +131,7 @@ async function getStoryList({ path }: PageProps['searchParams']) {
 
   // For more related documentation see app/(storyblok)/[[...slug]]/page.tsx
   const sbParams: ISbStoriesParams = {
-    version: activeEnv === 'development' ? 'draft' : 'published',
+    version: 'published',
     cv: activeEnv === 'development' ? Date.now() : undefined,
     starts_with: 'stories/',
     sort_by: 'first_published_at:desc',

--- a/app/(editor)/editor/page.tsx
+++ b/app/(editor)/editor/page.tsx
@@ -86,7 +86,9 @@ async function getStoryData({ path }: PageProps['searchParams']): Promise<ISbRes
 
 };
 
-// Get a list of stories that are of component sbStoryMvp
+/**
+ * Get a list of stories that are of component sbStoryMvp in reverse chronological order.
+ */
 async function getStories() {
   const activeEnv = process.env.NODE_ENV || 'development';
   const storyblokApi: StoryblokClient = getStoryblokApi();
@@ -94,8 +96,9 @@ async function getStories() {
     version: 'published',
     cv: activeEnv === 'development' ? Date.now() : undefined,
     resolve_relations: resolveRelations,
-    'starts_with': 'stories/',
-    'sort_by': 'first_published_at:desc',
+    starts_with: 'stories/',
+    sort_by: 'first_published_at:desc',
+    per_page: 100,
     filter_query: {
       component: {
         in: 'sbStoryMvp',

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -132,7 +132,7 @@ async function getStoryData(params: { slug: string[] }) {
 /**
  * Get a list of stories that are of component sbStoryMvp in reverse chronological order.
  */
-async function getStories(params: { slug: string[] }) {
+async function getStoryList(params: { slug: string[] }) {
   const activeEnv = process.env.NODE_ENV || 'development';
   const storyblokApi: StoryblokClient = getStoryblokApi();
   const fullslug = params.slug ? params.slug.join('/') : 'home';
@@ -170,8 +170,8 @@ async function getStories(params: { slug: string[] }) {
   };
 
   try {
-    const stories = await storyblokApi.getAll('cdn/stories', sbParams);
-    return stories;
+    const storyList = await storyblokApi.getAll('cdn/stories', sbParams);
+    return storyList;
   }
   catch (error) {
     if (typeof error === 'string') {
@@ -218,9 +218,9 @@ export default async function Page({ params }: { params: ParamsType }) {
   const { data } = await getStoryData(params);
   const slug = params.slug ? params.slug.join('/') : 'home';
 
-  let stories;
+  let storyList;
   if (slug === 'stories' || slug.includes('stories/list/')) {
-    stories = await getStories(params);
+    storyList = await getStoryList(params);
   }
 
   if (data === 404) {
@@ -230,7 +230,7 @@ export default async function Page({ params }: { params: ParamsType }) {
   return (
     <StoryblokStory
       story={data.story}
-      stories={stories}
+      storyList={storyList}
       bridgeOptions={bridgeOptions}
       slug={slug}
       name={data.story.name}

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -119,7 +119,9 @@ async function getStoryData(params: { slug: string[] }) {
   return { data: 404 };
 };
 
-// Get a list of stories that are of component sbStoryMvp in reverse chronological order.
+/**
+ * Get a list of stories that are of component sbStoryMvp in reverse chronological order.
+ */
 async function getStories() {
   const activeEnv = process.env.NODE_ENV || 'development';
   const storyblokApi: StoryblokClient = getStoryblokApi();
@@ -127,8 +129,9 @@ async function getStories() {
     version: 'published',
     cv: activeEnv === 'development' ? Date.now() : undefined,
     resolve_relations: resolveRelations,
-    'starts_with': 'stories/',
-    'sort_by': 'first_published_at:desc',
+    starts_with: 'stories/',
+    sort_by: 'first_published_at:desc',
+    per_page: 100,
     filter_query: {
       component: {
         in: 'sbStoryMvp',

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -162,9 +162,9 @@ async function getStoryList(params: { slug: string[] }) {
   }
 
   const sbParams: ISbStoriesParams = {
-    version: activeEnv === 'development' ? 'draft' : 'published',
+    version: 'published', // Only show published stories for now
     cv: activeEnv === 'development' ? Date.now() : undefined,
-    starts_with: 'stories/', // Only return stories that are inside the stories/ folder.
+    starts_with: 'stories/', // Only return stories that are inside the stories/ folder
     sort_by: 'first_published_at:desc',
     // When the number of stories gets larger, we should think about pagination. For now get the max number 100.
     per_page: 100,

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next';
 import {
   ISbStoriesParams, getStoryblokApi, storyblokInit, apiPlugin, StoryblokStory, StoryblokClient,
-  ISbStoryData,
 } from '@storyblok/react/rsc';
 import { components as Components } from '@/components/StoryblokProvider';
 import { resolveRelations } from '@/utilities/resolveRelations';
@@ -182,20 +181,9 @@ async function getStoryList(params: { slug: string[] }) {
     return storyList;
   }
   catch (error) {
-    if (typeof error === 'string') {
-      try {
-        const parsedError = JSON.parse(error);
-        if (parsedError.status === 404) {
-          return { data: 404 };
-        }
-      }
-      catch (e) {
-        console.error('Error', error);
-      }
-    }
+    console.error('Error fetching stories:', error);
+    return [];
   }
-
-  return [];
 }
 
 /**

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -131,6 +131,7 @@ async function getStoryData(params: { slug: string[] }) {
 
 /**
  * Get a list of stories that are of component sbStoryMvp in reverse chronological order.
+ * This is used for the story filter pages.
  */
 async function getStoryList(params: { slug: string[] }) {
   const activeEnv = process.env.NODE_ENV || 'development';
@@ -138,6 +139,13 @@ async function getStoryList(params: { slug: string[] }) {
   const fullslug = params.slug ? params.slug.join('/') : 'home';
   let slug = '';
   let orQuery: FilterQuery[] = [];
+
+  /**
+   * If the page is inside the folder stories/list/ (story list pages filtered by taxonomy),
+   * add a filter query to only return stories that has an initiative or theme that matches the slug of that story.
+   * E.g., if the full slug is stories/list/preparing-citizens,
+   * only return stories that have 'preparing-citizens' tagged as a theme or initiative.
+   */
   if (fullslug.includes('stories/list/')) {
     slug = params.slug[params.slug.length - 1];
     orQuery = [
@@ -157,13 +165,13 @@ async function getStoryList(params: { slug: string[] }) {
   const sbParams: ISbStoriesParams = {
     version: activeEnv === 'development' ? 'draft' : 'published',
     cv: activeEnv === 'development' ? Date.now() : undefined,
-    resolve_relations: resolveRelations,
-    starts_with: 'stories/',
+    starts_with: 'stories/', // Only return stories that are inside the stories/ folder.
     sort_by: 'first_published_at:desc',
+    // When the number of stories gets larger, we should think about pagination. For now get the max number 100.
     per_page: 100,
     filter_query: {
       component: {
-        in: 'sbStoryMvp',
+        in: 'sbStoryMvp', // Only return stories that are of component sbStoryMvp.
       },
       __or: orQuery,
     },

--- a/components/Cta/Cta.types.ts
+++ b/components/Cta/Cta.types.ts
@@ -1,4 +1,5 @@
-import { type HeroIconProps, type IconType } from '../HeroIcon';
+import { type HeroIconProps, type IconType } from '@/components/HeroIcon';
+import { type MarginType } from '@/utilities/datasource';
 import * as styles from './Cta.styles';
 
 export type CtaVariantType = keyof typeof styles.ctaVariants;
@@ -42,5 +43,7 @@ export interface CtaCommonProps {
   iconPosition?: 'left' | 'right';
   animate?: IconAnimationType;
   iconProps?: Omit<HeroIconProps, 'icon'> & React.ComponentProps<'svg'>;
+  mt?: MarginType;
+  mb?: MarginType;
   children?: React.ReactNode;
 }

--- a/components/Cta/CtaExternalLink.tsx
+++ b/components/Cta/CtaExternalLink.tsx
@@ -4,6 +4,7 @@ import { cnb } from 'cnbuilder';
 import { CtaContent } from './CtaContent';
 import { type CtaCommonProps } from './Cta.types';
 import { type SbLinkType } from '../Storyblok/Storyblok.types';
+import { marginTops, marginBottoms } from '@/utilities/datasource';
 import * as styles from './Cta.styles';
 import useUTMs from '@/hooks/useUTMs';
 
@@ -24,6 +25,8 @@ export const CtaExternalLink = React.forwardRef<HTMLAnchorElement, CtaExternalLi
       animate,
       iconProps,
       srText,
+      mt,
+      mb,
       children,
       className,
       href,
@@ -51,6 +54,8 @@ export const CtaExternalLink = React.forwardRef<HTMLAnchorElement, CtaExternalLi
           styles.ctaSizes[size] || styles.ctaSizes[styles.ctaSizeMap[variant]],
           curve ? styles.ctaCurves[curve] : '',
           color ? styles.ctaColors[color] : '',
+          mt ? marginTops[mt] : '',
+          mb ? marginBottoms[mb] : '',
           className,
         )}
       >

--- a/components/Cta/CtaNextLink.tsx
+++ b/components/Cta/CtaNextLink.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { type LinkProps } from 'next/link';
 import { CtaContent } from './CtaContent';
 import { type CtaCommonProps } from './Cta.types';
+import { marginTops, marginBottoms } from '@/utilities/datasource';
 import * as styles from './Cta.styles';
 
 export type CtaNextLinkProps = CtaCommonProps & LinkProps & {
@@ -24,6 +25,8 @@ export const CtaNextLink = React.forwardRef<HTMLAnchorElement, CtaNextLinkProps>
     iconProps,
     srText,
     target,
+    mt,
+    mb,
     children,
     className,
     ...rest
@@ -41,6 +44,8 @@ export const CtaNextLink = React.forwardRef<HTMLAnchorElement, CtaNextLinkProps>
         styles.ctaSizes[size] || styles.ctaSizes[styles.ctaSizeMap[variant]],
         curve ? styles.ctaCurves[curve] : '',
         color ? styles.ctaColors[color] : '',
+        mt ? marginTops[mt] : '',
+        mb ? marginBottoms[mb] : '',
         className,
       )}
     >

--- a/components/Hero/StoryListHero.styles.ts
+++ b/components/Hero/StoryListHero.styles.ts
@@ -2,7 +2,9 @@ import { cnb } from 'cnbuilder';
 export const root = 'relative break-words bg-black-70';
 
 export const contentWrapper = 'relative z-20 top-0 left-0 size-full *:mx-auto pt-61 sm:pt-68 md:pt-[7.4rem]';
-export const heading = 'mb-0';
+export const heading = (hasSubhead: boolean) => cnb('mb-0', {
+  '3xl:odd:*:text-[20rem] 3xl:even:*:text-[14rem]': !hasSubhead,
+});
 export const subhead = 'text-balance xl:max-w-1100 mx-auto rs-mt-4';
 
 export const image = 'absolute top-0 left-0 size-full object-cover';

--- a/components/Hero/StoryListHero.tsx
+++ b/components/Hero/StoryListHero.tsx
@@ -35,10 +35,10 @@ export const StoryListHero = ({
             align="center"
             leading="none"
             color="white"
-            className={styles.heading}
+            className={styles.heading(!!subheading)}
           >
             <Text as="span" font="druk" size={subheading ? 'f5' : 'splash'} leading="druk">Stories</Text>
-            <Text as="span" font="serif" size={subheading ? 'f4' : 'f7'} weight="normal" italic className="relative -top-[.23em] -ml-01em mr-02em"> of </Text>
+            <Text as="span" font="serif" size={subheading ? 'f4' : 'f7'} weight="normal" italic className="relative -top-[.23em] -ml-[.07em] mr-01em"> of </Text>
             <Text as="span" font="druk" size={subheading ? 'f5' : 'splash'} leading="druk">Impact</Text>
             {subheading && (
               <Text

--- a/components/Storyblok/SbCta.tsx
+++ b/components/Storyblok/SbCta.tsx
@@ -7,9 +7,10 @@ import {
   type CtaCurveType,
   type IconAnimationType,
   type IconColorType,
-} from '../Cta';
-import { type IconType } from '../HeroIcon';
-import { type SbLinkType } from './Storyblok.types';
+} from '@/components/Cta';
+import { type IconType } from '@/components/HeroIcon';
+import { type SbLinkType } from '@/components/Storyblok/Storyblok.types';
+import { type MarginType } from '@/utilities/datasource';
 
 type SbCtaType = {
   blok: {
@@ -23,6 +24,8 @@ type SbCtaType = {
     icon?: IconType;
     iconColor?: IconColorType;
     animation?: IconAnimationType;
+    spacingTop?: MarginType;
+    spacingBottom?: MarginType;
   };
 };
 
@@ -37,6 +40,8 @@ export const SbCta = ({
     icon,
     iconColor,
     animation,
+    spacingTop,
+    spacingBottom,
   },
   blok,
 }: SbCtaType) => {
@@ -56,6 +61,8 @@ export const SbCta = ({
       icon={icon}
       iconProps={{ className: iconColors[iconColor] }}
       animate={animation}
+      mt={spacingTop}
+      mb={spacingBottom}
     >
       {label}
     </CtaLink>

--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -37,7 +37,6 @@ export type SbStoryCardProps = {
     animation?: AnimationType;
     delay?: number;
     isHorizontal?: boolean;
-    isListView?: boolean;
     isDark?: boolean;
   };
 };
@@ -69,7 +68,6 @@ export const SbStoryCard = ({
     animation,
     delay,
     isHorizontal,
-    isListView,
     isDark,
   },
   blok,
@@ -92,7 +90,6 @@ export const SbStoryCard = ({
       delay={delay}
       taxonomy={taxonomyArray}
       isHorizontal={isHorizontal}
-      isListView={isListView}
       isDark={isDark}
     />
   );

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
@@ -1,3 +1,6 @@
+import { cnb } from 'cnbuilder';
+
+export const heading = (hasIntro: boolean) => cnb(!hasIntro ? 'mb-0' : '');
 export const intro = '*:intro-text *:max-w-prose *:leading-snug md:*:leading-cozy';
 export const latest = 'relative';
 export const skiplink = 'focus:block focus:w-fit focus:relative focus:bg-cardinal-red -top-60 focus:top-36 focus:mx-auto';

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
@@ -1,3 +1,3 @@
-export const intro = '*:intro-text *:max-w-prose';
-export const latest = 'relative bg-gc-black';
+export const intro = '*:intro-text *:max-w-prose *:leading-snug md:*:leading-cozy';
+export const latest = 'relative';
 export const skiplink = 'focus:block focus:w-fit focus:relative focus:bg-cardinal-red -top-60 focus:top-36 focus:mx-auto';

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
@@ -1,1 +1,3 @@
 export const intro = '*:intro-text *:max-w-prose';
+export const latest = 'relative bg-gc-black';
+export const skiplink = 'focus:block focus:w-fit focus:relative focus:bg-cardinal-red -top-60 focus:top-36 focus:mx-auto';

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -12,7 +12,6 @@ import { hasRichText } from '@/utilities/hasRichText';
 import { paletteAccentColors } from '@/utilities/colorPalettePlugin';
 import { getNumBloks } from '@/utilities/getNumBloks';
 import * as styles from './SbStoryFilterPage.styles';
-import { get } from 'http';
 
 type StoryPickerType = {
   uuid: string;
@@ -68,60 +67,69 @@ export const SbStoryFilterPage = ({
    */
   const filteredStoryList = storyList.filter(item => !featuredStoryUUIDSet.has(item.uuid));
 
+  const hasIntro = hasRichText(intro);
+  const hasFeaturedStories = !!getNumBloks(featuredStories);
+
   return (
     <div {...storyblokEditable(blok)}>
       <CreateStories stories={mastheadPicker} />
       <main id="main-content">
         <CreateStories stories={heroPicker} subheading={name !== 'Stories' ? name : ''} />
-        <Container bgColor="black" className={styles.latest}>
+        <Container pb={10} bgColor="black" className={styles.latest}>
           <Skiplink href="#latest-stories" className={styles.skiplink}>
             Skip past story list page menu to latest stories
           </Skiplink>
           <CreateStories stories={storyListNavPicker} fullSlug={slug} name={name} />
-          <Heading font="druk" size="f5" color="white" id="latest-stories">Latest stories</Heading>
-            {hasRichText(intro) && <RichText wysiwyg={intro} textColor="white" className={styles.intro} />}
+          <Heading font="druk" size="f5" color="white" id="latest-stories" className={styles.heading(hasIntro)}>Latest stories</Heading>
+            {hasIntro && <RichText wysiwyg={intro} textColor="white" className={styles.intro} />}
           <CreateBloks blokSection={belowIntro} />
-          {!!getNumBloks(featuredStories) && (
-            <Grid py={6} isList className="gap-y-45 md:gap-y-90 2xl:gap-y-95">
-              <CreateBloks blokSection={featuredStories} isListItems />
-            </Grid>
+          {hasFeaturedStories && (
+            <>
+              <Heading as="h3" srOnly>{`Featured Stor${getNumBloks(featuredStories) > 1 ? 'ies' : 'y'}`}</Heading>
+              <Grid py={6} isList className="gap-y-45 md:gap-y-90 2xl:gap-y-95">
+                <CreateBloks blokSection={featuredStories} isListItems />
+              </Grid>
+            </>
           )}
-          <Grid as="ul" py={6} className="list-unstyled *:mb-0 gap-y-45 md:gap-y-90 2xl:gap-y-95">
-            {!!filteredStoryList?.length && (
-              filteredStoryList.map((story) => {
-                const {
-                  cardTitle,
-                  title,
-                  cardTeaser,
-                  dek,
-                  cardImage,
-                  heroImage,
-                  bgImage,
-                  tabColor,
-                  initiatives,
-                  themes,
-                } = story.content;
+          {!!filteredStoryList?.length && (
+            <>
+            {hasFeaturedStories && <Heading as="h3" srOnly>Other stories</Heading>}
+              <Grid as="ul" pt={6} className="list-unstyled *:mb-0 gap-y-45 md:gap-y-90 2xl:gap-y-95">
+                {filteredStoryList.map((story) => {
+                  const {
+                    cardTitle,
+                    title,
+                    cardTeaser,
+                    dek,
+                    cardImage,
+                    heroImage,
+                    bgImage,
+                    tabColor,
+                    initiatives,
+                    themes,
+                  } = story.content;
 
-                return (
-                  <li key={story.uuid}>
-                    <StoryCard
-                      isListView
-                      isDark
-                      heading={cardTitle || title}
-                      headingLevel="h3"
-                      body={cardTeaser || dek}
-                      imageSrc={cardImage?.filename || heroImage?.filename || bgImage?.filename}
-                      imageFocus={cardImage?.focus || heroImage?.focus || bgImage?.focus}
-                      tabColor={paletteAccentColors[tabColor?.value]}
-                      href={`/${story.full_slug}`}
-                      animation="slideUp"
-                      taxonomy={[...initiatives, ...themes]}
-                    />
-                  </li>
-                );
-              })
-            )}
-          </Grid>
+                  return (
+                    <li key={story.uuid}>
+                      <StoryCard
+                        isListView
+                        isDark
+                        heading={cardTitle || title}
+                        headingLevel="h3"
+                        body={cardTeaser || dek}
+                        imageSrc={cardImage?.filename || heroImage?.filename || bgImage?.filename}
+                        imageFocus={cardImage?.focus || heroImage?.focus || bgImage?.focus}
+                        tabColor={paletteAccentColors[tabColor?.value]}
+                        href={`/${story.full_slug}`}
+                        animation="slideUp"
+                        taxonomy={[...initiatives, ...themes]}
+                      />
+                    </li>
+                  );
+                })}
+              </Grid>
+            </>
+          )}
         </Container>
         <CreateBloks blokSection={ankle} />
       </main>

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -115,7 +115,8 @@ export const SbStoryFilterPage = ({
                         isListView
                         isDark
                         heading={cardTitle || title}
-                        headingLevel="h3"
+                        // If there is no featured stories then there is only one ul with h2 latest stories
+                        headingLevel={hasFeaturedStories ? 'h4' : 'h3'}
                         body={cardTeaser || dek}
                         imageSrc={cardImage?.filename || heroImage?.filename || bgImage?.filename}
                         imageFocus={cardImage?.focus || heroImage?.focus || bgImage?.focus}

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -26,7 +26,7 @@ type SbStoryFilterPageProps = {
   };
   name?: string; // The name of the Storyblok story
   slug?: string;
-  stories?: ISbStoryData[];
+  storyList?: ISbStoryData[];
 };
 
 export const SbStoryFilterPage = ({
@@ -42,7 +42,7 @@ export const SbStoryFilterPage = ({
   blok,
   name,
   slug,
-  stories,
+  storyList,
 }: SbStoryFilterPageProps) => {
 
   return (
@@ -62,8 +62,8 @@ export const SbStoryFilterPage = ({
             <CreateBloks blokSection={featuredStories} isListItems />
           </Grid>
           <Grid as="ul" gap="card" py={6} className="list-unstyled">
-            {!!stories?.length && (
-              stories.map((story) => {
+            {!!storyList?.length && (
+              storyList.map((story) => {
                 const {
                   _uid,
                   cardTitle,

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -3,6 +3,7 @@ import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { Container } from '@/components/Container';
 import { CreateBloks } from '@/components/CreateBloks';
 import { CreateStories } from '@/components/CreateStories';
+import { Grid } from '@/components/Grid';
 import { Heading } from '@/components/Typography';
 import { RichText } from '@/components/RichText';
 import { Skiplink } from '@/components/SkipLink';
@@ -15,6 +16,7 @@ type SbStoryFilterPageProps = {
     _uid: string;
     intro?: StoryblokRichtext;
     belowIntro?: SbBlokData[];
+    featuredStories?: SbBlokData[];
     ankle?: SbBlokData[];
     mastheadPicker?: ISbStoryData[];
     heroPicker?: ISbStoryData[];
@@ -28,6 +30,7 @@ export const SbStoryFilterPage = ({
   blok: {
     intro,
     belowIntro,
+    featuredStories,
     ankle,
     mastheadPicker,
     heroPicker,
@@ -43,17 +46,21 @@ export const SbStoryFilterPage = ({
       <CreateStories stories={mastheadPicker} />
       <main id="main-content">
         <CreateStories stories={heroPicker} subheading={name !== 'Stories' ? name : ''} />
-        <section className={styles.latest}>
+        <Container bgColor="black" className={styles.latest}>
           <Skiplink href="#latest-stories" className={styles.skiplink}>
             Skip past story list page menu to latest stories
           </Skiplink>
           <CreateStories stories={storyListNavPicker} fullSlug={slug} name={name} />
-          <Container bgColor="black" className="bg-gc-black" id="latest-stories">
-            <Heading font="druk" size="f5" color="white">Latest stories</Heading>
+          <Heading font="druk" size="f5" color="white" id="latest-stories">Latest stories</Heading>
             {hasRichText(intro) && <RichText wysiwyg={intro} textColor="white" className={styles.intro} />}
-            <CreateBloks blokSection={belowIntro} />
-          </Container>
-        </section>
+          <CreateBloks blokSection={belowIntro} />
+          <Grid py={6} isList className="gap-y-45 md:gap-y-90 2xl:gap-y-95">
+            <CreateBloks blokSection={featuredStories} isListItems />
+          </Grid>
+          <Grid gap="card" py={6}>
+            {/* List of filtered story minus the featured stories goes here */}
+          </Grid>
+        </Container>
         <CreateBloks blokSection={ankle} />
       </main>
     </div>

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -1,10 +1,11 @@
 import { storyblokEditable, type SbBlokData, type ISbStoryData } from '@storyblok/react/rsc';
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
+import { Container } from '@/components/Container';
 import { CreateBloks } from '@/components/CreateBloks';
 import { CreateStories } from '@/components/CreateStories';
-import { Container } from '@/components/Container';
 import { Heading } from '@/components/Typography';
 import { RichText } from '@/components/RichText';
+import { Skiplink } from '@/components/SkipLink';
 import { hasRichText } from '@/utilities/hasRichText';
 import * as styles from './SbStoryFilterPage.styles';
 
@@ -42,12 +43,17 @@ export const SbStoryFilterPage = ({
       <CreateStories stories={mastheadPicker} />
       <main id="main-content">
         <CreateStories stories={heroPicker} subheading={name !== 'Stories' ? name : ''} />
-        <CreateStories stories={storyListNavPicker} fullSlug={slug} name={name} />
-        <Container bgColor="black" className="bg-gc-black">
-          <Heading font="druk" size="f5" color="white">Latest stories</Heading>
-          {hasRichText(intro) && <RichText wysiwyg={intro} textColor="white" className={styles.intro} />}
-          <CreateBloks blokSection={belowIntro} />
-        </Container>
+        <section className={styles.latest}>
+          <Skiplink href="#latest-stories" className={styles.skiplink}>
+            Skip past story list page menu to latest stories
+          </Skiplink>
+          <CreateStories stories={storyListNavPicker} fullSlug={slug} name={name} />
+          <Container bgColor="black" className="bg-gc-black" id="latest-stories">
+            <Heading font="druk" size="f5" color="white">Latest stories</Heading>
+            {hasRichText(intro) && <RichText wysiwyg={intro} textColor="white" className={styles.intro} />}
+            <CreateBloks blokSection={belowIntro} />
+          </Container>
+        </section>
         <CreateBloks blokSection={ankle} />
       </main>
     </div>

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -62,7 +62,7 @@ export const SbStoryFilterPage = ({
 
   /**
    * Filter storyList (list of all stories with taxonomy that matches the slug of the page)
-   * to exclude items with uuid that are in the featuredStoryUUIDArray,
+   * to exclude items with uuid that are in the featuredStoryUUIDSet,
    * ie, we remove stories that are already added as featured stories cards.
    */
   const filteredStoryList = storyList.filter(item => !featuredStoryUUIDSet.has(item.uuid));

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -76,7 +76,7 @@ export const SbStoryFilterPage = ({
                     tabColor={paletteAccentColors[story.content.tabColor.value]}
                     href={`/${story.full_slug}`}
                     animation="slideUp"
-                    taxonomy={story.content.taxonomyArray}
+                    taxonomy={[...story.content.initiatives, ...story.content.themes]}
                   />
                 </li>
               ))

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -61,25 +61,41 @@ export const SbStoryFilterPage = ({
           <Grid py={6} isList className="gap-y-45 md:gap-y-90 2xl:gap-y-95">
             <CreateBloks blokSection={featuredStories} isListItems />
           </Grid>
-          <Grid gap="card" py={6} as="ul" className="list-unstyled">
+          <Grid as="ul" gap="card" py={6} className="list-unstyled">
             {!!stories?.length && (
-              stories.map((story) => (
-                <li key={story.content._uid}>
-                  <StoryCard
-                    isListView
-                    isDark
-                    heading={story.content.cardTitle || story.content.title}
-                    headingLevel="h3"
-                    body={story.content.cardTeaser || story.content.dek}
-                    imageSrc={story.content.cardImage.filename || story.content.heroImage.filename || story.content.bgImage.filename }
-                    imageFocus={story.content.cardImage.focus || story.content.heroImage.focus ||  story.content.bgImage.focus}
-                    tabColor={paletteAccentColors[story.content.tabColor.value]}
-                    href={`/${story.full_slug}`}
-                    animation="slideUp"
-                    taxonomy={[...story.content.initiatives, ...story.content.themes]}
-                  />
-                </li>
-              ))
+              stories.map((story) => {
+                const {
+                  _uid,
+                  cardTitle,
+                  title,
+                  cardTeaser,
+                  dek,
+                  cardImage,
+                  heroImage,
+                  bgImage,
+                  tabColor,
+                  initiatives,
+                  themes,
+                } = story.content;
+
+                return (
+                  <li key={_uid}>
+                    <StoryCard
+                      isListView
+                      isDark
+                      heading={cardTitle || title}
+                      headingLevel="h3"
+                      body={cardTeaser || dek}
+                      imageSrc={cardImage?.filename || heroImage?.filename || bgImage?.filename}
+                      imageFocus={cardImage?.focus || heroImage?.focus || bgImage?.focus}
+                      tabColor={paletteAccentColors[tabColor?.value]}
+                      href={`/${story.full_slug}`}
+                      animation="slideUp"
+                      taxonomy={[...initiatives, ...themes]}
+                    />
+                  </li>
+                );
+              })
             )}
           </Grid>
         </Container>

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -7,7 +7,9 @@ import { Grid } from '@/components/Grid';
 import { Heading } from '@/components/Typography';
 import { RichText } from '@/components/RichText';
 import { Skiplink } from '@/components/SkipLink';
+import { StoryCard } from '@/components/StoryCard';
 import { hasRichText } from '@/utilities/hasRichText';
+import { paletteAccentColors } from '@/utilities/colorPalettePlugin';
 import * as styles from './SbStoryFilterPage.styles';
 
 
@@ -24,6 +26,7 @@ type SbStoryFilterPageProps = {
   };
   name?: string; // The name of the Storyblok story
   slug?: string;
+  stories?: ISbStoryData[];
 };
 
 export const SbStoryFilterPage = ({
@@ -39,6 +42,7 @@ export const SbStoryFilterPage = ({
   blok,
   name,
   slug,
+  stories,
 }: SbStoryFilterPageProps) => {
 
   return (
@@ -57,8 +61,26 @@ export const SbStoryFilterPage = ({
           <Grid py={6} isList className="gap-y-45 md:gap-y-90 2xl:gap-y-95">
             <CreateBloks blokSection={featuredStories} isListItems />
           </Grid>
-          <Grid gap="card" py={6}>
-            {/* List of filtered story minus the featured stories goes here */}
+          <Grid gap="card" py={6} as="ul" className="list-unstyled">
+            {!!stories?.length && (
+              stories.map((story) => (
+                <li key={story.content._uid}>
+                  <StoryCard
+                    isListView
+                    isDark
+                    heading={story.content.cardTitle || story.content.title}
+                    headingLevel="h3"
+                    body={story.content.cardTeaser || story.content.dek}
+                    imageSrc={story.content.cardImage.filename || story.content.heroImage.filename || story.content.bgImage.filename }
+                    imageFocus={story.content.cardImage.focus || story.content.heroImage.focus ||  story.content.bgImage.focus}
+                    tabColor={paletteAccentColors[story.content.tabColor.value]}
+                    href={`/${story.full_slug}`}
+                    animation="slideUp"
+                    taxonomy={story.content.taxonomyArray}
+                  />
+                </li>
+              ))
+            )}
           </Grid>
         </Container>
         <CreateBloks blokSection={ankle} />

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -2,7 +2,7 @@
 // Per PR discussion with Shea https://github.com/SU-SWS/ood-giving-campaign/pull/290#discussion_r1602386147
 
 export const initiativesMap = {
-  'ethics-society-and-technology': 'Ethics, Society & Technology',
+  'ethics-society-technology': 'Ethics, Society & Technology',
   'human-centered-artificial-intelligence': 'Human-Centered Artificial Intelligence',
   'innovative-medicines-accelerator': 'Innovative Medicines Accelerator',
   'racial-justice-initiative' : 'Racial Justice Initiative',
@@ -14,7 +14,7 @@ export const initiativesMap = {
   'stanford-impact-labs': 'Stanford Impact Labs',
   'stanford-public-humanities': 'Stanford Public Humanities',
   'stanford-science-fellows': 'Stanford Science Fellows',
-  'undergraduate-education-and-student-life': 'Undergraduate Education & Student Life',
+  'undergraduate-education-student-life': 'Undergraduate Education & Student Life',
   'undergraduate-financial-aid': 'Undergraduate Financial Aid',
 };
 export type InitiativesType = keyof typeof initiativesMap;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fetch stories to display in list view in story filter pages - top level at /stories (display all stories) and the filtered ones inside the directory /stories/list/
- Add skip link to skip past story filter menu on story filter pages (will work on mobile etc in another ticket)
- Allow the Storyblok CTA to have spacing top and bottom options

# Review By (Date)
- Soon would be nice

# Criticality
- 7

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to Storyblok /stories page
2. Choose the PR 301 from the visual editor URL list
3. Use the tab key on the keyboard and see how the skip link appears for the story filter nav
![Screenshot 2024-06-13 at 9 54 05 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/2bda6136-1ab0-4591-b53c-9ebd36b8b197)

4. Verify that the story list below the featured story (the large horizontal card) is displaying all published stories except for the featured story
5. Check that the stories are in reverse chronological order (featured story not part of this as it's manually added)
6. Try deleting the featured story card, verify that the featured story is now showing up in the list view
7. Go to /stories/list folder, click on the Preparing Citizens page
8. Check the same things as for the /stories page, except that now the list should only display stories that are tagged with Preparing Citizens.
9. Look at code for approach

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-358
