### PR TITLE
DS-1683 | Remove digital red logo option and change global footer to black

### DIFF
--- a/components/GlobalFooter/GlobalFooter.styles.ts
+++ b/components/GlobalFooter/GlobalFooter.styles.ts
@@ -1,4 +1,4 @@
-export const root = 'w-full basefont-20 rs-py-1 text-white bg-digital-red';
+export const root = 'w-full basefont-20 rs-py-1 text-white bg-gc-black';
 export const outerWrapper = 'lg:flex-row';
 export const logoWrapper = 'text-center mt-5 mb-9';
 export const logo = 'type-3';

--- a/components/GlobalFooter/GlobalFooter.tsx
+++ b/components/GlobalFooter/GlobalFooter.tsx
@@ -1,15 +1,10 @@
-import { cnb } from 'cnbuilder';
 import { StanfordLogo } from '@/components/Logo';
 import { Container } from '@/components/Container';
 import { FlexBox } from '@/components/FlexBox';
 import * as styles from './GlobalFooter.styles';
 
-type GlobalFooterProps = {
-  className?: string;
-};
-
-export const GlobalFooter = ({ className }: GlobalFooterProps) => (
-  <Container className={cnb(styles.root, className)}>
+export const GlobalFooter = () => (
+  <Container className={styles.root}>
     <FlexBox direction="col" className={styles.outerWrapper}>
       <div className={styles.logoWrapper}>
         <StanfordLogo isLink tabIndex={-1} aria-hidden className={styles.logo} type="stacked" color="white" />

--- a/components/Logo/StanfordLogo.styles.ts
+++ b/components/Logo/StanfordLogo.styles.ts
@@ -1,6 +1,5 @@
 export const stanfordLogoColors = {
   'cardinal-red': 'text-cardinal-red hocus:text-cardinal-red',
-  'digital-red': 'text-digital-red hocus:text-digital-red',
   black: 'text-gc-black hocus:text-gc-black',
   white: 'text-white hocus:text-white',
 };


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Change global footer to black
- Remove digital red stanford logo option

# Review By (Date)
- Retro

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. https://deploy-preview-410--giving-campaign.netlify.app/
Check that the global footer is black

# Associated Issues and/or People
- JIRA ticket(s) - DS-1683