### PR TITLE
NOJIRA | Add default link color for light text mode for card WYSIWYG

### DIFF
--- a/components/Storyblok/SbCardWysiwyg.tsx
+++ b/components/Storyblok/SbCardWysiwyg.tsx
@@ -32,7 +32,7 @@ export const SbCardWysiwyg = ({
       type="card"
       wysiwyg={content}
       textColor={isLightText ? 'white' : 'black'}
-      linkColor={linkColor}
+      linkColor={linkColor || isLightText ? 'digital-red-xlight' : 'unset'}
     />
   </div>
 );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use digital red xlight for link color as default if the card WYSIWYG is using the light text mode

# Review By (Date)
- Retro

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to this page and scroll to the bottom of the story where this card is
![Screenshot 2025-01-08 at 5 23 07 PM](https://github.com/user-attachments/assets/b359907e-78f5-4cc9-a2aa-24f84c3ab9df)
2. Check that the link color is digital red xlight
3. Compare to current live where it's using the darker digital red which is not accessible
https://momentum.stanford.edu/stories/agree-to-disagree

