### PR TITLE
Nojira | Do not render empty or undesired props in external links/asset links

### DIFF
--- a/components/Cta/CtaLink.tsx
+++ b/components/Cta/CtaLink.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 'use client';
 
 import React from 'react';
@@ -32,9 +33,13 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       email,
       target,
       anchor,
+      fieldtype,
       // External link in Storyblok can have additional custom attributes
       ...sbLinkProps
     } = sbLink || {};
+
+    // Keep only props with non empty values from sbLinkProps
+    const nonEmptySbLinkProps = Object.fromEntries(Object.entries(sbLinkProps).filter(([_, value]) => value !== '' && value !== null && value !== undefined));
 
     // Check for internal links
     const isInternal: boolean = linktype === 'story' || /^\/(?!\/)/.test(href);
@@ -69,7 +74,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
     return (
       <CtaExternalLink
         {...rest}
-        {...sbLinkProps}
+        {...nonEmptySbLinkProps}
         ref={ref}
         href={myLink}
         target={target || undefined}

--- a/components/Cta/CtaLink.tsx
+++ b/components/Cta/CtaLink.tsx
@@ -33,13 +33,17 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       email,
       target,
       anchor,
-      fieldtype, // Extracted to prevent it from being included in sbLinkProps
       // External link in Storyblok can have additional custom attributes
       ...sbLinkProps
     } = sbLink || {};
 
-    // Keep only props with non empty values from sbLinkProps
-    const nonEmptySbLinkProps = Object.fromEntries(Object.entries(sbLinkProps).filter(([_, value]) => value !== '' && value !== null && value !== undefined));
+    /**
+     * Filter out fieldtype and keep only props with non empty values from sbLinkProps.
+     * These include additional attributes such as rel, title and custom attributes that the user can pass in.
+     */
+    const sbLinkPropsToKeep = Object.fromEntries(
+      Object.entries(sbLinkProps).filter(([key, value]) => key !== 'fieldtype' && value !== '' && value !== null && value !== undefined),
+    );
 
     // Check for internal links
     const isInternal: boolean = linktype === 'story' || /^\/(?!\/)/.test(href);
@@ -74,7 +78,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
     return (
       <CtaExternalLink
         {...rest}
-        {...nonEmptySbLinkProps}
+        {...sbLinkPropsToKeep}
         ref={ref}
         href={myLink}
         target={target || undefined}

--- a/components/Cta/CtaLink.tsx
+++ b/components/Cta/CtaLink.tsx
@@ -33,7 +33,7 @@ export const CtaLink = React.forwardRef<HTMLAnchorElement, CtaLinkProps>(
       email,
       target,
       anchor,
-      fieldtype,
+      fieldtype, // Extracted to prevent it from being included in sbLinkProps
       // External link in Storyblok can have additional custom attributes
       ...sbLinkProps
     } = sbLink || {};


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Do not render empty or invalid attributes in external or asset CTALink

# Review By (Date)
- Soon

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://deploy-preview-416--giving-campaign.netlify.app/initiatives
2. Inspect the link on the first card which is an asset link
3. Check that it doesn't show fieldtype="multilink" and empty id as attributes anymore
4. Inspect the "Visit IMA" external link on the 3rd card
5. Check that it doesn't show fieldtype="multilink" and empty id as attributes anymore
6. Pull down branch and go to Storyblok Initiative page
7. Using the Visit IMA link as an example, if you add custom attributes (some empty), check that the link only renders the non empty custom attributes. For example
![Screenshot 2025-05-07 at 4 29 19 PM](https://github.com/user-attachments/assets/17966482-fc2c-4466-aaf5-bdd7b2d6af54)
![Screenshot 2025-05-07 at 4 29 27 PM](https://github.com/user-attachments/assets/97ff9b4a-fee4-403a-af01-40915f8ba08e)


