### PR TITLE
Always use draft for story data when in storyblok editor

### DIFF
--- a/app/(editor)/editor/page.tsx
+++ b/app/(editor)/editor/page.tsx
@@ -64,7 +64,7 @@ export default async function Page({ searchParams }: PageProps) {
   const slug = searchParams.path.replace(/\/$/, '');
 
   // Get data out of the API.
-  const { data } = await getStoryData(searchParams);
+  const { data } = await getStoryData({ path: slug, isEditor: true });
 
   // An extra container for passing along additional fetched data.
   let extra = {};

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -88,7 +88,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: ParamsType): Promise<Metadata> {
   try {
     const slug = params.slug ? params.slug.join('/') : 'home';
-    const { data } = await getStoryData({ path: slug, isEditor: false });
+    const { data } = await getStoryData({ path: slug });
     if (!data.story || !data.story.content) {
       notFound();
     }
@@ -109,7 +109,7 @@ export async function generateMetadata({ params }: ParamsType): Promise<Metadata
 export default async function Page({ params }: ParamsType) {
   const slug = params.slug ? params.slug.join('/') : 'home';
   // Get data out of the API.
-  const { data } = await getStoryData({ path: slug, isEditor: false });
+  const { data } = await getStoryData({ path: slug });
 
   // Define an additional data container to pass through server data fetch to client components.
   // as everything below the `StoryblokStory` is a client side component.

--- a/app/(storyblok)/[[...slug]]/page.tsx
+++ b/app/(storyblok)/[[...slug]]/page.tsx
@@ -88,7 +88,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: ParamsType): Promise<Metadata> {
   try {
     const slug = params.slug ? params.slug.join('/') : 'home';
-    const { data } = await getStoryData({ path: slug });
+    const { data } = await getStoryData({ path: slug, isEditor: false });
     if (!data.story || !data.story.content) {
       notFound();
     }
@@ -109,7 +109,7 @@ export async function generateMetadata({ params }: ParamsType): Promise<Metadata
 export default async function Page({ params }: ParamsType) {
   const slug = params.slug ? params.slug.join('/') : 'home';
   // Get data out of the API.
-  const { data } = await getStoryData({ path: slug });
+  const { data } = await getStoryData({ path: slug, isEditor: false });
 
   // Define an additional data container to pass through server data fetch to client components.
   // as everything below the `StoryblokStory` is a client side component.

--- a/utilities/data/getStoryData.ts
+++ b/utilities/data/getStoryData.ts
@@ -9,7 +9,7 @@ import { getStoryblokApi, StoryblokClient } from '@storyblok/react/rsc';
  * Make sure to not export the below functions otherwise there will be a typescript error
  * https://github.com/vercel/next.js/discussions/48724
  */
-async function getStoryData({ path, isEditor }: getStoryDataProps): Promise<ISbResult | { data: 404 }> {
+async function getStoryData({ path, isEditor = false }: getStoryDataProps): Promise<ISbResult | { data: 404 }> {
   const storyblokApi: StoryblokClient = getStoryblokApi();
   const activeEnv = process.env.NODE_ENV || 'development';
   let sbParams: ISbStoriesParams = {

--- a/utilities/data/getStoryData.ts
+++ b/utilities/data/getStoryData.ts
@@ -9,12 +9,12 @@ import { getStoryblokApi, StoryblokClient } from '@storyblok/react/rsc';
  * Make sure to not export the below functions otherwise there will be a typescript error
  * https://github.com/vercel/next.js/discussions/48724
  */
-async function getStoryData({ path }: getStoryDataProps): Promise<ISbResult | { data: 404 }> {
+async function getStoryData({ path, isEditor }: getStoryDataProps): Promise<ISbResult | { data: 404 }> {
   const storyblokApi: StoryblokClient = getStoryblokApi();
   const activeEnv = process.env.NODE_ENV || 'development';
   let sbParams: ISbStoriesParams = {
-    version: activeEnv === 'development' ? 'draft' : 'published',
-    cv: activeEnv === 'development' ? Date.now() : undefined,
+    version: activeEnv === 'development' || isEditor ? 'draft' : 'published',
+    cv: activeEnv === 'development' || isEditor ? Date.now() : undefined,
     resolve_relations: resolveRelations,
   };
 

--- a/utilities/data/getStoryList.ts
+++ b/utilities/data/getStoryList.ts
@@ -38,7 +38,7 @@ async function getStoryList({ path }: getStoryDataProps) {
 
   // For more related documentation see app/(storyblok)/[[...slug]]/page.tsx
   const sbParams: ISbStoriesParams = {
-    version: activeEnv === 'development' ? 'draft' : 'published',
+    version: 'published',
     cv: activeEnv === 'development' ? Date.now() : undefined,
     starts_with: 'stories/',
     sort_by: 'first_published_at:desc',

--- a/utilities/data/types.d.ts
+++ b/utilities/data/types.d.ts
@@ -1,5 +1,6 @@
 export type getStoryDataProps = {
   path: string;
+  isEditor?: boolean;
 };
 
 export type PageProps = {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- For use in the (editor) route group, we want to always pull in the draft version of the story data.
- In the getStoryList function, it is ok to always use the published version (this doesn't seem to cause an API permission issue)

# Review By (Date)
- July 11

# Criticality
- 7

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at code

