### PR TITLE
GIVCAMP-372 | Show all stories functionality on story filter pages

### DIFF
--- a/components/StoryCard/StoryCard.tsx
+++ b/components/StoryCard/StoryCard.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { cnb } from 'cnbuilder';
 import { AnimateInView, type AnimationType } from '@/components/Animate';
 import { CtaLink } from '@/components/Cta/CtaLink';
@@ -29,7 +30,7 @@ export type StoryCardProps = React.HTMLAttributes<HTMLDivElement> & {
   isDark?: boolean;
 };
 
-export const StoryCard = ({
+export const StoryCard = React.forwardRef<HTMLAnchorElement, StoryCardProps>(({
   heading,
   headingLevel = 'h3',
   isSmallHeading,
@@ -47,7 +48,7 @@ export const StoryCard = ({
   isDark,
   className,
   ...props
-}: StoryCardProps) => {
+}, ref) => {
   // The heading level of the tags should be one more than the heading level of the card, but maxes out at h6
   const tagsHeadingLevelNumber: HeadingLevelNumberType =
     Math.min(parseInt(headingLevel?.slice(1), 10) + 1, 6) as HeadingLevelNumberType;
@@ -104,7 +105,7 @@ export const StoryCard = ({
                   accentBorderColors[tabColor])
                 }
               >
-                <CtaLink sbLink={link} href={href} className={styles.headingLink}>
+                <CtaLink ref={ref} sbLink={link} href={href} className={styles.headingLink}>
                   {heading}
                 </CtaLink>
               </Heading>
@@ -139,4 +140,4 @@ export const StoryCard = ({
       </article>
     </AnimateInView>
   );
-};
+});

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
@@ -4,3 +4,4 @@ export const heading = (hasIntro: boolean) => cnb(!hasIntro ? 'mb-0' : '');
 export const intro = '*:intro-text *:max-w-prose *:leading-snug md:*:leading-cozy';
 export const latest = 'relative';
 export const skiplink = 'hidden lg:block focus:block focus:w-fit focus:relative focus:bg-cardinal-red -top-60 focus:top-36 focus:mx-auto';
+export const showAllButton = 'rs-mt-6 su-w-fit su-mx-auto';

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
@@ -4,4 +4,6 @@ export const heading = (hasIntro: boolean) => cnb(!hasIntro ? 'mb-0' : '');
 export const intro = '*:intro-text *:max-w-prose *:leading-snug md:*:leading-cozy';
 export const latest = 'relative';
 export const skiplink = 'hidden lg:block focus:block focus:w-fit focus:relative focus:bg-cardinal-red -top-60 focus:top-36 focus:mx-auto';
+export const featuredGrid = 'gap-y-45 md:gap-y-90 2xl:gap-y-95';
+export const otherGrid = 'gap-y-45 md:gap-y-90 2xl:gap-y-95';
 export const showAllButton = 'rs-mt-6 w-fit mx-auto';

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.styles.ts
@@ -4,4 +4,4 @@ export const heading = (hasIntro: boolean) => cnb(!hasIntro ? 'mb-0' : '');
 export const intro = '*:intro-text *:max-w-prose *:leading-snug md:*:leading-cozy';
 export const latest = 'relative';
 export const skiplink = 'hidden lg:block focus:block focus:w-fit focus:relative focus:bg-cardinal-red -top-60 focus:top-36 focus:mx-auto';
-export const showAllButton = 'rs-mt-6 su-w-fit su-mx-auto';
+export const showAllButton = 'rs-mt-6 w-fit mx-auto';

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -4,7 +4,7 @@ import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { Container } from '@/components/Container';
 import { CreateBloks } from '@/components/CreateBloks';
 import { CreateStories } from '@/components/CreateStories';
-import { CtaButton } from '@/components/Cta';
+import { CtaButton, CtaLink } from '@/components/Cta';
 import { Grid } from '@/components/Grid';
 import { Heading } from '@/components/Typography';
 import { RichText } from '@/components/RichText';
@@ -145,18 +145,34 @@ export const SbStoryFilterPage = ({
                   );
                 })}
               </Grid>
-              {!showAll && filteredStoryList.length > MAX_STORIES_BEFORE_SHOWALL && (
-                <CtaButton
-                  variant="ghost-swipe"
-                  color="white"
-                  size="large"
-                  icon="chevron-down"
-                  animate="down"
-                  onClick={handleShowAll}
-                  className={styles.showAllButton}
-                >
-                  Show all stories
-                </CtaButton>
+              {filteredStoryList.length > MAX_STORIES_BEFORE_SHOWALL && (
+                <>
+                  {showAll ? (
+                    <CtaLink
+                      href="#story-list-nav-heading"
+                      variant="ghost-swipe"
+                      color="white"
+                      size="large"
+                      icon="chevron-up"
+                      animate="up"
+                      className={styles.showAllButton}
+                    >
+                      Back to top
+                    </CtaLink>
+                  ) : (
+                  <CtaButton
+                    variant="ghost-swipe"
+                    color="white"
+                    size="large"
+                    icon="chevron-down"
+                    animate="down"
+                    onClick={handleShowAll}
+                    className={styles.showAllButton}
+                  >
+                    Show all stories
+                  </CtaButton>
+                  )}
+                </>
               )}
             </>
           )}

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -147,6 +147,11 @@ export const SbStoryFilterPage = ({
               </Grid>
               {!showAll && filteredStoryList.length > MAX_STORIES_BEFORE_SHOWALL && (
                 <CtaButton
+                  variant="ghost-swipe"
+                  color="white"
+                  size="large"
+                  icon="chevron-down"
+                  animate="down"
                   onClick={handleShowAll}
                   className={styles.showAllButton}
                 >

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -101,7 +101,7 @@ export const SbStoryFilterPage = ({
           {hasFeaturedStories && (
             <>
               <Heading as="h3" srOnly>{`Featured Stor${getNumBloks(featuredStories) > 1 ? 'ies' : 'y'}`}</Heading>
-              <Grid py={6} isList className="gap-y-45 md:gap-y-90 2xl:gap-y-95">
+              <Grid py={6} isList className={styles.featuredGrid}>
                 <CreateBloks blokSection={featuredStories} isListItems />
               </Grid>
             </>
@@ -109,7 +109,7 @@ export const SbStoryFilterPage = ({
           {!!filteredStoryList?.length && (
             <>
             {hasFeaturedStories && <Heading as="h3" srOnly>Other stories</Heading>}
-              <Grid as="ul" pt={6} className="list-unstyled *:mb-0 gap-y-45 md:gap-y-90 2xl:gap-y-95">
+              <Grid isList pt={6} className={styles.otherGrid}>
                 {storyListToDisplay.map((story, index) => {
                   const {
                     cardTitle,

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -1,8 +1,10 @@
+import { useRef, useState } from 'react';
 import { storyblokEditable, type SbBlokData, type ISbStoryData } from '@storyblok/react/rsc';
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { Container } from '@/components/Container';
 import { CreateBloks } from '@/components/CreateBloks';
 import { CreateStories } from '@/components/CreateStories';
+import { CtaButton } from '@/components/Cta';
 import { Grid } from '@/components/Grid';
 import { Heading } from '@/components/Typography';
 import { RichText } from '@/components/RichText';
@@ -53,6 +55,9 @@ export const SbStoryFilterPage = ({
   slug,
   extra,
 }: SbStoryFilterPageProps) => {
+  // Maximum number of stories to show before the "Show all" button is displayed
+  const MAX_STORIES_BEFORE_SHOWALL = 10;
+
   /**
    * Extract uuid's from the featured stories into a Set.
    * The reason for using a Set in this case is its O(1) average time complexity for lookups,
@@ -66,9 +71,19 @@ export const SbStoryFilterPage = ({
    * ie, we remove stories that are already added as featured stories cards.
    */
   const filteredStoryList = extra.filter(item => !featuredStoryUUIDSet.has(item.uuid));
-
   const hasIntro = hasRichText(intro);
   const hasFeaturedStories = !!getNumBloks(featuredStories);
+
+  const [showAll, setShowAll] = useState(false);
+  const storyListToDisplay = showAll ? filteredStoryList : filteredStoryList.slice(0, MAX_STORIES_BEFORE_SHOWALL);
+  const firstStoryAfterShowAllRef = useRef(null);
+
+  const handleShowAll = () => {
+    setShowAll(true);
+    setTimeout(() => {
+      firstStoryAfterShowAllRef.current?.focus();
+    }, 200);
+  };
 
   return (
     <div {...storyblokEditable(blok)}>
@@ -95,7 +110,7 @@ export const SbStoryFilterPage = ({
             <>
             {hasFeaturedStories && <Heading as="h3" srOnly>Other stories</Heading>}
               <Grid as="ul" pt={6} className="list-unstyled *:mb-0 gap-y-45 md:gap-y-90 2xl:gap-y-95">
-                {filteredStoryList.map((story) => {
+                {storyListToDisplay.map((story, index) => {
                   const {
                     cardTitle,
                     title,
@@ -112,6 +127,7 @@ export const SbStoryFilterPage = ({
                   return (
                     <li key={story.uuid}>
                       <StoryCard
+                        ref={index === MAX_STORIES_BEFORE_SHOWALL ? firstStoryAfterShowAllRef : null}
                         isListView
                         isDark
                         heading={cardTitle || title}
@@ -129,6 +145,14 @@ export const SbStoryFilterPage = ({
                   );
                 })}
               </Grid>
+              {!showAll && filteredStoryList.length > MAX_STORIES_BEFORE_SHOWALL && (
+                <CtaButton
+                  onClick={handleShowAll}
+                  className={styles.showAllButton}
+                >
+                  Show all stories
+                </CtaButton>
+              )}
             </>
           )}
         </Container>

--- a/components/Storyblok/SbStoryListNav/SbStoryListNav.tsx
+++ b/components/Storyblok/SbStoryListNav/SbStoryListNav.tsx
@@ -63,7 +63,7 @@ export const SbStoryListNav = ({
   return (
     <Container width="full" bgColor="black" className={styles.root} {...storyblokEditable(blok)}>
       <Container as="nav" aria-label="Story list page menu">
-        <Heading size="base" align="center" className={styles.heading}>{heading}</Heading>
+        <Heading id="story-list-nav-heading" size="base" align="center" className={styles.heading}>{heading}</Heading>
         <div className={styles.desktop}>
           <StoryListContent blok={blok} fullSlug={fullSlug} name={name} />
         </div>


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- Display "Show all stories" button when there are more than 10 stories (excluding the featured one).
- After the button is click, it changes to a "Back to top" button that takes users to the filter menu heading.
- NOTE: Client likes the max number of stories to be 10 before the "Show all stories" button is displayed.

# Review By (Date)
- retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-332--giving-campaign.netlify.app/stories
2. scroll to the end of the list of stories and test the "Show all stories" button
3. It should show all stories and if using keyboard, focus on the 11th story after the button is clicked.
4. After that, it should become a "Back to top" button
5. Click that and it should bring users back to the filter menu heading.

# Associated Issues and/or People
- JIRA ticket(s) - GIVCAMP-372