### PR TITLE
Nojira | Sync tour changes

### DIFF
--- a/components/EventBanner/EventBanner.styles.ts
+++ b/components/EventBanner/EventBanner.styles.ts
@@ -3,15 +3,13 @@ import { type EventBannerHeadingSizeType } from './EventBanner';
 
 export const root = 'relative overflow-hidden';
 export const wrapper = 'relative z-10';
-export const contentWrapper = 'sm:flex-row gap-26 sm:gap-30 md:gap-36 xl:gap-60 2xl:gap-95 rs-mt-8';
+export const contentWrapper = 'sm:flex-row gap-26 sm:gap-30 md:gap-36 xl:gap-60 2xl:gap-95 rs-mt-8 first:*:shrink-0 first:*:grow-0';
 
-export const dateWrapper = 'sm:flex-col shrink-0 gap-26 md:gap-36';
+export const dateWrapper = 'sm:flex-col shrink-0 gap-26 md:gap-36 sm:w-60 md:w-70 lg:w-90 xl:w-100';
 export const time = 'flex flex-col items-center';
 
 export const bgImage = 'absolute top-0 left-0 size-full object-cover';
 export const overlay = (hasBgGradient: boolean) => cnb('absolute top-0 left-0 size-full z-10', hasBgGradient ? 'bg-gradient-to-b via-50%' : '');
-
-
 
 export const heading = (headingSize: EventBannerHeadingSizeType, isSerifHeading: boolean) => cnb('rs-mb-1', {
   'fluid-type-5 font-bold leading-tight -mt-02em': isSerifHeading,

--- a/components/EventBanner/EventBanner.tsx
+++ b/components/EventBanner/EventBanner.tsx
@@ -154,7 +154,12 @@ export const EventBanner = ({
           </AnimateInView>
           <div>
             <AnimateInView animation="slideUp">
-              <Text aria-hidden font={isSerifHeading ? 'serif' : 'druk'} leading="druk" className={styles.heading(headingSize, isSerifHeading)}>
+              <Text
+                aria-hidden="true"
+                font={isSerifHeading ? 'serif' : 'druk'}
+                leading="druk"
+                className={styles.heading(headingSize, isSerifHeading)}
+              >
                 {heading}
               </Text>
             </AnimateInView>

--- a/components/EventBanner/EventBanner.tsx
+++ b/components/EventBanner/EventBanner.tsx
@@ -125,10 +125,13 @@ export const EventBanner = ({
         />
       )}
       <Container className={styles.wrapper}>
-        {/* Attach SR only heading after superhead: at the beginning of the content for a11y */}
-        <Heading font="serif" weight="semibold" size={2} aria-hidden>
-          {superhead}<SrOnlyText>{`:${heading}`}</SrOnlyText>
-        </Heading>
+        {/* Attach SR only heading after superhead at the beginning of the content for a11y */}
+        {(superhead || heading) && (
+          <Heading as="h2" font="serif" weight="semibold" size={2}>
+            {superhead}
+            {heading && <SrOnlyText>{superhead ? `:${heading}` : heading}</SrOnlyText>}
+          </Heading>
+        )}
         <FlexBox direction="col" className={styles.contentWrapper}>
           <AnimateInView animation="slideInFromLeft" delay={0.1}>
             <FlexBox alignItems="center" className={styles.dateWrapper}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "devDependencies": {
         "@netlify/plugin-nextjs": "^5.10.1",
         "@tailwindcss/container-queries": "^0.1.1",
-        "@types/node": "^22.7.2",
+        "@types/node": "^22.13.13",
         "@types/react": "^18.3.9",
         "@types/react-dom": "^18.3.0",
         "@types/react-slick": "^0.23.13",
@@ -867,13 +867,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.2.tgz",
-      "integrity": "sha512-866lXSrpGpgyHBZUa2m9YNWqHDjjM0aBTJlNtYaGEw4rqY/dcD7deRVTbBBAJelfA7oaGDbNftXF/TL/A6RgoA==",
+      "version": "22.13.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
+      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -22050,9 +22050,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@netlify/plugin-nextjs": "^5.10.1",
     "@tailwindcss/container-queries": "^0.1.1",
-    "@types/node": "^22.7.2",
+    "@types/node": "^22.13.13",
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
     "@types/react-slick": "^0.23.13",

--- a/utilities/getProcessedImage.ts
+++ b/utilities/getProcessedImage.ts
@@ -25,6 +25,9 @@ export const getProcessedImage = (
 ): string => {
   if (!imageSrc) {
     return '';
+  // Leave the SVGs alone since they don't need to be processed
+  } else if (imageSrc.endsWith('.svg')) {
+    return getMaskedAsset(imageSrc);
   }
 
   // Get the width and the height from the crop dimension


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- While I was sync-ing Momentum changes to Tour, I discovered small things that I want to bring from Tour back to Momentum.
- Update `getProcessedImage` to not use Storyblok image service stuff on svgs
- Update Event Banner (a11y and style fix up)
- Update `@types/node`

# Review By (Date)
- Retro

# Criticality
- 4

# Review Tasks

## Setup tasks and/or behavior to test

1. Look at code and preview
2. Go to https://deploy-preview-407--giving-campaign.netlify.app/experience-the-moment
3. See that the druk headings are left aligned whether there is a date or not on the event banner
![Screenshot 2025-03-25 at 2 55 37 PM](https://github.com/user-attachments/assets/092ac404-9813-4390-af58-f96d09f0250f)
4. Inspect the superheading and see that it's a h2 with SR only text of the Druk heading following the visible superheading text.

