### PR TITLE
GIVCAMP-362 | Story tag revision

### DIFF
--- a/components/BlurryPoster/BlurryPoster.tsx
+++ b/components/BlurryPoster/BlurryPoster.tsx
@@ -223,11 +223,11 @@ export const BlurryPoster = ({
               {!!taxonomy?.length && (
                 <>
                   <Heading as="h2" className="sr-only">Story tags:</Heading>
-                  <FlexBox as="ul" direction="col" className={styles.taxonomy}>
+                  <FlexBox as="ul" wrap="wrap" className={styles.taxonomy}>
                     {taxonomy.map((item) => (
                       taxonomyMap[item] ? (
                         <li key={item} className={styles.taxonomyItem}>
-                          <CtaLink href={`/stories/list/${item}`} variant={bgColor === 'black' ? 'storyCardChipBlack' : 'storyCardChip'}>
+                          <CtaLink href={`/stories/list/${item}`} variant={bgColor === 'black' ? 'storyCardChipDark' : 'storyCardChip'}>
                             {taxonomyMap[item]}
                           </CtaLink>
                         </li>

--- a/components/Cta/Cta.styles.ts
+++ b/components/Cta/Cta.styles.ts
@@ -22,7 +22,6 @@ const brochurePoppy = 'from-poppy to-poppy';
 const chipBase = 'relative inline-block leading-display rounded-full font-normal no-underline underline-offset-4 hocus:underline decoration-1 hocus:bg-digital-red-light hocus:text-white';
 const chipLight = 'border border-gc-black/10 bg-gc-black-10 text-gc-black-80 hocus:border-digital-red-xlight';
 const chipDark = 'border border-gc-black-80 bg-gc-black-90 text-gc-black-40 hocus:border-digital-red-xlight';
-const chipBlack = 'border border-gc-black-90 bg-gc-black text-gc-black-40 hocus:border-digital-red-xlight';
 const chipNav = 'bg-gc-black-90 text-gc-black-40 hocus-visible:bg-gradient-to-r hocus-visible:from-digital-red hocus-visible:to-cardinal-red-dark border-2 border-gc-black-90 hocus-visible:border-digital-red-xlight';
 
 export const ctaVariants = {
@@ -42,7 +41,6 @@ export const ctaVariants = {
   chip: 'inline-block leading-display no-underline text-current rounded-full border-2 border-current hocus:text-current font-normal underline-offset-4 decoration-transparent hocus-visible:decoration-current hocus-visible:decoration-2',
   storyCardChip: `${chipBase} ${chipLight}`,
   storyCardChipDark: `${chipBase} ${chipDark}`,
-  storyCardChipBlack: `${chipBase} ${chipBlack}`,
   storyListNav: `${chipBase} ${chipNav}`,
   brochure: `${brochureBase} ${brochureIlluminating}`,
   brochurePoppy: `${brochureBase} ${brochurePoppy}`,
@@ -111,7 +109,6 @@ export const ctaSizeMap: CtaSizeMapType = {
   chip: 'chip',
   storyCardChip: 'storyCardChip',
   storyCardChipDark: 'storyCardChip',
-  storyCardChipBlack: 'storyCardChip',
   storyListNav: 'storyListNav',
   brochure: 'brochure',
   brochurePoppy: 'brochure',

--- a/components/Hero/StoryHeroStacked.tsx
+++ b/components/Hero/StoryHeroStacked.tsx
@@ -127,11 +127,11 @@ export const StoryHeroStacked = ({
         {!!taxonomy?.length && (
           <AnimateInView animation="slideUp" delay={0.4}>
             <Heading as="h2" className="sr-only">Story tags:</Heading>
-            <FlexBox as="ul" direction="col" alignItems="center" className={styles.taxonomy}>
+            <FlexBox as="ul" wrap="wrap" alignItems="center" justifyContent="center" className={styles.taxonomy}>
               {taxonomy.map((item) => (
                 taxonomyMap[item] ? (
                   <li key={item} className={styles.taxonomyItem}>
-                    <CtaLink href={`/stories/list/${item}`} variant={isLightHero ? 'storyCardChip' : 'storyCardChipBlack'}>
+                    <CtaLink href={`/stories/list/${item}`} variant={isLightHero ? 'storyCardChip' : 'storyCardChipDark'}>
                       {taxonomyMap[item]}
                     </CtaLink>
                   </li>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Kerri said let's get rid of the black version of story tags and use the dark grey one for story heroes as well
- Have tags next to each other instead of one on each row for story heroes

# Review By (Date)
- Retro


# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-305--giving-campaign.netlify.app/stories/an-ideal-approach
2. Story tags should now be dark grey instead of black and they are next to each other
![Screenshot 2024-06-20 at 11 18 59 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/49895376-420e-44f9-b0af-fe97f89befcb)
3. Go to https://deploy-preview-305--giving-campaign.netlify.app/stories/cartographer-of-cancer
4. Same check as step2

![Screenshot 2024-06-20 at 11 19 25 AM](https://github.com/SU-SWS/ood-giving-campaign/assets/42749717/3fcd1aa1-6589-48a5-af8a-ea0552058ecf)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-362