### PR TITLE
GIVCAMP-373 | Add caption background options to Section and Story Image

### DIFF
--- a/components/StoryImage/StoryImage.styles.ts
+++ b/components/StoryImage/StoryImage.styles.ts
@@ -65,6 +65,14 @@ export const imageCropsMobile = {
   'free': '600x0',
 };
 
+export const captionBgColors = {
+  black: 'bg-gc-black',
+  'black-60': 'bg-black-true/60',
+  white: 'bg-white',
+  transparent: '',
+};
+export type CaptionBgColorType = keyof typeof captionBgColors;
+
 export const root = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const animateWrapper = (isFullHeight?: boolean) => cnb(isFullHeight ? 'h-full' : '');
 export const figure = (isFullHeight: boolean) => cnb(isFullHeight ? 'h-full' : '');
@@ -73,4 +81,8 @@ export const imageWrapper = (isFullHeight: boolean, isParallax: boolean) => cnb(
   isParallax ? 'overflow-hidden' : '',
 );
 export const image = (isParallax: boolean) => cnb('w-full object-cover', isParallax ? 'h-[calc(100%_+_12rem)] -mt-60' : 'h-full');
-export const caption = '*:*:leading-display mt-06em max-w-prose-wide first:*:*:mt-0';
+export const captionWrapper = 'mt-0';
+export const caption = (captionBgColor: CaptionBgColorType) => cnb(
+  '*:*:leading-display max-w-prose-wide first:*:*:mt-0',
+  !!captionBgColor && captionBgColor !== 'transparent' ? 'px-1em py-08em' : 'pt-06em',
+);

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -16,13 +16,14 @@ type StoryImageProps = React.HTMLAttributes<HTMLDivElement> & {
   isParallax?: boolean;
   alt?: string;
   caption?: React.ReactNode;
+  isCaptionInset?: boolean;
+  captionBgColor?: styles.CaptionBgColorType;
   aspectRatio?: ImageAspectRatioType;
   isFullHeight?: boolean;
   boundingWidth?: 'site' | 'full';
   width?: WidthType;
   spacingTop?: PaddingType;
   spacingBottom?: PaddingType;
-  isCaptionInset?: boolean;
   animation?: AnimationType;
   delay?: number;
 };
