### PR TITLE
DS-1115 | A11y: Don't use heading for changemaker cards because there is no content

### DIFF
--- a/components/ChangemakerCard/ChangemakerCard.styles.ts
+++ b/components/ChangemakerCard/ChangemakerCard.styles.ts
@@ -24,7 +24,7 @@ export const overlay = 'absolute top-0 left-0 size-full bg-gradient-to-t via-bla
 export const info = (isHorizontal: boolean) => cnb('rs-px-1 pb-150 absolute size-full bottom-0 left-0 mb-0', {
   'px-20 md:px-45 sm:pb-200 xl:pb-130': isHorizontal,
 });
-export const heading = (isHorizontal: boolean) => cnb('mb-02em mt-auto text-30 whitespace-pre-line', {
+export const heading = (isHorizontal: boolean) => cnb('mb-02em mt-auto text-30 whitespace-pre-line tracking-tight', {
   '2xl:text-[3.6rem]': !isHorizontal,
   'sm:fluid-type-4 xl:max-w-[30ch] mx-auto': isHorizontal,
 });

--- a/components/ChangemakerCard/ChangemakerCard.tsx
+++ b/components/ChangemakerCard/ChangemakerCard.tsx
@@ -6,7 +6,7 @@ import {
 } from '@headlessui/react';
 import { useOnClickOutside } from 'usehooks-ts';
 import { AnimateInView, type AnimationType } from '@/components/Animate';
-import { Heading, type HeadingType, Text } from '@/components/Typography';
+import { Text, type HeadingType } from '@/components/Typography';
 import { FlexBox } from '@/components/FlexBox';
 import { HeroIcon } from '@/components/HeroIcon';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
@@ -49,7 +49,7 @@ export const ChangemakerCard = ({
   return (
     <>
       <AnimateInView animation={animation} delay={delay}>
-        <article
+        <div
           className={cnb('changemaker-card', styles.root(isHorizontal), className)}
           {...props}
         >
@@ -110,15 +110,16 @@ export const ChangemakerCard = ({
                 </div>
               )}
               <FlexBox direction="col" className={styles.info(isHorizontal)}>
-                <Heading
-                  as={headingLevel || 'h3'}
+                <Text
+                  font="serif"
                   leading="tight"
                   align="center"
                   color="white"
+                  weight="bold"
                   className={styles.heading(isHorizontal)}
                 >
                   {heading}
-                </Heading>
+                </Text>
                 {subheading && (
                   <Text align="center" leading="display" color="white" className={styles.subhead}>{subheading}</Text>
                 )}
@@ -139,7 +140,7 @@ export const ChangemakerCard = ({
               />
             </button>
           </div>
-        </article>
+        </div>
       </AnimateInView>
       {/* Content is displayed in a modal */}
       <Transition show={isModalOpen}>

--- a/components/ChangemakerCard/ChangemakerCard.tsx
+++ b/components/ChangemakerCard/ChangemakerCard.tsx
@@ -6,7 +6,7 @@ import {
 } from '@headlessui/react';
 import { useOnClickOutside } from 'usehooks-ts';
 import { AnimateInView, type AnimationType } from '@/components/Animate';
-import { Text, type HeadingType } from '@/components/Typography';
+import { Text } from '@/components/Typography';
 import { FlexBox } from '@/components/FlexBox';
 import { HeroIcon } from '@/components/HeroIcon';
 import { getProcessedImage } from '@/utilities/getProcessedImage';
@@ -15,7 +15,6 @@ import * as styles from './ChangemakerCard.styles';
 
 export type ChangemakerCardProps = React.HTMLAttributes<HTMLDivElement> & {
   heading: string;
-  headingLevel?: HeadingType;
   subheading?: string;
   imageSrc?: string;
   imageFocus?: string;
@@ -28,7 +27,6 @@ export type ChangemakerCardProps = React.HTMLAttributes<HTMLDivElement> & {
 
 export const ChangemakerCard = ({
   heading,
-  headingLevel = 'h3',
   subheading,
   imageSrc,
   imageFocus,

--- a/components/Storyblok/SbChangemakerCard.tsx
+++ b/components/Storyblok/SbChangemakerCard.tsx
@@ -1,7 +1,6 @@
 import { storyblokEditable, type SbBlokData } from '@storyblok/react/rsc';
 import { ChangemakerCard } from '@/components/ChangemakerCard';
 import { type AnimationType } from '@/components/Animate';
-import { type HeadingType } from '@/components/Typography';
 import { CreateBloks } from '@/components/CreateBloks';
 import { type SbImageType } from '@/components/Storyblok/Storyblok.types';
 import { getNumBloks } from '@/utilities/getNumBloks';
@@ -11,7 +10,6 @@ export type SbChangemakerCardProps = {
   blok: {
     _uid: string;
     heading?: string;
-    headingLevel?: HeadingType;
     subheading?: string;
     image?: SbImageType;
     body?: SbBlokData[];
@@ -24,7 +22,6 @@ export type SbChangemakerCardProps = {
 export const SbChangemakerCard = ({
   blok: {
     heading,
-    headingLevel,
     subheading,
     image: { filename, focus } = {},
     body,
@@ -40,7 +37,6 @@ export const SbChangemakerCard = ({
     <ChangemakerCard
       {...storyblokEditable(blok)}
       heading={heading}
-      headingLevel={headingLevel}
       subheading={subheading}
       imageSrc={filename}
       imageFocus={focus}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This is a siteimprove suggestion https://stanford.atlassian.net/browse/DS-1115
- Headline for “Changemaker Card” needs text (not heading) option. If there’s no text other than the headline, the headline must not be a heading. 

# Review By (Date)
- Retro

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-388--giving-campaign.netlify.app/initiatives/undergraduate-financial-aid
2. Look at the Changemaker Cards in question and check that the "headings" are no longer headings
![Screenshot 2025-02-04 at 2 21 30 PM](https://github.com/user-attachments/assets/a493ed53-0195-4cf2-87cf-f16e874cb80a)


# Associated Issues and/or People
- JIRA ticket(s) - DS-1115
