### PR TITLE
DS-1505 | Allow user to use tab label for heading or superheading; optimization

### DIFF
--- a/components/Storyblok/Storyblok.types.ts
+++ b/components/Storyblok/Storyblok.types.ts
@@ -114,7 +114,9 @@ export type SbSliderImageType = {
 export type SbTabItemType = {
   _uid: string;
   label: string;
+  useLabelFor?: 'heading' | 'superhead';
   featuredMedia?: SbBlokData[];
+  superhead?: string;
   heading?: string;
   body?: StoryblokRichtext;
   otherContent?: SbBlokData[];

--- a/components/Tabs/Tabs.styles.ts
+++ b/components/Tabs/Tabs.styles.ts
@@ -10,12 +10,12 @@ export type TabItemHeadingSizeType = keyof typeof headingSizes;
 export const root = 'relative cc break-words scroll-mt-80';
 export const tabGroup = 'hidden sm:grid grid-cols-12';
 export const tabList = (isKeyboardUser: boolean) => cnb('flex flex-col col-span-4', isKeyboardUser && 'focus-within:outline focus-within:outline-digital-blue');
-export const tabItem = (isLightText: boolean) => cnb('relative data-[hover]:underline data-[hover]:underline-offset-4 data-[selected]:outline-none text-left md:pl-20 pr-20 lg:px-26 py-20 lg:py-26 type-1 lg:text-[2.7rem] xl:text-[3.4rem] font-normal data-[selected]:underline data-[selected]:underline-offset-4 leading-display transition-colors',
+export const tabItem = (isLightText: boolean) => cnb('relative data-[hover]:underline data-[hover]:underline-offset-4 data-[selected]:outline-none text-left lg:pl-20 pr-30 xl:pl-26 xl:pr-40 py-20 lg:py-26 type-1 lg:text-[2.7rem] xl:text-[3.4rem] font-normal data-[selected]:underline data-[selected]:underline-offset-4 leading-display transition-colors',
   isLightText ?
     'text-black-30 data-[selected]:text-white hover:text-white'
     : 'text-black/60 data-[selected]:text-gc-black hover:text-gc-black',
 );
-export const tabItemBar = (isLightText: boolean) => cnb('h-full w-20 absolute right-0 top-0 ',
+export const tabItemBar = (isLightText: boolean) => cnb('h-full w-14 xl:w-20 absolute right-0 top-0 ',
   isLightText ? 'bg-digital-red-light' : 'bg-digital-red',
 );
 export const tabPanel = (isLightText: boolean) => cnb('border-l pl-20 lg:pl-30 xl:pl-36 col-span-8',

--- a/components/Tabs/Tabs.styles.ts
+++ b/components/Tabs/Tabs.styles.ts
@@ -21,8 +21,8 @@ export const tabItemBar = (isLightText: boolean) => cnb('h-full w-20 absolute ri
 export const tabPanel = (isLightText: boolean) => cnb('border-l pl-20 lg:pl-30 xl:pl-36 col-span-8',
   isLightText ? 'border-black-50' : 'border-black-60',
 );
-
-export const superhead = 'rs-mt-2 first:mt-0 mb-04em';
+export const contentWrapper = 'gap-16 md:gap-26 xl:gap-36';
+export const superhead = 'mb-03em';
 export const heading = (headingSize: TabItemHeadingSizeType) => headingSizes[headingSize || 'medium'];
 export const mobileGrid = 'sm:hidden list-unstyled';
 export const li = 'scroll-mt-30';

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -166,7 +166,7 @@ export const Tabs = ({
       {/* For SM breakpoint and above, display tab group */}
       <TabGroup vertical className={styles.tabGroup} selectedIndex={selectedIndex} onChange={handleTabChange}>
         <TabList className={styles.tabList(isKeyboardUser)}>
-          {tabItemsWithSlug?.map((tabItem) => (
+          {tabItemsWithSlug.map((tabItem) => (
             <Tab as={Fragment} key={tabItem._uid}>
               {({ selected }) => (
                 <button className={styles.tabItem(isLightText)}>
@@ -183,7 +183,7 @@ export const Tabs = ({
           ))}
         </TabList>
         <TabPanels className={styles.tabPanel(isLightText)}>
-          {tabItemsWithSlug?.map((tabItem) => (
+          {tabItemsWithSlug.map((tabItem) => (
             <TabPanel key={tabItem._uid}>
               <TabContent
                 label={tabItem.label}
@@ -206,7 +206,7 @@ export const Tabs = ({
       {/* For mobile (XS only), display expanded list of all the tab item content */}
       <Grid as="ul" gap="card" className={styles.mobileGrid}>
         {tabItemsWithSlug.map((tabItem) => (
-          <li key={tabItem._uid} id={`#${uniquePrefix}${tabItem.slug}`} className={styles.li}>
+          <li key={tabItem._uid} id={`${uniquePrefix}${tabItem.slug}`} className={styles.li}>
             <TabContent
               label={tabItem.label}
               useLabelFor={tabItem.useLabelFor || 'superhead'}

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -9,6 +9,7 @@ import { useMediaQuery } from 'usehooks-ts';
 import { useKeyboard } from '@/hooks/useKeyboard';
 import { AnimateInView, type AnimationType } from '@/components/Animate';
 import { CreateBloks } from '@/components/CreateBloks';
+import { FlexBox } from '@/components/FlexBox';
 import { Grid } from '@/components/Grid';
 import { RichText } from '@/components/RichText';
 import {
@@ -40,42 +41,55 @@ const TabContent = ({
   isLightText,
   animation,
   label,
+  useLabelFor = 'superhead',
+  superhead,
   heading,
   featuredMedia,
   id,
   body,
   otherContent,
-}: TabContentProps) => (
-  <AnimateInView animation={animation} id={id}>
-    <CreateBloks blokSection={featuredMedia} />
-    <Text
-      size={1}
-      weight="semibold"
-      aria-hidden="true"
-      color={isLightText ? 'white' : 'black'}
-      leading="display"
-      className={styles.superhead}
-    >
-      {label}
-    </Text>
-    <Heading
-      as={headingLevel}
-      font={isSerifHeading ? 'serif' : 'druk'}
-      color={isLightText ? 'white' : 'black'}
-      className={styles.heading(headingSize)}
-    >
-      <SrOnlyText>{`${label}:`}</SrOnlyText>{heading}
-    </Heading>
-    {hasRichText(body) && (
-      <RichText
-        wysiwyg={body}
-        textColor={isLightText ? 'white' : 'black'}
-        linkColor={isLightText ? 'digital-red-xlight' : 'unset'}
-      />
-    )}
-    <CreateBloks blokSection={otherContent} />
-  </AnimateInView>
-);
+}: TabContentProps) => {
+  const visibleSuperhead = useLabelFor === 'superhead' ? label : superhead;
+
+  return (
+    <AnimateInView animation={animation} id={id}>
+      <FlexBox direction="col" className={styles.contentWrapper}>
+        <CreateBloks blokSection={featuredMedia} />
+        <div>
+          {visibleSuperhead && (
+            <Text
+              size={1}
+              weight="semibold"
+              aria-hidden="true"
+              color={isLightText ? 'white' : 'black'}
+              leading="display"
+              className={styles.superhead}
+            >
+              {visibleSuperhead}
+            </Text>
+          )}
+          <Heading
+            as={headingLevel}
+            font={isSerifHeading ? 'serif' : 'druk'}
+            color={isLightText ? 'white' : 'black'}
+            className={styles.heading(headingSize)}
+          >
+            {visibleSuperhead && <SrOnlyText>{`${visibleSuperhead}:`}</SrOnlyText>}
+            {useLabelFor === 'heading' ? label : heading}
+          </Heading>
+          {hasRichText(body) && (
+            <RichText
+              wysiwyg={body}
+              textColor={isLightText ? 'white' : 'black'}
+              linkColor={isLightText ? 'digital-red-xlight' : 'unset'}
+            />
+          )}
+          <CreateBloks blokSection={otherContent} />
+        </div>
+      </FlexBox>
+    </AnimateInView>
+  );
+};
 
 export const Tabs = ({
   tabItems,
@@ -167,6 +181,8 @@ export const Tabs = ({
             <TabPanel key={tabItem._uid}>
               <TabContent
                 label={tabItem.label}
+                useLabelFor={tabItem.useLabelFor || 'superhead'}
+                superhead={tabItem.superhead}
                 heading={tabItem.heading}
                 featuredMedia={tabItem.featuredMedia}
                 body={tabItem.body}
@@ -187,6 +203,8 @@ export const Tabs = ({
           <li key={tabItem._uid} id={`#${uniquePrefix}${slugify(tabItems[index].label)}`} className={styles.li}>
             <TabContent
               label={tabItem.label}
+              useLabelFor={tabItem.useLabelFor || 'superhead'}
+              superhead={tabItem.superhead}
               heading={tabItem.heading}
               featuredMedia={tabItem.featuredMedia}
               body={tabItem.body}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add superheading field to Tab items
- Allow user to choose whether to use tab label for superheading or heading
- Code optimization

# Review By (Date)
- Retro

# Criticality
- 6

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-399--giving-campaign.netlify.app/test/yvonne-test-agenda-update
2. Check that all the tab groups are working correctly
3. Check that in the first tab group, the tab labels are used as the big Serif headings in each tab item
4. Check that in the other tab group, the tab labels can be used as either heading or superheading.
5. Go to https://deploy-preview-399--giving-campaign.netlify.app/test/yvonne-test-agenda-update#agenda-3-240-pm-connect--break
6. Check that it opens up the correct tab and scrolls to the right place
7. Go to the above link on mobile and make sure that it scrolls to the correct section

# Associated Issues and/or People
- JIRA ticket(s) - DS-1505