### PR TITLE
DS-853 | Add id options to 10 storyblok components; update CtaLink

### DIFF
--- a/components/Cta/CtaLink.tsx
+++ b/components/Cta/CtaLink.tsx
@@ -47,6 +47,10 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
     if (isInternal) {
       myLink = cachedUrl || href;
 
+      if (myLink === 'home') {
+        myLink = '';
+      }
+
       if (!myLink?.startsWith('/')) {
         myLink = `/${myLink}`;
       }

--- a/components/GAProvider.tsx
+++ b/components/GAProvider.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { GoogleTagManager } from '@next/third-parties/google'
+import { GoogleTagManager } from '@next/third-parties/google';
 import { useEffect } from 'react';
 import useUTMs from '@/hooks/useUTMs';
 const GTM_ID = 'GTM-5RGQ5DD';

--- a/components/Storyblok/SbBasicCard.tsx
+++ b/components/Storyblok/SbBasicCard.tsx
@@ -14,6 +14,7 @@ import { type SbImageType } from './Storyblok.types';
 export type SbBasicCardProps = {
   blok: {
     _uid: string;
+    id: string;
     superhead?: string;
     heading?: string;
     headingLevel?: HeadingType;
@@ -35,6 +36,7 @@ export type SbBasicCardProps = {
 
 export const SbBasicCard = ({
   blok: {
+    id,
     superhead,
     heading,
     headingLevel,
@@ -66,6 +68,7 @@ export const SbBasicCard = ({
   return (
     <BasicCard
       {...storyblokEditable(blok)}
+      id={id}
       superhead={superhead}
       heading={heading}
       headingLevel={headingLevel || 'h3'}

--- a/components/Storyblok/SbEmbedMedia.tsx
+++ b/components/Storyblok/SbEmbedMedia.tsx
@@ -10,6 +10,7 @@ import { RichText } from '../RichText';
 type SbEmbedMediaProps = {
   blok: {
     _uid: string;
+    id: string;
     mediaUrl: string;
     caption?: StoryblokRichtext;
     aspectRatio?: MediaAspectRatioType;
@@ -27,6 +28,7 @@ type SbEmbedMediaProps = {
 
 export const SbEmbedMedia = ({
   blok: {
+    id,
     mediaUrl,
     caption,
     aspectRatio,
@@ -51,6 +53,7 @@ export const SbEmbedMedia = ({
   return (
     <EmbedMedia
       {...storyblokEditable(blok)}
+      id={id}
       mediaUrl={mediaUrl}
       caption={Caption}
       aspectRatio={aspectRatio}

--- a/components/Storyblok/SbEventBanner.tsx
+++ b/components/Storyblok/SbEventBanner.tsx
@@ -11,6 +11,7 @@ import { type GradientFromType, type GradientToType, type GradientViaType } from
 type SbEventBannerProps = {
   blok: {
     _uid: string;
+    id: string;
     heading?: string;
     body: StoryblokRichtext;
     startDate?: string;
@@ -34,6 +35,7 @@ type SbEventBannerProps = {
 
 export const SbEventBanner = ({
   blok: {
+    id,
     heading,
     body,
     startDate,
@@ -65,6 +67,7 @@ export const SbEventBanner = ({
   return (
     <EventBanner
       {...storyblokEditable(blok)}
+      id={id}
       heading={heading}
       body={Body}
       startDate={startDate}

--- a/components/Storyblok/SbGrid.tsx
+++ b/components/Storyblok/SbGrid.tsx
@@ -7,6 +7,7 @@ import { type PaddingType, type MarginType } from '@/utilities/datasource';
 type SbGridProps = {
   blok: {
     _uid: string;
+    id: string;
     // Turn grid into <ul> and items into <li>
     isList?: boolean;
     gap?: GridGapType;
@@ -35,6 +36,7 @@ type SbGridProps = {
 
 export const SbGrid = ({
   blok: {
+    id,
     isList,
     gap,
     boundingWidth = 'full',
@@ -63,6 +65,7 @@ export const SbGrid = ({
   return (
     <WidthBox
       {...storyblokEditable(blok)}
+      id={id}
       boundingWidth={boundingWidth}
       width={width}
       align={align}

--- a/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
+++ b/components/Storyblok/SbHomepageThemeSection/SbHomepageThemeSection.tsx
@@ -26,6 +26,7 @@ import { getNumBloks } from '@/utilities/getNumBloks';
 type SbHomepageThemeSectionProps = {
   blok: {
     _uid: string;
+    id: string;
     superhead?: string;
     heading?: string;
     intro?: StoryblokRichtext;
@@ -43,6 +44,7 @@ type SbHomepageThemeSectionProps = {
 
 export const SbHomepageThemeSection = ({
   blok: {
+    id,
     superhead,
     heading,
     intro,
@@ -66,6 +68,7 @@ export const SbHomepageThemeSection = ({
 
   return (
     <Container
+      id={id}
       as="section"
       bgColor={isDarkTheme ? 'black' : 'white'}
       py={10}

--- a/components/Storyblok/SbScrollytelling.tsx
+++ b/components/Storyblok/SbScrollytelling.tsx
@@ -16,6 +16,7 @@ import { type MarginType } from '@/utilities/datasource';
 type SbScrollytellingProps = {
   blok: {
     _uid: string;
+    id: string;
     heading?: string;
     headingLevel?: HeadingType;
     subheading?: string;
@@ -34,6 +35,7 @@ type SbScrollytellingProps = {
 
 export const SbScrollytelling = ({
   blok: {
+    id,
     heading,
     headingLevel,
     subheading,
@@ -59,6 +61,7 @@ export const SbScrollytelling = ({
   return (
     <Scrollytelling
       {...storyblokEditable(blok)}
+      id={id}
       heading={heading}
       headingLevel={headingLevel}
       subheading={subheading}

--- a/components/Storyblok/SbSection/SbSection.tsx
+++ b/components/Storyblok/SbSection/SbSection.tsx
@@ -38,6 +38,7 @@ import * as styles from './SbSection.styles';
 type SbSectionProps = {
   blok: {
     _uid: string;
+    id?: string;
     content?: SbBlokData[];
     superhead?: string;
     heading?: string;
@@ -71,6 +72,7 @@ type SbSectionProps = {
 
 export const SbSection = ({
   blok: {
+    id,
     content,
     superhead,
     heading,
@@ -139,6 +141,7 @@ export const SbSection = ({
 
   return (
     <Container
+      id={id}
       as={!!heading ? 'section' : 'div'}
       width="full"
       mt={marginTop}

--- a/components/Storyblok/SbSidebarCard.tsx
+++ b/components/Storyblok/SbSidebarCard.tsx
@@ -9,6 +9,7 @@ import { getNumBloks } from '@/utilities/getNumBloks';
 export type SbSidebarCardProps = {
   blok: {
     _uid: string;
+    id: string;
     heading?: string;
     headingLevel?: HeadingType;
     isSmallHeading?: boolean;
@@ -30,6 +31,7 @@ export type SbSidebarCardProps = {
 
 export const SbSidebarCard = ({
   blok: {
+    id,
     heading,
     headingLevel,
     isSmallHeading,
@@ -51,6 +53,7 @@ export const SbSidebarCard = ({
   return (
     <SidebarCard
       {...storyblokEditable(blok)}
+      id={id}
       heading={heading}
       headingLevel={headingLevel}
       isSmallHeading={isSmallHeading}

--- a/components/Storyblok/SbText.tsx
+++ b/components/Storyblok/SbText.tsx
@@ -17,6 +17,7 @@ import {
 export type SbTextProps = {
   blok: {
     _uid: string;
+    id: string;
     text: string;
     color?: TextColorType;
     headingLevel?: HeadingType;
@@ -42,6 +43,7 @@ export type SbTextProps = {
 
 export const SbText = ({
   blok: {
+    id,
     text,
     color,
     headingLevel,
@@ -67,6 +69,7 @@ export const SbText = ({
 }: SbTextProps) => (
   <AnimateInView {...storyblokEditable(blok)} animation={animation} delay={delay}>
     <WidthBox
+      id={id}
       boundingWidth={boundingWidth}
       width={width}
       mt={marginTop}

--- a/components/Storyblok/SbWysiwyg.tsx
+++ b/components/Storyblok/SbWysiwyg.tsx
@@ -8,6 +8,7 @@ import { type PaddingType } from '@/utilities/datasource';
 type SbWysiwygProps = {
   blok: {
     _uid: string;
+    id: string;
     content: StoryblokRichtext;
     // TODO: I might remove this option and just pass down the color from the parent
     isLightText?: boolean;
@@ -25,6 +26,7 @@ type SbWysiwygProps = {
 
 export const SbWysiwyg = ({
   blok: {
+    id,
     content,
     isLightText,
     textAlign,
@@ -46,6 +48,7 @@ export const SbWysiwyg = ({
   return (
     <WidthBox
       {...storyblokEditable(blok)}
+      id={id}
       boundingWidth={boundingWidth}
       width={width}
       pt={spacingTop}


### PR DESCRIPTION
# READY FOR REVIEW


# Summary
- The goal of this ticket is to allow adding ids to some components (Section was the one that was asked, but adding to more components due to the way it's used). Also, confirm that anchor link is working for CTA component and links in WYSIWYG.
- Add id option to 10 components
- If `cached_url` is home in `CtaLink`, set it to empty string (the / is added afterwards in another statement). Note: In some cases, linking to the home page will result in cached_url as `/`. Actually I believe this is the case before, but I found that sometimes it can be `home`, so adding this check to replace `home`. 

# Review By (Date)
- Retro

# Criticality
- 6

# Review Tasks

## Setup tasks and/or behavior to test

1. I've published a couple test pages to test this. They're now unpublished, but you can see the preview build here:
https://deploy-preview-339--giving-campaign.netlify.app/test/test-stories/yvonne-test-new-story-hero
Test the 3 links in the WYSIWYG with the anchor links.
![Screenshot 2024-09-03 at 10 55 02 PM](https://github.com/user-attachments/assets/325ef8f1-7934-49b7-8f65-07cbad8d2e2f)

2. Go to this page
https://deploy-preview-339--giving-campaign.netlify.app/test/yvonne-test-homepage-reorder-changemaker
and test the 2 link button with anchor links
![Screenshot 2024-09-03 at 10 57 14 PM](https://github.com/user-attachments/assets/80e70785-eca0-4978-be35-e27f1898a2a6)



# Associated Issues and/or People
- JIRA ticket(s) - DS-853
