### PR TITLE
GIVCAMP-356: Move Heap script so that it doesnt load on the editor page.

### DIFF
--- a/app/(storyblok)/[[...slug]]/layout.tsx
+++ b/app/(storyblok)/[[...slug]]/layout.tsx
@@ -1,4 +1,5 @@
 import StoryblokProvider from '@/components/StoryblokProvider';
+import { Heap } from '@/components/Heap';
 
 type StoryblokLayoutProps = {
   children: React.ReactNode,
@@ -13,8 +14,11 @@ export const dynamic = 'force-static';
 
 export default function StoryblokLayout({ children }: StoryblokLayoutProps) {
   return (
-    <StoryblokProvider>
-      {children}
-    </StoryblokProvider>
+    <>
+      <Heap />
+      <StoryblokProvider>
+        {children}
+      </StoryblokProvider>
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,6 @@ import { FlexBox } from '@/components/FlexBox';
 import { LocalFooterMvp } from '@/components/LocalFooter';
 import { GlobalFooter } from '@/components/GlobalFooter';
 import GAProvider, { GTAG } from '@/components/GAProvider';
-import { Heap } from '@/components/Heap';
 
 type LayoutProps = {
   children: React.ReactNode,
@@ -61,7 +60,6 @@ export default function RootLayout({ children }: LayoutProps) {
           )}
         >
           <GTAG />
-          <Heap />
           {/* Absolutely necessary to have a body tag here, otherwise your components won't get any interactivity */}
           <body>
             <FlexBox justifyContent="between" direction="col" className="min-h-screen relative">


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Moves heap script to load on the SB pages and not on the editor

# Review By (Date)
- Whenever

# Criticality
- Regular

# Review Tasks

1. Check out this branch
2. Set your `.env` file `CONTEXT` variable to `production`
3. Navigate to the [home page](http://localhost:3000/) on your local
4. Validate that the heap script loads by looking at your network tab requests (look for `heap-2306378928.js` or similar)
5. Do the same with an [interior page](http://localhost:3000/initiatives)
6. Navigate to storyblok and [load a page in the editor](https://app.storyblok.com/#/me/spaces/1005200/stories/0/0/8269210?env=Localhost) using the Localhost URL
9. Look at your network tab and confirm that the heap script does not load

# Associated Issues and/or People
- GIVCAMP-356