@@ -41,6 +42,7 @@ export const StoryImage = ({
   spacingTop,
   spacingBottom,
   isCaptionInset,
+  captionBgColor = 'transparent',
   animation = 'none',
   delay,
   className,
@@ -101,8 +103,12 @@ export const StoryImage = ({
             )}
           </div>
           {caption && (
-            <Container as="figcaption" width={isCaptionInset ? 'site' : 'full'}>
-              <div className={styles.caption}>
+            <Container
+              as="figcaption"
+              width={isCaptionInset ? 'site' : 'full'}
+              className={cnb(styles.captionWrapper, styles.captionBgColors[captionBgColor])}
+            >
+              <div className={styles.caption(captionBgColor)}>
                 {caption}
               </div>
             </Container>

--- a/components/StoryImage/index.ts
+++ b/components/StoryImage/index.ts
@@ -1,1 +1,2 @@
 export * from './StoryImage';
+export * from './StoryImage.styles';

--- a/components/Storyblok/SbSection/SbSection.styles.ts
+++ b/components/Storyblok/SbSection/SbSection.styles.ts
@@ -35,7 +35,7 @@ export const subhead = (headerAlign?: AlignType) => cnb('relative z-10 rs-mt-3 t
 });
 export const contentWrapper = 'relative z-10';
 export const cta = 'cc md:flex-row *:mx-auto rs-mt-3 gap-20 lg:gap-27 w-fit';
-export const caption = 'gc-caption first:*:mt-0 *:leading-display mt-06em max-w-prose-wide';
+export const caption = 'gc-caption first:*:mt-0 *:leading-display pt-06em max-w-prose-wide';
 
 export const bgImage = 'absolute top-0 left-0 size-full object-cover';
 export const overlay = (hasBgGradient?: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');

--- a/components/Storyblok/SbSection/SbSection.tsx
+++ b/components/Storyblok/SbSection/SbSection.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/Typography';
 import { Container, type BgColorType } from '@/components/Container';
 import { RichText } from '@/components/RichText';
+import { captionBgColors, type CaptionBgColorType } from '@/components/StoryImage';
 import { WidthBox } from '@/components/WidthBox';
 import { accentBgColors, type PaddingType, type MarginType } from '@/utilities/datasource';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
@@ -49,6 +50,8 @@ type SbSectionProps = {
     cta?: SbBlokData[];
     caption?: StoryblokRichtext;
     captionColumnWidth?: '12' | '10' | '8' | '6' | '4';
+    isLightCaption?: boolean;
+    captionBgColor?: CaptionBgColorType;
     barColor?: {
       value?: PaletteAccentHexColorType;
     }
@@ -80,6 +83,8 @@ export const SbSection = ({
     cta,
     caption,
     captionColumnWidth,
+    isLightCaption,
+    captionBgColor,
     barColor: { value: barColorValue } = {},
     bgColor,
     bgImage: { filename, focus } = {},
@@ -260,10 +265,11 @@ export const SbSection = ({
         </Container>
       </m.div>
       {hasRichText(caption) && (
-        <WidthBox boundingWidth="site" width={captionColumnWidth}>
+        <WidthBox boundingWidth="site" width={captionColumnWidth} className={captionBgColors[captionBgColor]}>
           <RichText
             wysiwyg={caption}
-            textColor="black-70"
+            textColor={isLightCaption ? 'white' : 'black-70'}
+            linkColor={isLightCaption ? 'digital-red-xlight' : 'unset'}
             className={styles.caption}
           />
         </WidthBox>

--- a/components/Storyblok/SbSection/SbSection.tsx
+++ b/components/Storyblok/SbSection/SbSection.tsx
@@ -16,7 +16,6 @@ import {
 } from '@/components/Typography';
 import { Container, type BgColorType } from '@/components/Container';
 import { RichText } from '@/components/RichText';
-import { captionBgColors, type CaptionBgColorType } from '@/components/StoryImage';
 import { WidthBox } from '@/components/WidthBox';
 import { accentBgColors, type PaddingType, type MarginType } from '@/utilities/datasource';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
@@ -51,7 +50,7 @@ type SbSectionProps = {
     caption?: StoryblokRichtext;
     captionColumnWidth?: '12' | '10' | '8' | '6' | '4';
     isLightCaption?: boolean;
-    captionBgColor?: CaptionBgColorType;
+    captionBgColor?: BgColorType;
     barColor?: {
       value?: PaletteAccentHexColorType;
     }
@@ -265,7 +264,7 @@ export const SbSection = ({
         </Container>
       </m.div>
       {hasRichText(caption) && (
-        <WidthBox boundingWidth="site" width={captionColumnWidth} className={captionBgColors[captionBgColor]}>
+        <WidthBox boundingWidth="site" width={captionColumnWidth} bgColor={captionBgColor}>
           <RichText
             wysiwyg={caption}
             textColor={isLightCaption ? 'white' : 'black-70'}

--- a/components/Storyblok/SbStoryImage.tsx
+++ b/components/Storyblok/SbStoryImage.tsx
@@ -4,7 +4,7 @@ import { type ImageAspectRatioType } from '@/utilities/datasource';
 import { type WidthType } from '@/components/WidthBox';
 import { type PaddingType } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
-import { StoryImage } from '@/components/StoryImage';
+import { StoryImage, CaptionBgColorType } from '@/components/StoryImage';
 import { RichText } from '@/components/RichText';
 import { type AnimationType } from '@/components/Animate';
 import { type SbImageType } from './Storyblok.types';
@@ -25,6 +25,7 @@ type SbStoryImageProps = {
     spacingBottom?: PaddingType;
     isCaptionInset?: boolean;
     isCaptionLight?: boolean;
+    captionBgColor?: CaptionBgColorType;
     animation?: AnimationType;
     delay?: number;
     isHidden?: boolean;
@@ -46,6 +47,7 @@ export const SbStoryImage = ({
     spacingBottom,
     isCaptionInset,
     isCaptionLight,
+    captionBgColor = 'transparent',
     animation = 'none',
     delay,
     isHidden,
@@ -80,6 +82,7 @@ export const SbStoryImage = ({
       spacingTop={spacingTop}
       spacingBottom={spacingBottom}
       isCaptionInset={isCaptionInset}
+      captionBgColor={captionBgColor}
       animation={animation}
       delay={delay}
     />

--- a/components/WidthBox/WidthBox.tsx
+++ b/components/WidthBox/WidthBox.tsx
@@ -1,5 +1,5 @@
 import { cnb } from 'cnbuilder';
-import { Container, type ContainerProps } from '../Container';
+import { Container, type ContainerProps, type BgColorType } from '../Container';
 import { Grid, type GridProps } from '../Grid';
 import * as styles from './WidthBox.styles';
 
@@ -19,6 +19,7 @@ type NonFullWidthBoxProps = GridProps & {
   boundingWidth?: 'full' | 'site';
   width?: '12' | '10' | '8' | '6' | '4';
   align?: 'left' | 'center';
+  bgColor?: BgColorType;
 };
 
 export type WidthType = NonFullWidthBoxProps['width'];
@@ -28,6 +29,7 @@ export const WidthBox = ({
   boundingWidth = 'full',
   width = '12',
   align = 'center',
+  bgColor,
   children,
   className,
   ...props
@@ -37,6 +39,7 @@ export const WidthBox = ({
     return (
       <Container
         {...props as FullWidthBoxProps}
+        bgColor={bgColor}
         width={boundingWidth}
         className={className}
       >
@@ -46,7 +49,7 @@ export const WidthBox = ({
   }
 
   return (
-    <Container width={boundingWidth}>
+    <Container width={boundingWidth} bgColor={bgColor}>
       <Grid {...props as NonFullWidthBoxProps} gap="default" sm={12} className={className}>
         <div
           className={cnb(

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "next lint",
     "hps": "local-ssl-proxy --cert ./dev/localhost.pem --key ./dev/localhost-key.pem",
     "https-proxy-start": "local-ssl-proxy --source 3010 --target 3000 --cert ./dev/localhost.pem --key ./dev/localhost-key.pem",
+    "proxy": "local-ssl-proxy --source 3010 --target 3000 --cert ./dev/localhost.pem --key ./dev/localhost-key.pem",
     "vault": "netlify-plugin-vault-variables",
     "vault:local": "NODE_ENV=development netlify-plugin-vault-variables",
     "lint:fix": "eslint \"{components,utilities}/**/*.{ts,tsx,js,jsx}\" --quiet --fix",


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Provide options to add background colors to captions in Section and Story Image components
- Add padding to caption if background color is selected for Image compnent

# Review By (Date)
- Retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to Test -> Yvonne Test Caption - The Power of Art in storyblok and pick PR 330 from the visual editor.
2. Scroll down to see how these examples are possible
![Screenshot 2024-08-01 at 2 14 55 PM](https://github.com/user-attachments/assets/93a8f167-9a5b-4118-a40d-accd79347cca)
![Screenshot 2024-08-01 at 2 14 47 PM](https://github.com/user-attachments/assets/a991e5f2-c04d-4d4f-9ac5-7cbac4a051d9)


# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-373