### PR TITLE
DS-1102 | Allow adding custom preview image for Embed Media video light mode

### DIFF
--- a/components/EmbedMedia/EmbedMedia.styles.ts
+++ b/components/EmbedMedia/EmbedMedia.styles.ts
@@ -1,4 +1,6 @@
-export const mediaWrapper = '*:!w-full *:!h-full';
+export const mediaWrapper = '*:!w-full *:!h-full overflow-hidden relative';
 export const caption = '*:*:leading-display first:*:*:mt-0 mt-06em max-w-prose-wide';
-export const iconWrapper = 'size-50 sm:size-70 bg-black-true/70 border-3 rounded-full border-white group-hocus-within:scale-110 transition group-hocus-within:bg-digital-red';
+export const iconWrapper = 'z-10 size-50 sm:size-70 bg-black-true/70 border-3 rounded-full border-white group-hocus-within:scale-110 transition group-hocus-within:bg-digital-red';
+export const previewImage = 'absolute inset-0 size-full object-cover';
 export const previewIcon = 'text-white size-24 sm:size-30';
+

--- a/components/EmbedMedia/EmbedMedia.tsx
+++ b/components/EmbedMedia/EmbedMedia.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { cnb } from 'cnbuilder';
 import ReactPlayer from 'react-player/lazy';
-import { Container } from '../Container';
-import { FlexBox } from '../FlexBox';
-import { WidthBox, type WidthType } from '../WidthBox';
-import { HeroIcon } from '../HeroIcon';
+import { Container } from '@/components/Container';
+import { FlexBox } from '@/components/FlexBox';
+import { WidthBox, type WidthType } from '@/components/WidthBox';
+import { HeroIcon } from '@/components/HeroIcon';
 import { type PaddingType } from '@/utilities/datasource';
 import { type MediaAspectRatioType, mediaAspectRatios } from '@/utilities/datasource';
+import { getProcessedImage } from '@/utilities/getProcessedImage';
+import { getSbImageSize } from '@/utilities/getSbImageSize';
 import * as styles from './EmbedMedia.styles';
 
 type EmbedMediaProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -19,6 +21,8 @@ type EmbedMediaProps = React.HTMLAttributes<HTMLDivElement> & {
   spacingBottom?: PaddingType;
   isCaptionInset?: boolean;
   isPreview?: boolean;
+  previewImageSrc?: string;
+  previewImageFocus?: string;
   previewAriaLabel?: string;
 };
 
