### PR TITLE
GIVCAMP-369 | Story Filter SEO update

### DIFF
--- a/utilities/getPageMetadata.ts
+++ b/utilities/getPageMetadata.ts
@@ -16,6 +16,7 @@ export type SbSEOType = {
 
 type PageMetadataProps = {
   blok: {
+    component: string;
     title: string;
     dek?: string;
     heroImage?: SbImageType;
@@ -30,6 +31,7 @@ type PageMetadataProps = {
 
 export const getPageMetadata = ({
   blok: {
+    component,
     title: pageTitle,
     dek,
     heroImage: { filename = '', focus = '' } = {},
@@ -71,7 +73,7 @@ export const getPageMetadata = ({
   const ogImage = ogCropped || heroImageCropped;
 
   let ogType = 'website';
-  if (slug.startsWith('stories/')) {
+  if (component === 'sbStoryMvp') {
     ogType = 'article';
   }
 

--- a/utilities/getPageMetadata.ts
+++ b/utilities/getPageMetadata.ts
@@ -1,3 +1,4 @@
+import { type ISbStoryData } from '@storyblok/react/rsc';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
 import { type SbImageType, type SbLinkType } from '@/components/Storyblok/Storyblok.types';
 import { config } from './config';
@@ -18,6 +19,7 @@ type PageMetadataProps = {
     title: string;
     dek?: string;
     heroImage?: SbImageType;
+    heroPicker?: ISbStoryData[];
     bgImage?: SbImageType;
     noindex?: boolean;
     canonicalUrl?: SbLinkType;
@@ -31,6 +33,7 @@ export const getPageMetadata = ({
     title: pageTitle,
     dek,
     heroImage: { filename = '', focus = '' } = {},
+    heroPicker,
     bgImage: { filename: bgFilename = '', focus: bgFocus = '' } = {},
     noindex = false,
     canonicalUrl,
@@ -49,13 +52,15 @@ export const getPageMetadata = ({
 }: PageMetadataProps) => {
   // We only care about canonical URL for production so ok to use the prod URL here
   const { siteTitle, siteDescription, siteUrlProd: siteUrl } = config;
+  const heroPickerImage = heroPicker?.[0]?.content?.heroImage?.filename;
+  const heroPickerFocus = heroPicker?.[0]?.content?.heroImage?.focus;
 
   const title = seoTitle || pageTitle;
   const searchTitle = slug === 'home' ? 'Home' : title;
   const description = seoDescription || dek || siteDescription;
   const ogTitle = og_title || title;
   const ogDescription = og_description || description;
-  const heroImageCropped = getProcessedImage(filename || bgFilename, '1200x630', focus || bgFocus);
+  const heroImageCropped = getProcessedImage(filename || bgFilename || heroPickerImage, '1200x630', focus || bgFocus || heroPickerFocus);
 
   /**
    * The og_image and twitter_image fields provided by the Storyblok SEO plugin has no image focus support

--- a/utilities/getPageMetadata.ts
+++ b/utilities/getPageMetadata.ts
@@ -60,7 +60,7 @@ export const getPageMetadata = ({
   const description = seoDescription || dek || siteDescription;
   const ogTitle = og_title || title;
   const ogDescription = og_description || description;
-  const heroImageCropped = getProcessedImage(filename || bgFilename || heroPickerImage, '1200x630', focus || bgFocus || heroPickerFocus);
+  const heroImageCropped = getProcessedImage(filename, '1200x630', focus) || getProcessedImage(bgFilename, '1200x630', bgFocus) || getProcessedImage(heroPickerImage, '1200x630', heroPickerFocus);
 
   /**
    * The og_image and twitter_image fields provided by the Storyblok SEO plugin has no image focus support

--- a/utilities/getPageMetadata.ts
+++ b/utilities/getPageMetadata.ts
@@ -72,10 +72,7 @@ export const getPageMetadata = ({
   const twitterCropped = getProcessedImage(twitter_image, '1200x600');
   const ogImage = ogCropped || heroImageCropped;
 
-  let ogType = 'website';
-  if (component === 'sbStoryMvp') {
-    ogType = 'article';
-  }
+  const ogType = component === 'sbStoryMvp' ? 'article' : 'website';
 
   // Self reference URL is the page's URL without any query params
   const selfReferencingUrl = slug !== 'home' ? `${siteUrl}/${slug}` : siteUrl;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use hero image from the hero in the hero picker as the og image for metadata if there is one (for Story Filter page for example)
- Use top level component type to determine og type for metadata

# Review By (Date)
- Retro

# Criticality
- 3

# Review Tasks

## Setup tasks and/or behavior to test

1. I have quickly published some pages (with noindex=true) last night to test and this behaved as expected
2. This is the screen cap I took - story filter pages are using the image from the hero selected in the hero picker field as the OG image
![Screenshot 2024-07-10 at 4 18 10 PM](https://github.com/user-attachments/assets/9ba6e480-2011-47e5-a0bc-d3c87f980860)
3. Go to any non story pages, eg. homepage, og type in the head metadata should be "website"
https://deploy-preview-322--giving-campaign.netlify.app/
4. Go to any story pages, eg, https://deploy-preview-322--giving-campaign.netlify.app/stories/not-her-first-rodeo
og type should be "article"

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-369
