### PR TITLE
DS-1138 | Add support for School taxonomy tags and filter pages

### DIFF
--- a/components/Storyblok/SbStoryCard.tsx
+++ b/components/Storyblok/SbStoryCard.tsx
@@ -3,7 +3,7 @@ import { type AnimationType } from '@/components/Animate';
 import { type HeadingType } from '@/components/Typography';
 import { StoryCard } from '@/components/StoryCard';
 import { type SbImageType, type SbLinkType } from './Storyblok.types';
-import { type InitiativesType, type ThemesType } from '@/utilities/taxonomyMaps';
+import { type InitiativesType, type SchoolsType, type ThemesType } from '@/utilities/taxonomyMaps';
 import { paletteAccentColors, type PaletteAccentHexColorType } from '@/utilities/colorPalettePlugin';
 
 export type SbStoryCardProps = {
@@ -14,6 +14,7 @@ export type SbStoryCardProps = {
         title?: string;
         dek?: string;
         initiatives?: InitiativesType[];
+        schools?: SchoolsType[];
         themes?: ThemesType[];
         heroImage?: SbImageType;
         bgImage?: SbImageType;
@@ -48,6 +49,7 @@ export const SbStoryCard = ({
         title = '',
         dek = '',
         initiatives = [],
+        schools = [],
         themes = [],
         heroImage: { filename: heroFilename = '', focus: heroFocus = '' } = {},
         bgImage: { filename: bgFilename = '', focus: bgFocus = '' } = {},
@@ -72,7 +74,7 @@ export const SbStoryCard = ({
   },
   blok,
 }: SbStoryCardProps) => {
-  const taxonomyArray = [...initiatives, ...themes];
+  const taxonomyArray = [...initiatives, ...themes, ...schools];
 
   return (
     <StoryCard

--- a/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
+++ b/components/Storyblok/SbStoryFilterPage/SbStoryFilterPage.tsx
@@ -20,7 +20,7 @@ type StoryPickerType = {
   [key: string]: unknown;
 }
 
-type FaturedStoryType = SbBlokData & {
+type FeaturedStoryType = SbBlokData & {
   storyPicker: StoryPickerType;
 }
 
@@ -29,7 +29,7 @@ type SbStoryFilterPageProps = {
     _uid: string;
     intro?: StoryblokRichtext;
     belowIntro?: SbBlokData[];
-    featuredStories?: FaturedStoryType[];
+    featuredStories?: FeaturedStoryType[];
     ankle?: SbBlokData[];
     mastheadPicker?: ISbStoryData[];
     heroPicker?: ISbStoryData[];
@@ -121,6 +121,7 @@ export const SbStoryFilterPage = ({
                     bgImage,
                     tabColor,
                     initiatives,
+                    schools,
                     themes,
                   } = story.content;
 
@@ -139,7 +140,7 @@ export const SbStoryFilterPage = ({
                         tabColor={paletteAccentColors[tabColor?.value]}
                         href={`/${story.full_slug}`}
                         animation="slideUp"
-                        taxonomy={[...initiatives, ...themes]}
+                        taxonomy={[...initiatives, ...themes, ...schools]}
                       />
                     </li>
                   );

--- a/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
+++ b/components/Storyblok/SbStoryMvp/SbStoryMvp.tsx
@@ -4,7 +4,7 @@ import { CreateStories } from '@/components/CreateStories';
 import { Container } from '@/components/Container';
 import { SocialSharing } from '@/components/SocialSharing';
 import { StoryHeroMvp, type StoryHeroMvpProps } from '@/components/Hero';
-import { type InitiativesType, type ThemesType } from '@/utilities/taxonomyMaps';
+import { type InitiativesType, type SchoolsType, type ThemesType } from '@/utilities/taxonomyMaps';
 import { SbAboveContent } from './SbAboveContent';
 import { getNumBloks } from '@/utilities/getNumBloks';
 
@@ -20,6 +20,7 @@ type SbStoryMvpProps = {
     ankle?: SbBlokData[];
     mastheadPicker?: ISbStoryData[];
     initiatives?: InitiativesType[];
+    schools?: SchoolsType[];
     themes?: ThemesType[];
   } & StoryHeroMvpProps;
   slug?: string;
@@ -35,8 +36,9 @@ export const SbStoryMvp = ({
     byline,
     dek,
     publishedDate,
-    initiatives,
-    themes,
+    initiatives = [],
+    schools = [],
+    themes = [],
     heroVariant,
     heroBgColor,
     heroImage,
@@ -71,7 +73,7 @@ export const SbStoryMvp = ({
   slug,
 }: SbStoryMvpProps) => {
   const showAboveContent = !!getNumBloks(aboveSidebar) || !!getNumBloks(intro) || !!getNumBloks(sidebar);
-  const taxonomyArray = [...initiatives, ...themes];
+  const taxonomyArray = [...initiatives, ...themes, ...schools];
 
   return (
     <div {...storyblokEditable(blok)}>

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -143,19 +143,18 @@ export const Tabs = ({
 
       if (index !== -1) {
         setSelectedIndex(index);
-
-        setTimeout(() => {
-          /**
-           * For SM breakpoint and above, if the page hash matches a tab hash,
-           * set that tab as active and scroll to the top of the correct tab group
-           */
-          if (isRenderTabs) {
-            tabGroupRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          } else {
-            const element = document.getElementById(`${uniquePrefix}${tabItemsWithSlug[index].slug}`);
-            element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          }
-        }, 0); // Ensures the DOM is fully loaded before scrolling
+        /**
+         * For SM breakpoint and above, if the page hash matches a tab hash,
+         * set that tab as active and scroll to the top of the correct tab group
+         */
+        if (isRenderTabs) {
+          tabGroupRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        // On mobile (XS), scroll to the id anchor at the top of the exposed item content
+        else {
+          const element = document.getElementById(`#${uniquePrefix}${slugify(tabItems[index].label)}`);
+          element?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
       }
     }
     // Run only on mount

--- a/utilities/data/getStoryList.ts
+++ b/utilities/data/getStoryList.ts
@@ -31,6 +31,11 @@ export async function getStoryList({ path }: getStoryDataProps) {
         },
       },
       {
+        schools: {
+          in_array: slug,
+        },
+      },
+      {
         themes: {
           in_array: slug,
         },

--- a/utilities/data/types.d.ts
+++ b/utilities/data/types.d.ts
@@ -23,6 +23,9 @@ export type FilterQuery = {
   initiatives?: {
     in_array: string;
   };
+  schools?: {
+    in_array: string;
+  };
   themes?: {
     in_array: string;
   };

--- a/utilities/taxonomyMaps.ts
+++ b/utilities/taxonomyMaps.ts
@@ -19,6 +19,17 @@ export const initiativesMap = {
 };
 export type InitiativesType = keyof typeof initiativesMap;
 
+export const schoolsMap = {
+  'graduate-school-of-business': 'Graduate School of Business',
+  'stanford-doerr-school-of-sustainability': 'Stanford Doerr School of Sustainability',
+  'graduate-school-of-education': 'Graduate School of Education',
+  'school-of-engineering': 'School of Engineering',
+  'school-of-humanities-and-sciences': 'School of Humanities and Sciences',
+  'school-of-law': 'School of Law',
+  'school-of-medicine': 'School of Medicine',
+};
+export type SchoolsType = keyof typeof schoolsMap;
+
 export const themesMap = {
   'accelerating-solutions': 'Accelerating Solutions',
   'catalyzing-discovery': 'Catalyzing Discovery',
@@ -30,6 +41,7 @@ export type ThemesType = keyof typeof themesMap;
 
 export const taxonomyMap = {
   ...initiativesMap,
+  ...schoolsMap,
   ...themesMap,
 };
 export type TaxonomyType = keyof typeof taxonomyMap;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Support school taxonomy tags and filter pages
- Remove setTimeout in Tabs component

# Review By (Date)
- Retro

# Criticality
- 6

# Review Tasks

## Setup tasks and/or behavior to test

1. See the top level filter page
https://deploy-preview-401--giving-campaign.netlify.app/stories

The 4 school pages with stories (i'll publish the other 3 with no stories currently as well, since Alexis said go ahead and publish and she'll tag stories to them)
https://deploy-preview-401--giving-campaign.netlify.app/stories/list/graduate-school-of-business
https://deploy-preview-401--giving-campaign.netlify.app/stories/list/stanford-doerr-school-of-sustainability
https://deploy-preview-401--giving-campaign.netlify.app/stories/list/school-of-humanities-and-sciences
https://deploy-preview-401--giving-campaign.netlify.app/stories/list/school-of-medicine (edited)
2. Check that they're showing stories that are tagged correctly
3. Click on the chips/nav and check that they work correctly

# Associated Issues and/or People
- JIRA ticket(s) - DS-1138