@@ -38,6 +42,7 @@ export const EmbedMedia = ({
   spacingBottom,
   isCaptionInset,
   isPreview,
+  previewImageSrc,
   previewAriaLabel,
   className,
   ...props
@@ -52,6 +57,45 @@ export const EmbedMedia = ({
       setHasWindow(true);
     }
   }, []);
+
+  let PreviewImage: ReactElement;
+  if (previewImageSrc) {
+    const { width: originalWidth, height: originalHeight } = getSbImageSize(previewImageSrc);
+    const cropHeight = Math.round(originalHeight * 1500 / originalWidth);
+
+    PreviewImage = (
+      <picture>
+        <source
+          srcSet={getProcessedImage(previewImageSrc, '1500x0')}
+          media="(min-width: 1200px)"
+        />
+        <source
+          srcSet={getProcessedImage(previewImageSrc, '1200x0')}
+          media="(min-width: 992px)"
+        />
+        <source
+          srcSet={getProcessedImage(previewImageSrc, '1000x0')}
+          media="(min-width: 768px)"
+        />
+        <source
+          srcSet={getProcessedImage(previewImageSrc, '800x0')}
+          media="(min-width: 576px)"
+        />
+        <source
+          srcSet={getProcessedImage(previewImageSrc, '600x0')}
+          media="(max-width: 575px)"
+        />
+        <img
+          src={getProcessedImage(previewImageSrc, '1500x0')}
+          loading="lazy"
+          width={1500}
+          height={cropHeight}
+          alt=""
+          className={styles.previewImage}
+        />
+      </picture>
+    );
+  }
 
   return (
     <WidthBox
@@ -72,7 +116,7 @@ export const EmbedMedia = ({
               url={mediaUrl}
               controls
               playsinline
-              light={isPreview ? true : false}
+              light={previewImageSrc && isPreview ? PreviewImage : isPreview}
               playing={isPreview ? true : false}
               playIcon={isPreview ? PlayPreviewIcon : undefined}
               // This previewAriaLabel prop is not documented but it is in the React Player source code

--- a/components/EmbedMedia/EmbedMedia.tsx
+++ b/components/EmbedMedia/EmbedMedia.tsx
@@ -22,7 +22,6 @@ type EmbedMediaProps = React.HTMLAttributes<HTMLDivElement> & {
   isCaptionInset?: boolean;
   isPreview?: boolean;
   previewImageSrc?: string;
-  previewImageFocus?: string;
   previewAriaLabel?: string;
 };
 

--- a/components/Storyblok/SbEmbedMedia.tsx
+++ b/components/Storyblok/SbEmbedMedia.tsx
@@ -1,11 +1,12 @@
 import { storyblokEditable } from '@storyblok/react/rsc';
 import { type StoryblokRichtext } from 'storyblok-rich-text-react-renderer-ts';
 import { type MediaAspectRatioType } from '@/utilities/datasource';
-import { type WidthType } from '../WidthBox';
+import { type WidthType } from '@/components/WidthBox';
 import { type PaddingType } from '@/utilities/datasource';
 import { hasRichText } from '@/utilities/hasRichText';
-import { EmbedMedia } from '../EmbedMedia';
-import { RichText } from '../RichText';
+import { EmbedMedia } from '@/components/EmbedMedia';
+import { RichText } from '@/components/RichText';
+import { type SbImageType } from '@/components/Storyblok/Storyblok.types';
 
 type SbEmbedMediaProps = {
   blok: {
@@ -21,6 +22,7 @@ type SbEmbedMediaProps = {
     isCaptionInset?: boolean;
     isCaptionLight?: boolean;
     isPreview?: boolean;
+    previewImage?: SbImageType;
     previewAriaLabel?: string;
     isHidden?: boolean;
   };
@@ -39,6 +41,7 @@ export const SbEmbedMedia = ({
     isCaptionInset,
     isCaptionLight,
     isPreview,
+    previewImage: { filename } = {},
     previewAriaLabel = 'Play video',
     isHidden,
   },
@@ -63,6 +66,7 @@ export const SbEmbedMedia = ({
       spacingBottom={spacingBottom}
       isCaptionInset={isCaptionInset}
       isPreview={isPreview}
+      previewImageSrc={filename}
       previewAriaLabel={previewAriaLabel}
     />
   );


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add Preview Image field to the Embed Media component because React Player pulls the low res thumbnail (600px) as the preview image if using their "light" mode (shows the preview image with an icon instead of the player on page load)

# Review By (Date)
- Sooner would be nice

# Criticality
- 6

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to the live site and look at the video preview of this story, and confirm that it is a low res image:
https://momentum.stanford.edu/stories/into-the-future

2. Go to Momentum Storyblok `Momentum/Test/Yvonne Test Video Preview`
3. Select PR 382 from the visual editor URL
4. Scroll down to see that both of the videos on the page have high res preview images that were selected in storyblok
5. The first video is Vimeo, 2nd is Youtube with a 1x1 aspect ratio. Check that the image fills the container and that the play icon hover/focus animation still works.
6. Click the preview image and confirm that it plays the video on non-mobile devices. On mobile devices, it will load the player but won't autoplay.
7. Remove the preview image in Storyblok, check that it still uses the preview mode, but with the default low res image it pulls from the streaming platform.
8. Note: I've tested in Safari, Firefox and Chrome so you don't have to. I've tested on mobile myself but please feel free to test that yourself.

# Associated Issues and/or People
- JIRA ticket(s) - DS-1102
