### PR TITLE
A11y | DS-1510 | Add role="button" to clickable video preview wrapper

### DIFF
--- a/components/EmbedMedia/EmbedMedia.tsx
+++ b/components/EmbedMedia/EmbedMedia.tsx
@@ -103,6 +103,7 @@ export const EmbedMedia = ({
       className={className}
     >
       <figure>
+        {/* Extra classnames passed into wrapper for Vimeo responsive bug */}
         <div className={cnb(mediaAspectRatios[aspectRatio], styles.mediaWrapper)} ref={playerWrapperRef}>
           {hasWindow && (
             <ReactPlayer

--- a/components/EmbedMedia/EmbedMedia.tsx
+++ b/components/EmbedMedia/EmbedMedia.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { cnb } from 'cnbuilder';
 import ReactPlayer from 'react-player/lazy';
 import { Caption, type CaptionProps } from '@/components/Media/Caption';
@@ -56,6 +56,30 @@ export const EmbedMedia = ({
   }, []);
 
   const PreviewImg = previewImageSrc ? <PreviewImage previewImageSrc={previewImageSrc} /> : null;
+  const playerWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isPreview) return;
+
+    const wrapper = playerWrapperRef.current;
+    if (!wrapper) return;
+
+    const observer = new MutationObserver(() => {
+      const preview = wrapper.querySelector('.react-player__preview');
+      if (preview) {
+        preview.setAttribute('role', 'button');
+        observer.disconnect(); // stop observing once done
+      }
+    });
+
+    observer.observe(wrapper, {
+      childList: true, // Look for added/removed child elements
+      subtree: true, // Look for added/removed elements in all descendants inside wrapper
+    });
+
+    // Cleanup on unmount
+    return () => observer.disconnect();
+  }, [isPreview]);
 
   return (
     <WidthBox
@@ -68,7 +92,7 @@ export const EmbedMedia = ({
     >
       <figure>
         {/* Extra classnames passed into wrapper for Vimeo responsive bug */}
-        <div className={cnb(mediaAspectRatios[aspectRatio], styles.mediaWrapper)}>
+        <div className={cnb(mediaAspectRatios[aspectRatio], styles.mediaWrapper)} ref={playerWrapperRef}>
           {hasWindow && (
             <ReactPlayer
               width="100%"

--- a/utilities/getNumBloks.ts
+++ b/utilities/getNumBloks.ts
@@ -2,13 +2,13 @@ import { type SbBlokData } from '@storyblok/react/rsc';
 /**
  * Returns the number of nested bloks when we use the CreateBloks utility.
  *
- * @param {object} section - The section to count bloks in.
- * @returns {number} The number of bloks in the section.
+ * @param sbField - The Storyblok field to count bloks in.
+ * @returns The number of bloks added to this Storyblok field.
  */
 
-export const getNumBloks = (section: SbBlokData[]) => {
-  if (section) {
-    return Object.keys(section).length;
+export const getNumBloks = (sbField: SbBlokData[]) => {
+  if (!!sbField?.length) {
+    return sbField.length;
   }
 
   return 0;


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add `role="button"` to the clickable div when EmbedMedia preview mode is on (I can't change the HTML element so this is a compromise to make it accessible)
- Better handling when space key is pressed while focused on the preview (so it doesn't scroll down the page - should behave like enter key)
- Update `getNumBloks`

# Review By (Date)
- Soon

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-411--giving-campaign.netlify.app/test/yvonne-test-video-preview-a11y
2. There are 3 embed media on the page. Only the first 2 are using the preview mode. The 2nd one has a custom preview image while the 1st one uses the default. Inspect the first two players using the preview mode. Check that the `div` has `role="button"`  as an attribute.
![Screenshot 2025-04-29 at 4 09 14 PM](https://github.com/user-attachments/assets/72a09511-1e0d-4b52-be4e-97759b5b4bd1)

3. Press the space bar while you're focused on the preview, check that it plays the video and doesn't scroll the page.
4. Inspect the last embed player on the page. It shouldn't have any role="button" class because it's not using the preview mode.
5. Look at code

# Associated Issues and/or People
- JIRA ticket(s) - DS-1510
